### PR TITLE
Add the ability to open Settings with specific view

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -219,7 +219,8 @@ app.on('ready', () => {
 		page.send('tray', messageCount);
 	});
 
-	ipc.on('forward', (event, listener) => {
+	ipc.on('forward-message', (event, listener, ...params) => {
+		console.log(listener, ...params);
 		page.send(listener);
 	});
 });

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -143,7 +143,7 @@ const darwinTpl = [
 				type: 'separator'
 			},
 			{
-				label: 'Manage Zulip Servers',
+				label: 'Settings',
 				accelerator: 'Cmd+,',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
@@ -280,7 +280,7 @@ const otherTpl = [
 				type: 'separator'
 			},
 			{
-				label: 'Manage Zulip Servers',
+				label: 'Settings',
 				accelerator: 'Ctrl+,',
 				click(item, focusedWindow) {
 					if (focusedWindow) {

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -162,6 +162,12 @@ html, body {
     line-height: 17px;
 }
 
+#add-tab {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}
+
 /*******************
  *   Webview Area  *
  *******************/

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -173,6 +173,10 @@ class WebView extends BaseComponent {
 		this.hide();
 		this.$el.reload();
 	}
+
+	send(...param) {
+		this.$el.send(...param);
+	}
 }
 
 module.exports = WebView;

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -37,7 +37,7 @@ class ServerManagerView {
 			}
 			this.activateTab(0);
 		} else {
-			this.openSettings();
+			this.openSettings('Servers');
 		}
 	}
 
@@ -66,8 +66,12 @@ class ServerManagerView {
 		this.$reloadButton.addEventListener('click', () => {
 			this.tabs[this.activeTabIndex].webview.reload();
 		});
-		this.$addServerButton.addEventListener('click', this.openSettings.bind(this));
-		this.$settingsButton.addEventListener('click', this.openSettings.bind(this));
+		this.$addServerButton.addEventListener('click', () => {
+			this.openSettings('Servers');
+		});
+		this.$settingsButton.addEventListener('click', () => {
+			this.openSettings('General');
+		});
 	}
 
 	openFunctionalTab(tabProps) {
@@ -101,12 +105,13 @@ class ServerManagerView {
 		this.activateTab(this.functionalTabs[tabProps.name]);
 	}
 
-	openSettings() {
+	openSettings(nav = 'General') {
 		this.openFunctionalTab({
 			name: 'Settings',
 			materialIcon: 'settings',
-			url: `file://${__dirname}/preference.html`
+			url: `file://${__dirname}/preference.html#${nav}`
 		});
+		this.tabs[this.functionalTabs['Settings']].webview.send('switch-settings-nav', nav);		
 	}
 
 	openAbout() {
@@ -194,7 +199,9 @@ class ServerManagerView {
 			});
 		}
 
-		ipcRenderer.on('open-settings', this.openSettings.bind(this));
+		ipcRenderer.on('open-settings', (event, settingNav) => {
+			this.openSettings(settingNav);
+		});
 		ipcRenderer.on('open-about', this.openAbout.bind(this));
 	}
 }

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -10,11 +10,11 @@ const FunctionalTab = require(__dirname + '/js/components/functional-tab.js');
 
 class ServerManagerView {
 	constructor() {
+		this.$addServerButton = document.getElementById('add-tab');
 		this.$tabsContainer = document.getElementById('tabs-container');
 
 		const $actionsContainer = document.getElementById('actions-container');
 		this.$reloadButton = $actionsContainer.querySelector('#reload-action');
-		this.$addServerButton = $actionsContainer.querySelector('#add-action');
 		this.$settingsButton = $actionsContainer.querySelector('#settings-action');
 		this.$content = document.getElementById('content');
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -111,7 +111,7 @@ class ServerManagerView {
 			materialIcon: 'settings',
 			url: `file://${__dirname}/preference.html#${nav}`
 		});
-		this.tabs[this.functionalTabs['Settings']].webview.send('switch-settings-nav', nav);		
+		this.tabs[this.functionalTabs.Settings].webview.send('switch-settings-nav', nav);
 	}
 
 	openAbout() {

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -85,7 +85,7 @@ class GeneralSection extends BaseComponent {
 		$trayOption.addEventListener('click', () => {
 			const newValue = !ConfigUtil.getConfigItem('trayIcon');
 			ConfigUtil.setConfigItem('trayIcon', newValue);
-			ipcRenderer.send('forward', 'toggletray');
+			ipcRenderer.send('forward-message', 'toggletray');
 			this.initTrayOption();
 		});
 	}

--- a/app/renderer/js/pages/preference/preference.js
+++ b/app/renderer/js/pages/preference/preference.js
@@ -28,7 +28,7 @@ class PreferenceView extends BaseComponent {
 	setDefaultView() {
 		let nav = 'General';
 		const hasTag = window.location.hash;
-		if(hasTag) {
+		if (hasTag) {
 			nav = hasTag.substring(1);
 		}
 		this.handleNavigation(nav);

--- a/app/renderer/js/pages/preference/preference.js
+++ b/app/renderer/js/pages/preference/preference.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseComponent = require(__dirname + '/js/components/base.js');
+const {ipcRenderer} = require('electron');
 
 const Nav = require(__dirname + '/js/pages/preference/nav.js');
 const ServersSection = require(__dirname + '/js/pages/preference/servers-section.js');
@@ -19,7 +20,18 @@ class PreferenceView extends BaseComponent {
 			$root: this.$sidebarContainer,
 			onItemSelected: this.handleNavigation.bind(this)
 		});
-		this.handleNavigation('General');
+
+		this.setDefaultView();
+		this.registerIpcs();
+	}
+
+	setDefaultView() {
+		let nav = 'General';
+		const hasTag = window.location.hash;
+		if(hasTag) {
+			nav = hasTag.substring(1);
+		}
+		this.handleNavigation(nav);
 	}
 
 	handleNavigation(navItem) {
@@ -40,6 +52,13 @@ class PreferenceView extends BaseComponent {
 			default: break;
 		}
 		this.section.init();
+		window.location.hash = `#${navItem}`;
+	}
+
+	registerIpcs() {
+		ipcRenderer.on('switch-settings-nav', (event, navItem) => {
+			this.handleNavigation(navItem);
+		});
 	}
 }
 

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -136,7 +136,7 @@ const createTray = function () {
 		type: 'separator'
 	},
 	{
-		label: 'Manage Zulip servers',
+		label: 'Settings',
 		click() {
 			ipcRenderer.send('focus-app');
 			sendAction('open-settings');

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -9,13 +9,17 @@
   <body>
     <div id="content">
       <div id="sidebar">
-        <div id="tabs-container"></div>
+        <div id="view-controls-container">
+          <div id="tabs-container"></div>
+          <div id ="add-tab" class="tab">
+            <div class="server-tab functional-tab" id="add-action">
+              <i class="material-icons">add</i>
+            </div>
+          </div>
+        </div>
         <div id="actions-container">
           <div class="action-button" id="reload-action">
             <i class="material-icons md-48">refresh</i>
-          </div>
-          <div class="action-button" id="add-action">
-            <i class="material-icons md-48">add_circle</i>
           </div>
           <div class="action-button" id="settings-action">
             <i class="material-icons md-48">settings</i>


### PR DESCRIPTION
![screen shot 2017-07-09 at 11 09 15 pm](https://user-images.githubusercontent.com/7262715/27995140-f6ac23da-648e-11e7-95ca-cd4ae7cec6b6.png)

 - The `+` button is moved up.
 - Support loading Settings with specified view shown.
 - `Manage Zulip Servers` are renamed to `Settings` in the menu, as there are more settings available now.