### PR TITLE
Added condition to stop error in Internet connectivity when app resumes

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -63,7 +63,8 @@ const connectivityERR = [
 	'ERR_PROXY_CONNECTION_FAILED',
 	'ERR_CONNECTION_RESET',
 	'ERR_NOT_CONNECTED',
-	'ERR_NAME_NOT_RESOLVED'
+	'ERR_NAME_NOT_RESOLVED',
+	'ERR_NETWORK_CHANGED'
 ];
 
 // TODO
@@ -239,6 +240,7 @@ app.on('ready', () => {
 		}
 	});
 	electron.powerMonitor.on('resume', () => {
+		console.log("App resumed from sleep");
 		mainWindow.reload();
 		mainWindow.webContents.send('destroytray');
 	});


### PR DESCRIPTION
This PR fixes for error #157 
I found the following error. Added condition to avoid such error.

![erroronappresume](https://cloud.githubusercontent.com/assets/13533873/26554982/a8f08b3e-44b0-11e7-868e-81dd1145d271.jpg)

