### PR TITLE
darwin-menu: Capitalize menu items to style match.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -175,7 +175,7 @@ const darwinTpl = [
 		label: `${app.getName()}`,
 		submenu: [
 			{
-				label: 'Zulip desktop',
+				label: 'Zulip Desktop',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						sendAction('open-about');
@@ -195,7 +195,7 @@ const darwinTpl = [
 				}
 			},
 			{
-				label: 'Keyboard shortcuts',
+				label: 'Keyboard Shortcuts',
 				accelerator: 'Cmd+K',
 				click(item, focusedWindow) {
 					if (focusedWindow) {


### PR DESCRIPTION
This capitalizes the menu items to be consistent with how all other
menu items are capitalized on almost all applications across Mac native
menus.