### PR TITLE
Issue/new server icon cache

### DIFF
--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -49,6 +49,7 @@ class ServerManagerView {
 		if (servers.length > 0) {
 			for (let i = 0; i < servers.length; i++) {
 				this.initServer(servers[i], i);
+				DomainUtil.updateSavedServer(servers[i].url, i);				
 			}
 			this.activateTab(0);
 		} else {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -49,7 +49,7 @@ class ServerManagerView {
 		if (servers.length > 0) {
 			for (let i = 0; i < servers.length; i++) {
 				this.initServer(servers[i], i);
-				DomainUtil.updateSavedServer(servers[i].url, i);				
+				DomainUtil.updateSavedServer(servers[i].url, i);
 			}
 			this.activateTab(0);
 		} else {

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -90,8 +90,9 @@ class DomainUtil {
 	}
 
 	checkDomain(domain, silent = false) {
-		if (silent && this.duplicateDomain(domain)) {
-			alert('This Server Address already exists.');
+		if (!silent && this.duplicateDomain(domain)) {
+			// Do not check duplicate in silent mode
+			alert('This server has been added.');
 			return;
 		}
 
@@ -200,7 +201,7 @@ class DomainUtil {
 
 	updateSavedServer(url, index) {
 		// Does not promise successful update
-		this.checkDomain(url, false).then(newServerConf => {
+		this.checkDomain(url, true).then(newServerConf => {
 			this.saveServerIcon(newServerConf.icon).then(localIconUrl => {
 				newServerConf.icon = localIconUrl;
 				this.updateDomain(index, newServerConf);
@@ -220,8 +221,8 @@ class DomainUtil {
 		let hash = 5381;
 		let len = url.length;
 
-		while(len) {
-			hash = (hash * 33) ^ url.charCodeAt(--len)
+		while (len) {
+			hash = (hash * 33) ^ url.charCodeAt(--len);
 		}
 
 		// Create 'server-icons' directory if not existed

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -162,14 +162,8 @@ class DomainUtil {
 
 	saveServerIcon(url) {
 		// The save will always succeed. If url is invalid, downgrade to default icon.
-		const dir = `${app.getPath('userData')}/server-icons`;
-
-		if (!fs.existsSync(dir)) {
-			fs.mkdirSync(dir);
-		}
-
 		return new Promise(resolve => {
-			const filePath = `${dir}/${new Date().getMilliseconds()}${path.extname(url).split('?')[0]}`;
+			const filePath = this.generateFilePath(url);
 			const file = fs.createWriteStream(filePath);
 			try {
 				request(url).on('response', response => {
@@ -193,6 +187,25 @@ class DomainUtil {
 
 	reloadDB() {
 		this.db = new JsonDB(app.getPath('userData') + '/domain.json', true, true);
+	}
+
+	generateFilePath(url) {
+		const dir = `${app.getPath('userData')}/server-icons`;
+		const extension = path.extname(url).split('?')[0];
+
+		let hash = 5381;
+		let len = url.length;
+
+		while(len) {
+			hash = (hash * 33) ^ url.charCodeAt(--len)
+		}
+
+		// Create 'server-icons' directory if not existed
+		if (!fs.existsSync(dir)) {
+			fs.mkdirSync(dir);
+		}
+
+		return `${dir}/${hash >>> 0}${extension}`;
 	}
 }
 

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -80,6 +80,7 @@ class DomainUtil {
 
 	// Check if domain is already added
 	duplicateDomain(domain) {
+		domain = this.formatUrl(domain);
 		const servers = this.getDomains();
 		for (const i in servers) {
 			if (servers[i].url === domain) {
@@ -96,10 +97,7 @@ class DomainUtil {
 			return;
 		}
 
-		const hasPrefix = (domain.indexOf('http') === 0);
-		if (!hasPrefix) {
-			domain = (domain.indexOf('localhost:') >= 0) ? `http://${domain}` : `https://${domain}`;
-		}
+		domain = this.formatUrl(domain);
 
 		const checkDomain = domain + '/static/audio/zulip.ogg';
 
@@ -231,6 +229,15 @@ class DomainUtil {
 		}
 
 		return `${dir}/${hash >>> 0}${extension}`;
+	}
+
+	formatUrl(domain) {
+		const hasPrefix = (domain.indexOf('http') === 0);
+		if (hasPrefix) {
+			return domain;
+		} else {
+			return (domain.indexOf('localhost:') >= 0) ? `http://${domain}` : `https://${domain}`;
+		}
 	}
 }
 


### PR DESCRIPTION
1. Use the hash mechanism to generate local icon filenames. As a result, when you try to save an existed icon, your user-data folder won't be filled with duplicated files.
2. Update `icon` and `name` when app reloads. It updates lazily so we are still able to utilize the cache capability to display icons, but if a user's `server_settings` has updated, the new icon will show on the next reload.