### PR TITLE
Bugfix #158 focus webview on tab app switch

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -125,6 +125,10 @@ function createMainWindow() {
 		show: false
 	});
 
+	win.on('focus', () => {
+		win.webContents.send('focus')
+	})
+
 	win.once('ready-to-show', () => {
 		win.show();
 	});

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -182,9 +182,6 @@ class ServerManagerView {
 		$webView.addEventListener('dom-ready', () => {
 			$webView.focus();
 		});
-		$webView.addEventListener('focus', () => {
-			console.log('webview focus...', $webView.focus)
-		})
 	}
 
 	registerIpcs() {
@@ -199,7 +196,7 @@ class ServerManagerView {
 				activeWebview.goBack();
 			}
 		});
-		
+
 		ipcRenderer.on('focus', () => {
 			const activeWebview = document.getElementById(`webview-${this.activeTabIndex}`);
 			activeWebview.focus()

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -182,6 +182,9 @@ class ServerManagerView {
 		$webView.addEventListener('dom-ready', () => {
 			$webView.focus();
 		});
+		$webView.addEventListener('focus', () => {
+			console.log('webview focus...', $webView.focus)
+		})
 	}
 
 	registerIpcs() {
@@ -195,6 +198,11 @@ class ServerManagerView {
 			if (activeWebview.canGoBack()) {
 				activeWebview.goBack();
 			}
+		});
+		
+		ipcRenderer.on('focus', () => {
+			const activeWebview = document.getElementById(`webview-${this.activeTabIndex}`);
+			activeWebview.focus()
 		});
 
 		ipcRenderer.on('forward', () => {


### PR DESCRIPTION
This PR solves the issue reported by @jamak here: https://github.com/zulip/zulip-electron/issues/158

The issue is when you open Zulip and type text into a chat area, then switch applications via Command+Tab to another app, and return to the Zulip app, you will no longer have focus on the chat area. If you type on your keyboard the key events won't be sent to the text area you had activated before you switched out of the app. This doesn't happen with applications like Microsoft Word, you can tab switch to another app and return to continue typing where you had left your cursor.

This PR solves this issue by listening for a `focus` event on the browserWindow in the main process and forwarding the focus event to the renderer process. The listener on the renderer process will then focus the currently activated webview.