### PR TITLE
Set show-sidebar to true by default.

### DIFF
--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -36,7 +36,7 @@ class ServerManagerView {
 	}
 
 	initSidebar() {
-		const showSidebar = ConfigUtil.getConfigItem('show-sidebar');
+		const showSidebar = ConfigUtil.getConfigItem('show-sidebar', true);
 		this.toggleSidebar(showSidebar);
 	}
 

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -126,7 +126,7 @@ class GeneralSection extends BaseComponent {
 		this.$silentOptionSettings.appendChild($silentOption);
 
 		$silentOption.addEventListener('click', () => {
-			const newValue = !ConfigUtil.getConfigItem('silent');
+			const newValue = !ConfigUtil.getConfigItem('silent', true);
 			ConfigUtil.setConfigItem('silent', newValue);
 			this.initSilentOption();
 		});


### PR DESCRIPTION
Fix a bug that `sow-sidebar` was set to null when the key is not present in settings. Instead, set it to true, i.e. show sidebar by default.