### PR TITLE
settings: Tweak text of initial screen to be a bit clearer.

### DIFF
--- a/app/renderer/js/pages/preference/servers-section.js
+++ b/app/renderer/js/pages/preference/servers-section.js
@@ -20,7 +20,7 @@ class ServersSection extends BaseComponent {
 				<div class="actions-container">
 					<div class="action green" id="new-server-action">
 						<i class="material-icons">add_box</i>
-						<span>New Server</span>
+						<span>Add Server</span>
 					</div>
 				</div>
 				<div id="new-server-container" class="hidden"></div>


### PR DESCRIPTION
The label "New Server" sounds to me like it's suggesting I create
a new actual server -- which I don't want to do, I want to connect
to an existing server where a community I know is talking.
Change the text to track a bit closer to what's really going on.

I think there's probably more that would be useful to do to
make this flow smoother for a new user, but this is a start.