### PR TITLE
Dock(Badge) unread feature added in settings

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -17,6 +17,9 @@ const conf = new Configstore();
 // Setting userAgent so that server-side code can identify the desktop app
 
 // Prevent window being garbage collected
+
+let badgeCount;
+
 let mainWindow;
 
 let isQuitting = false;
@@ -210,12 +213,26 @@ app.on('ready', () => {
 		}
 	});
 
-	ipc.on('update-badge', (event, messageCount) => {
-		if (process.platform === 'darwin') {
-			app.setBadgeCount(messageCount);
+	ipc.on('toggle-dock-unread-option', (event, dockarg) => {
+		if (dockarg === true && process.platform === 'darwin') {
+			showBadgeCount(badgeCount);
+		} else if (dockarg === false) {
+			hideBadgeCount();
 		}
+	});
+
+	ipc.on('update-badge', (event, messageCount) => {
+		badgeCount = messageCount;
 		page.send('tray', messageCount);
 	});
+
+	function showBadgeCount(messageCount) {
+		return app.setBadgeCount(messageCount);
+	}
+
+	function hideBadgeCount() {
+		return app.setBadgeCount(0);
+	}
 
 	ipc.on('forward-message', (event, listener, ...params) => {
 		console.log(listener, ...params);

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -97,7 +97,6 @@ class GeneralSection extends BaseComponent {
 		$trayOption.addEventListener('click', () => {
 			const newValue = !ConfigUtil.getConfigItem('trayIcon');
 			ConfigUtil.setConfigItem('trayIcon', newValue);
-			ipcRenderer.send('forward-message', 'toggletray');
 			this.initTrayOption();
 		});
 	}

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -35,6 +35,13 @@ class GeneralSection extends BaseComponent {
 						<div class="setting-control"></div>
 					</div>
 				</div>
+				<div class="title">Dock toggle</div>
+                <div id="dock-unread-option-settings" class="settings-card">
+					<div class="setting-row">
+						<div class="setting-description">Toggle dock unread messages</div>
+						<div class="setting-control"></div>
+					</div>
+				</div>
             </div>
 		`;
 	}
@@ -67,11 +74,16 @@ class GeneralSection extends BaseComponent {
 		this.settingsOptionTemplate(silentOption);
 	}
 
+	dockUnreadOptionTemplate(dockToggleOption) {
+		this.settingsOptionTemplate(dockToggleOption);
+	}
+
 	init() {
 		this.props.$root.innerHTML = this.template();
 		this.initTrayOption();
 		this.initUpdateOption();
 		this.initSilentOption();
+		this.initDockToggleUnreadOption();
 	}
 
 	initTrayOption() {
@@ -116,7 +128,24 @@ class GeneralSection extends BaseComponent {
 		$silentOption.addEventListener('click', () => {
 			const newValue = !ConfigUtil.getConfigItem('silent');
 			ConfigUtil.setConfigItem('silent', newValue);
+			ipcRenderer.send('toggle-dock-unread', newValue);
 			this.initSilentOption();
+		});
+	}
+
+	initDockToggleUnreadOption() {
+		this.$dockToggleUnreadoptionSettings = document.querySelector('#dock-unread-option-settings .setting-control');
+		this.$dockToggleUnreadoptionSettings.innerHTML = '';
+
+		const dockToggleOption = ConfigUtil.getConfigItem('dock-toggle-unread', false);
+		const $dockToggleOption = this.generateNodeFromTemplate(this.settingsOptionTemplate(dockToggleOption));
+		this.$dockToggleUnreadoptionSettings.appendChild($dockToggleOption);
+
+		$dockToggleOption.addEventListener('click', () => {
+			const newValue = !ConfigUtil.getConfigItem('dock-toggle-unread');
+			ConfigUtil.setConfigItem('dock-toggle-unread', newValue);
+			ipcRenderer.send('toggle-dock-unread-option', newValue);
+			this.initDockToggleUnreadOption();
 		});
 	}
 


### PR DESCRIPTION
Added enhancement, deck unread message toggle feature added to the setting page.
macOS Sierra Version: 10.12.5.
Issue: #192 
Type: Enhancement

<img width="650" alt="off" src="https://user-images.githubusercontent.com/18073126/28430568-9b772c08-6d9e-11e7-96ca-884821fa3bcd.png">

<img width="650" alt="on" src="https://user-images.githubusercontent.com/18073126/28430578-a4fed6f4-6d9e-11e7-8d65-c773a0773194.png">

