### PR TITLE
Don't create tray on Windows + macOS

### DIFF
--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -3,9 +3,9 @@ const path = require('path');
 
 const electron = require('electron');
 
-const {ipcRenderer, remote} = electron;
+const { ipcRenderer, remote } = electron;
 
-const {Tray, Menu, nativeImage, BrowserWindow} = remote;
+const { Tray, Menu, nativeImage, BrowserWindow } = remote;
 
 const APP_ICON = path.join(__dirname, '../../resources/tray', 'tray');
 
@@ -181,18 +181,19 @@ ipcRenderer.on('tray', (event, arg) => {
 		return;
 	}
 
-	if (arg === 0) {
-		unread = arg;
-		// Message Count // console.log("message count is zero.");
-		window.tray.setImage(iconPath());
-		window.tray.setToolTip('No unread messages');
-	} else {
-		unread = arg;
-		renderNativeImage(arg).then(image => {
-			window.tray.setImage(image);
-			window.tray.setToolTip(arg + ' unread messages');
-		});
-	}
+	if (process.platform === 'linux')
+		if (arg === 0) {
+			unread = arg;
+			// Message Count // console.log("message count is zero.");
+			window.tray.setImage(iconPath());
+			window.tray.setToolTip('No unread messages');
+		} else {
+			unread = arg;
+			renderNativeImage(arg).then(image => {
+				window.tray.setImage(image);
+				window.tray.setToolTip(arg + ' unread messages');
+			});
+		}
 });
 
 function toggleTray() {
@@ -204,10 +205,12 @@ function toggleTray() {
 		ConfigUtil.setConfigItem('trayIcon', false);
 	} else {
 		createTray();
-		renderNativeImage(unread).then(image => {
-			window.tray.setImage(image);
-			window.tray.setToolTip(unread + ' unread messages');
-		});
+		if (process.platform === 'linux') {
+			renderNativeImage(unread).then(image => {
+				window.tray.setImage(image);
+				window.tray.setToolTip(unread + ' unread messages');
+			});
+		}
 		ConfigUtil.setConfigItem('trayIcon', true);
 	}
 }

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -180,7 +180,7 @@ ipcRenderer.on('tray', (event, arg) => {
 	if (!window.tray) {
 		return;
 	}
-
+	// We don't want to create tray from unread messages on windows and macOS since these systems already have dock badges and taskbar overlay icon.
 	if (process.platform === 'linux') {
 		if (arg === 0) {
 			unread = arg;

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -3,9 +3,9 @@ const path = require('path');
 
 const electron = require('electron');
 
-const { ipcRenderer, remote } = electron;
+const {ipcRenderer, remote} = electron;
 
-const { Tray, Menu, nativeImage, BrowserWindow } = remote;
+const {Tray, Menu, nativeImage, BrowserWindow} = remote;
 
 const APP_ICON = path.join(__dirname, '../../resources/tray', 'tray');
 
@@ -181,7 +181,7 @@ ipcRenderer.on('tray', (event, arg) => {
 		return;
 	}
 
-	if (process.platform === 'linux')
+	if (process.platform === 'linux') {
 		if (arg === 0) {
 			unread = arg;
 			// Message Count // console.log("message count is zero.");
@@ -194,6 +194,7 @@ ipcRenderer.on('tray', (event, arg) => {
 				window.tray.setToolTip(arg + ' unread messages');
 			});
 		}
+	}
 });
 
 function toggleTray() {


### PR DESCRIPTION
We don't want to create tray from unread messages on Windows and macOS since these systems already have dock badges and taskbar overlay icon. 

On the other side, Linux does not support badges and taskbar icon so we need to keep this thing as it is there.