### PR TITLE
Send destroy tray after hard reload.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -144,10 +144,13 @@ function registerLocalShortcuts(page) {
 	electronLocalshortcut.register(mainWindow, 'CommandOrControl+R', () => {
 		page.send('reload-viewer');
 	});
+
 	// Reload full app not just webview, useful in debugging
 	electronLocalshortcut.register(mainWindow, 'CommandOrControl+Shift+R', () => {
 		mainWindow.reload();
+		page.send('destroytray');		
 	});
+
 	// Also adding these shortcuts because some users might want to use it instead of CMD/Left-Right
 	electronLocalshortcut.register(mainWindow, 'CommandOrControl+[', () => {
 		page.send('back');


### PR DESCRIPTION
Per the comment in #235, seems that the hard-reload shortcut is not working from the menu item. We need to keep the `electronLocalshortcut`.

This PR adds the missing `destroytray` after `hard-reload`.