### PR TITLE
Add an os check for webview focus events.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -57,6 +57,7 @@ function createMainWindow() {
 		icon: iconPath(),
 		minWidth: 600,
 		minHeight: 500,
+		titleBarStyle: 'hidden',
 		webPreferences: {
 			plugins: true,
 			allowDisplayingInsecureContent: true,

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -104,7 +104,7 @@ class WebView extends BaseComponent {
 		// The bug is introduced from Electron and this is a tempory fix.
 		// See https://github.com/zulip/zulip-electron/issues/216
 		const osName = SystemUtil.getOS();
-		if (osName === 'Mac' || osName === 'Linux') {
+		if (osName === 'Mac') {
 			this.$el.focus();
 		}
 	}

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -100,7 +100,13 @@ class WebView extends BaseComponent {
 	}
 
 	focus() {
-		this.$el.focus();
+		// Explicit focusing the webview causes a bug the input cannot regain focus on Winodws.
+		// The bug is introduced from Electron and this is a tempory fix.
+		// See https://github.com/zulip/zulip-electron/issues/216
+		const osName = SystemUtil.getOS();
+		if (osName === 'Mac' || osName === 'Linux') {
+			this.$el.focus();
+		}
 	}
 
 	hide() {


### PR DESCRIPTION
Fix #216.

**macOS:**
![1](https://user-images.githubusercontent.com/7262715/28839923-ddad4a9c-76ba-11e7-8106-6ed725fde3f4.gif)

**Windows:**
![2](https://user-images.githubusercontent.com/7262715/28839929-df46ba64-76ba-11e7-8db4-bcff99a136df.gif)
