### PR TITLE
Reload db after update.

### DIFF
--- a/app/renderer/js/utils/config-util.js
+++ b/app/renderer/js/utils/config-util.js
@@ -21,7 +21,7 @@ class ConfigUtil {
 			instance = this;
 		}
 
-		this.db = new JsonDB(app.getPath('userData') + '/settings.json', true, true);
+		this.reloadDB();
 		return instance;
 	}
 
@@ -37,10 +37,16 @@ class ConfigUtil {
 
 	setConfigItem(key, value) {
 		this.db.push(`/${key}`, value, true);
+		this.reloadDB();
 	}
 
 	removeConfigItem(key) {
 		this.db.delete(`/${key}`);
+		this.reloadDB();
+	}
+
+	reloadDB() {
+		this.db = new JsonDB(app.getPath('userData') + '/settings.json', true, true);
 	}
 }
 


### PR DESCRIPTION
Due to JsonDB's wierd update strategies, it caches the object on initialization and modifies the object on update. Thus we always need to re-initialize the object after update.