### PR TITLE
Fix WebView resize problem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-}

--- a/app/renderer/css/servermanager.css
+++ b/app/renderer/css/servermanager.css
@@ -51,10 +51,6 @@ html, body {
     -webkit-app-region: drag;
 }
 
-#webview {
-    flex-grow: 1;
-}
-
 .action-button {
     display: flex;
     flex-direction: column;
@@ -140,5 +136,7 @@ webview.loading {
 }
 
 webview.disabled {
-    display: none;
+    flex: 0 1;
+    height: 0;
+    width: 0;
 }


### PR DESCRIPTION
**Steps to reproduce:**
1. Add more than one domains.
2. Load both webviews.
3. Switching back to the other webview.

![screen shot 2017-05-30 at 7 40 34 pm](https://cloud.githubusercontent.com/assets/7262715/26583596/75c65dec-4578-11e7-8a07-907dcba87069.png)

**Cause:**
This bug was introduced from the upstream. It is documented in [electron#5110](https://github.com/electron/electron/issues/5110). The bug has not yet been fixed but we have a workaround.

It's weird that I run into this bug for the first time tonight. Have you ever seen this before?