### PR TITLE
normalize whitespace

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "InstantMessaging"
   ],
   "dependencies": {
-    "electron-config":"0.2.1",
+    "electron-config": "0.2.1",
     "electron-debug": "1.1.0",
     "electron-is-dev": "0.1.2",
     "electron-localshortcut": "1.0.0",


### PR DESCRIPTION
Normally I wouldn't PR for a single-character whitespace change, but there's something run by zulip-electron-launcher that keeps adding this space back in every time, so it always thinks I have uncommitted changes in my working tree that are different from what's in origin/master...