### PR TITLE
Issue/fetch server details from zulip api

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -70,8 +70,8 @@ html, body {
     align-items: center;
     padding: 10px;
 }
+
 .action-button:hover {
-    background: #eee;
     cursor: pointer;
 }
 

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -106,11 +106,9 @@ body {
 }
 
 img.server-info-icon {
-    background: #a4d3c4;
-    border-radius: 4px;
-    width: 28px;
-    height: 28px;
-    padding: 8px;
+    width: 36px;
+    height: 36px;
+    padding: 4px;
 }
 
 .server-info-left {
@@ -124,19 +122,14 @@ img.server-info-icon {
 
 .server-info-row {
     display: flex;
-    line-height: 27px;
-    margin: 8px 0;
-    height: 27px;
+    margin: 8px 0 0 0;
 }
 
-.server-info-key {
-    width: 40px;
-    margin-right: 20px;
+.server-info-alias {
     font-weight: bold;
-    text-align: right;
 }
 
-.server-info-value {
+.server-info-url {
     flex-grow: 1;
     font-size: 14px;
     height: 24px;
@@ -165,6 +158,7 @@ img.server-info-icon {
     align-items: center;
     padding: 0 10px;
     border-radius: 2px;
+    margin-right: 10px;
 }
 
 .action i {

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -194,11 +194,8 @@ img.server-info-icon {
 }
 
 .hidden {
-    height: 0 !important;
-    width: 0 !important;
+    display: none;
     margin: 5px !important;
-    opacity: 0 !important;
-    transition: opacity 0.3s;
 }
 
 .red {

--- a/app/renderer/js/pages/preference/new-server-form.js
+++ b/app/renderer/js/pages/preference/new-server-form.js
@@ -17,19 +17,9 @@ class NewServerForm extends BaseComponent {
 				</div>
 				<div class="server-info-right">
 					<div class="server-info-row">
-						<span class="server-info-key">Url</span>
-						<input class="server-info-value" placeholder="(Required)"/>
+						<input class="server-info-url" placeholder="Enter the url of your Zulip server..."/>
 					</div>
 					<div class="server-info-row">
-						<span class="server-info-key">Label</span>
-						<input class="server-info-value" placeholder="(Optional)"/>
-					</div>
-					<div class="server-info-row">
-						<span class="server-info-key">Icon</span>
-						<input class="server-info-value" placeholder="(Optional)"/>
-					</div>
-					<div class="server-info-row">
-						<span class="server-info-key"></span>
 						<div class="action green server-save-action">
 							<i class="material-icons">check_box</i>
 							<span>Save</span>
@@ -51,20 +41,12 @@ class NewServerForm extends BaseComponent {
 		this.props.$root.innerHTML = '';
 		this.props.$root.appendChild(this.$newServerForm);
 
-		this.$newServerUrl = this.$newServerForm.querySelectorAll('input.server-info-value')[0];
-		this.$newServerAlias = this.$newServerForm.querySelectorAll('input.server-info-value')[1];
-		this.$newServerIcon = this.$newServerForm.querySelectorAll('input.server-info-value')[2];
+		this.$newServerUrl = this.$newServerForm.querySelectorAll('input.server-info-url')[0];
 	}
 
 	initActions() {
 		this.$saveServerButton.addEventListener('click', () => {
-			const newServerConf = {
-				alias: this.$newServerAlias.value,
-				url: this.$newServerUrl.value,
-				icon: this.$newServerIcon.value
-			};
-
-			DomainUtil.checkDomain(newServerConf).then(serverConf => {
+			DomainUtil.checkDomain(this.$newServerUrl.value).then(serverConf => {
 				DomainUtil.addDomain(serverConf).then(() => {
 					this.props.onChange(this.props.index);
 				});

--- a/app/renderer/js/pages/preference/new-server-form.js
+++ b/app/renderer/js/pages/preference/new-server-form.js
@@ -17,12 +17,12 @@ class NewServerForm extends BaseComponent {
 				</div>
 				<div class="server-info-right">
 					<div class="server-info-row">
-						<span class="server-info-key">Name</span>
+						<span class="server-info-key">Url</span>
 						<input class="server-info-value" placeholder="(Required)"/>
 					</div>
 					<div class="server-info-row">
-						<span class="server-info-key">Url</span>
-						<input class="server-info-value" placeholder="(Required)"/>
+						<span class="server-info-key">Label</span>
+						<input class="server-info-value" placeholder="(Optional)"/>
 					</div>
 					<div class="server-info-row">
 						<span class="server-info-key">Icon</span>
@@ -51,8 +51,8 @@ class NewServerForm extends BaseComponent {
 		this.props.$root.innerHTML = '';
 		this.props.$root.appendChild(this.$newServerForm);
 
-		this.$newServerAlias = this.$newServerForm.querySelectorAll('input.server-info-value')[0];
-		this.$newServerUrl = this.$newServerForm.querySelectorAll('input.server-info-value')[1];
+		this.$newServerUrl = this.$newServerForm.querySelectorAll('input.server-info-value')[0];
+		this.$newServerAlias = this.$newServerForm.querySelectorAll('input.server-info-value')[1];
 		this.$newServerIcon = this.$newServerForm.querySelectorAll('input.server-info-value')[2];
 	}
 

--- a/app/renderer/js/pages/preference/new-server-form.js
+++ b/app/renderer/js/pages/preference/new-server-form.js
@@ -58,13 +58,14 @@ class NewServerForm extends BaseComponent {
 
 	initActions() {
 		this.$saveServerButton.addEventListener('click', () => {
-			DomainUtil.checkDomain(this.$newServerUrl.value).then(domain => {
-				const server = {
-					alias: this.$newServerAlias.value,
-					url: domain,
-					icon: this.$newServerIcon.value
-				};
-				DomainUtil.addDomain(server).then(() => {
+			const newServerConf = {
+				alias: this.$newServerAlias.value,
+				url: this.$newServerUrl.value,
+				icon: this.$newServerIcon.value
+			};
+
+			DomainUtil.checkDomain(newServerConf).then(serverConf => {
+				DomainUtil.addDomain(serverConf).then(() => {
 					this.props.onChange(this.props.index);
 				});
 			}, errorMessage => {

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -18,19 +18,12 @@ class ServerInfoForm extends BaseComponent {
 				</div>
 				<div class="server-info-right">
 					<div class="server-info-row">
-						<span class="server-info-key">Url</span>
-						<input class="server-info-value" disabled value="${this.props.server.url}"/>
+						<span class="server-info-alias">${this.props.server.alias}</span>
 					</div>
 					<div class="server-info-row">
-						<span class="server-info-key">Label</span>
-						<input class="server-info-value" disabled value="${this.props.server.alias}"/>
+						<input class="server-info-url" disabled value="${this.props.server.url}"/>
 					</div>
 					<div class="server-info-row">
-						<span class="server-info-key">Icon</span>
-						<input class="server-info-value" disabled value="${this.props.server.icon}"/>
-					</div>
-					<div class="server-info-row">
-						<span class="server-info-key"></span>
 						<div class="action red server-delete-action">
 							<i class="material-icons">indeterminate_check_box</i>
 							<span>Delete</span>

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -18,12 +18,12 @@ class ServerInfoForm extends BaseComponent {
 				</div>
 				<div class="server-info-right">
 					<div class="server-info-row">
-						<span class="server-info-key">Name</span>
-						<input class="server-info-value" disabled value="${this.props.server.alias}"/>
-					</div>
-					<div class="server-info-row">
 						<span class="server-info-key">Url</span>
 						<input class="server-info-value" disabled value="${this.props.server.url}"/>
+					</div>
+					<div class="server-info-row">
+						<span class="server-info-key">Label</span>
+						<input class="server-info-value" disabled value="${this.props.server.alias}"/>
 					</div>
 					<div class="server-info-row">
 						<span class="server-info-key">Icon</span>

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -73,7 +73,10 @@ class DomainUtil {
 		this.reloadDB();
 	}
 
-	checkDomain(domain) {
+	checkDomain(server) {
+		let domain = server.url;
+		server.icon = server.icon || defaultIconUrl;
+
 		const hasPrefix = (domain.indexOf('http') === 0);
 		if (!hasPrefix) {
 			domain = (domain.indexOf('localhost:') >= 0) ? `http://${domain}` : `https://${domain}`;
@@ -88,7 +91,12 @@ class DomainUtil {
 						'Error: unable to verify the first certificate'
 					];
 				if (!error && response.statusCode !== 404) {
-					resolve(domain);
+					// Correct
+					this.getServerSettings(domain).then((serverSettings) => {
+						resolve(serverSettings);
+					}, () => {
+						resolve(server);
+					})
 				} else if (certsError.indexOf(error.toString()) >= 0) {
 					dialog.showMessageBox({
 						type: 'question',
@@ -97,13 +105,38 @@ class DomainUtil {
 						message: `Do you trust certificate from ${domain}? \n ${error}`
 					}, response => {
 						if (response === 0) {
-							resolve(domain);
+							this.getServerSettings(domain).then((serverSettings) => {
+								resolve(serverSettings);
+							}, () => {
+								resolve(server);
+							})
 						} else {
 							reject('Untrusted Certificate.');
 						}
 					});
 				} else {
 					reject('Not a valid Zulip server');
+				}
+			});
+		});
+	}
+
+	getServerSettings(domain) {
+		const serverSettingsUrl = domain + '/api/v1/server_settings';
+		return new Promise((resolve, reject) => {
+			request(serverSettingsUrl, (error, response) => {
+				if (!error && response.statusCode == 200) {
+					const data = JSON.parse(response.body);
+					if (data.hasOwnProperty('realm_icon') && data.realm_icon) {
+						const server = {
+							icon: data.realm_uri + data.realm_icon,
+							url: data.realm_uri,
+							alias: data.realm_name
+						}
+						resolve(server);
+					}
+				} else {
+					reject('Zulip server version < 1.6.');
 				}
 			});
 		});
@@ -118,7 +151,7 @@ class DomainUtil {
 		}
 
 		return new Promise(resolve => {
-			const filePath = `${dir}/${new Date().getMilliseconds()}${path.extname(url)}`;
+			const filePath = `${dir}/${new Date().getMilliseconds()}${path.extname(url).split("?")[0]}`;
 			const file = fs.createWriteStream(filePath);
 			try {
 				request(url).on('response', response => {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
           "guard-for-in": 0,
           "prefer-promise-reject-errors": 0,
           "import/no-unresolved": 0,
-          "import/no-extraneous-dependencies": 0
+          "import/no-extraneous-dependencies": 0,
+          "no-prototype-builtins": 0
         }
       }
     ],


### PR DESCRIPTION
 - Automatically fetch server details from `server_settings` API (if supported).
 - Make ServerName optional.
 - Rename server `Name` to `Label`.
Fix #214.