### PR TITLE
Load realm settings from server_settings endpoint

### DIFF
--- a/app/renderer/js/preference.js
+++ b/app/renderer/js/preference.js
@@ -109,12 +109,9 @@ class PreferenceView {
 			this.$newServerButton.classList.add('hidden');
 		});
 		this.$saveServerButton.addEventListener('click', () => {
-			this.domainUtil.checkDomain(this.$newServerUrl.value).then(domain => {
-				const server = {
-					alias: this.$newServerAlias.value,
-					url: domain,
-					icon: this.$newServerIcon.value
-				};
+			this.domainUtil.checkDomain(this.$newServerUrl.value).then(server => {
+				server.alias = this.$newServerAlias.value || server.alias;
+				
 				this.domainUtil.addDomain(server);
 				this.$saveServerButton.classList.add('hidden');
 				this.$newServerButton.classList.remove('hidden');

--- a/app/renderer/js/preference.js
+++ b/app/renderer/js/preference.js
@@ -109,9 +109,12 @@ class PreferenceView {
 			this.$newServerButton.classList.add('hidden');
 		});
 		this.$saveServerButton.addEventListener('click', () => {
-			this.domainUtil.checkDomain(this.$newServerUrl.value).then(server => {
-				server.alias = this.$newServerAlias.value || server.alias;
-				
+			const newServerConf = {
+				alias: this.$newServerAlias.value,
+				url: this.$newServerUrl.value,
+				icon: this.$newServerIcon.value
+			}
+			this.domainUtil.checkDomain(newServerConf).then(server => {				
 				this.domainUtil.addDomain(server);
 				this.$saveServerButton.classList.add('hidden');
 				this.$newServerButton.classList.remove('hidden');

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -42,33 +42,58 @@ class DomainUtil {
 		this.db.delete(`/domains[${index}]`);
 	}
 
-	checkDomain(domain) {
+	checkDomain(server) {
+		let domain = server.url;
+		server.icon = server.icon || defaultIconUrl;
+		
 		const hasPrefix = (domain.indexOf('http') === 0);
 		if (!hasPrefix) {
 			domain = (domain.indexOf('localhost:') >= 0) ? `http://${domain}` : `https://${domain}`;
 		}
-		let server = {};
-		const serverSettingsUrl = domain + '/api/v1/server_settings';
+
+		const checkDomain = domain + '/static/audio/zulip.ogg';
 
 		return new Promise((resolve, reject) => {
-			request(serverSettingsUrl, (error, response) => {
-				const data = JSON.parse(response.body);
-				if (data.hasOwnProperty('realm_icon') && data.realm_icon) {
-					server.icon = (domain + data.realm_icon) || defaultIconUrl;
-					server.url = data.realm_uri;
-					server.alias = data.realm_name;
-				}
+			request(checkDomain, (error, response) => {
 				if (!error && response.statusCode !== 404) {
-					resolve(server);
+					this.getServerSettings(domain).then((serverSettings) => {
+						resolve(serverSettings);
+					}, () => {
+						resolve(server);
+					})
 				} else if (error.toString().indexOf('Error: self signed certificate') >= 0) {
 					if (window.confirm(`Do you trust certificate from ${domain}?`)) {
-						resolve(server);
+						this.getServerSettings(domain).then((serverSettings) => {
+							resolve(serverSettings);
+						}, () => {
+							resolve(server);
+						})
 					} else {
 						reject('Untrusted Certificate.');
 					}
 				} else {
 					reject('Not a valid Zulip server');
 				}
+			});
+		});
+	}
+
+	getServerSettings(domain) {
+		const serverSettingsUrl = domain + '/api/v1/server_settings';
+		return new Promise((resolve, reject) => {
+			request(serverSettingsUrl, (error, response) => {
+				if (!error && response.statusCode == 200) {
+					const data = JSON.parse(response.body);
+					if (data.hasOwnProperty('realm_icon') && data.realm_icon) {
+						const server = {
+							icon: domain + data.realm_icon,
+							url: data.realm_uri,
+							alias: data.realm_name
+						}
+						resolve(server);
+					}
+				} 
+				reject('Zulip server version < 1.6.');
 			});
 		});
 	}

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -4,7 +4,7 @@ const {app} = require('electron').remote;
 const JsonDB = require('node-json-db');
 const request = require('request');
 
-const defaultIconUrl = 'https://chat.zulip.org/static/images/logo/zulip-icon-128x128.271d0f6a0ca2.png';
+const defaultIconUrl = __dirname + '../../../../resources/icon.png';
 class DomainUtil {
 	constructor() {
 		this.db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);


### PR DESCRIPTION
According to #163, we should load server icon from the `/api/v1/server_settings` endpoint, or load default icon from local.

Endpoint:
![image](https://cloud.githubusercontent.com/assets/7262715/26683545/c5d9f358-4716-11e7-8d9b-80e01577f0f1.png)

Settings:
![image](https://cloud.githubusercontent.com/assets/7262715/26683539/bb177148-4716-11e7-9ac8-0ece1ce4a4ac.png)
