### PR TITLE
Adding keyboard shortcuts to Settings page

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -11,6 +11,39 @@ body {
     background: #efefef;
 }
 
+kbd {
+    padding: 0.1em 0.6em;
+    border: 1px solid #ccc;
+    font-size: 11px;
+    font-family: Arial,Helvetica,sans-serif;
+    background-color: #f7f7f7;
+    color: #333;
+    -moz-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    -webkit-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px #ffffff inset;
+    -moz-border-radius: 3px;
+    -webkit-border-radius: 3px;
+    border-radius: 3px;
+    display: inline-block;
+    margin: 0 0.1em;
+    text-shadow: 0 1px 0 #fff;
+    line-height: 1.4;
+    white-space: nowrap;
+}
+
+table, th, td {
+    border: 1px solid #ddd;
+    border-collapse: collapse;
+}
+
+table { width: 70%; }
+
+table tr:nth-child(even) { background-color: #f2f2f2; }
+
+td { padding: 5px; }
+
+td:nth-child(odd) { text-align: right; }
+
 @font-face {
   font-family: 'Material Icons';
   font-style: normal;

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -14,7 +14,7 @@ body {
 kbd {
     padding: 0.1em 0.6em;
     border: 1px solid #ccc;
-    font-size: 11px;
+    font-size: 12px;
     font-family: Arial,Helvetica,sans-serif;
     background-color: #f7f7f7;
     color: #333;
@@ -36,13 +36,16 @@ table, th, td {
     border-collapse: collapse;
 }
 
-table { width: 70%; }
+table { width: 85%; }
 
 table tr:nth-child(even) { background-color: #f2f2f2; }
 
 td { padding: 5px; }
 
-td:nth-child(odd) { text-align: right; }
+td:nth-child(odd) {
+		text-align: right;
+		width: 50%;
+}
 
 @font-face {
   font-family: 'Material Icons';
@@ -297,4 +300,15 @@ i.open-tab-button {
 .reset-data-button:hover {
     background-color: #32a692;
     color: #fff;
+}
+
+#open-shortcuts-url {
+		color: #08c;
+		cursor: pointer;
+		text-decoration: none;
+}
+
+#open-shortcuts-url:hover {
+		color: #005580;;
+		text-decoration: underline;
 }

--- a/app/renderer/js/pages/preference/nav.js
+++ b/app/renderer/js/pages/preference/nav.js
@@ -8,7 +8,7 @@ class PreferenceNav extends BaseComponent {
 
 		this.props = props;
 
-		this.navItems = ['General', 'Network', 'Servers', 'Keyboard Shortcuts'];
+		this.navItems = ['General', 'Network', 'Servers', 'Shortcuts'];
 
 		this.init();
 	}

--- a/app/renderer/js/pages/preference/nav.js
+++ b/app/renderer/js/pages/preference/nav.js
@@ -8,7 +8,7 @@ class PreferenceNav extends BaseComponent {
 
 		this.props = props;
 
-		this.navItems = ['General', 'Network', 'Servers'];
+		this.navItems = ['General', 'Network', 'Servers', 'Keyboard Shortcuts'];
 
 		this.init();
 	}

--- a/app/renderer/js/pages/preference/preference.js
+++ b/app/renderer/js/pages/preference/preference.js
@@ -57,7 +57,7 @@ class PreferenceView extends BaseComponent {
 				});
 				break;
 			}
-			case 'Keyboard Shortcuts': {
+			case 'Shortcuts': {
 				this.section = new ShortcutsSection({
 					$root: this.$settingsContainer
 				});

--- a/app/renderer/js/pages/preference/preference.js
+++ b/app/renderer/js/pages/preference/preference.js
@@ -7,6 +7,7 @@ const Nav = require(__dirname + '/js/pages/preference/nav.js');
 const ServersSection = require(__dirname + '/js/pages/preference/servers-section.js');
 const GeneralSection = require(__dirname + '/js/pages/preference/general-section.js');
 const NetworkSection = require(__dirname + '/js/pages/preference/network-section.js');
+const ShortcutsSection = require(__dirname + '/js/pages/preference/shortcuts-section.js');
 
 class PreferenceView extends BaseComponent {
 	constructor() {
@@ -52,6 +53,12 @@ class PreferenceView extends BaseComponent {
 			}
 			case 'Network': {
 				this.section = new NetworkSection({
+					$root: this.$settingsContainer
+				});
+				break;
+			}
+			case 'Keyboard Shortcuts': {
+				this.section = new ShortcutsSection({
 					$root: this.$settingsContainer
 				});
 				break;

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -11,21 +11,26 @@ class ShortcutsSection extends BaseSection {
 	}
 
 	template() {
+		let userOSKey = 'Ctrl';
+		if (process.platform === 'darwin') {
+			userOSKey = '⌘';
+		}
+
 		return `
             <div class="settings-pane">
               <div class="title">Desktop-specific</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>,</kbd></td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>,</kbd></td>
                     <td>Manage servers</td>
                   </tr>
                   <tr>
-                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>[</kbd></td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>[</kbd></td>
                     <td>Back</td>
                   </tr>
                   <tr>
-                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>]</kbd></td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>]</kbd></td>
                     <td>Forward</td>
                   </tr>
                 </table>
@@ -101,7 +106,7 @@ class ShortcutsSection extends BaseSection {
                     <td>Scroll up</td>
                   </tr>
                   <tr>
-                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>Enter</kbd></td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Enter</kbd></td>
                     <td>Send message</td>
                   </tr>
                   <tr>
@@ -173,7 +178,7 @@ class ShortcutsSection extends BaseSection {
                     <td>Cycle between stream narrows</td>
                   </tr>
                   <tr>
-                    <td><kbd>Esc</kbd>, <kbd>Ctrl/Cmd</kbd> + <kbd>[</kbd></td>
+                    <td><kbd>Esc</kbd>, <kbd>${userOSKey}</kbd> + <kbd>[</kbd></td>
                     <td>Return to Home view</td>
                   </tr>
                 </table>

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { shell } = require('electron');
-
 const BaseSection = require(__dirname + '/base-section.js');
 
 class ShortcutsSection extends BaseSection {
@@ -10,276 +8,294 @@ class ShortcutsSection extends BaseSection {
 		this.props = props;
 	}
 
-	template() {
-		let userOSKey = 'Ctrl';
-		if (process.platform === 'darwin') {
-			userOSKey = '⌘';
-		}
+	templateMac() {
+		const userOSKey = '⌘';
 
 		return `
             <div class="settings-pane">
-              <div class="title">Desktop-specific</div>
+              <div class="title">Application Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>,</kbd></td>
-                    <td>Manage servers</td>
+                    <td><kbd>${userOSKey}</kbd><kbd>,</kbd></td>
+                    <td>Settings</td>
                   </tr>
                   <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>[</kbd></td>
+                    <td><kbd>${userOSKey}</kbd><kbd>K</kbd></td>
+                    <td>Keyboard Shortcuts</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Shift</kbd><kbd>${userOSKey}</kbd><kbd>D</kbd></td>
+                    <td>Reset App Settings</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>L</kbd></td>
+                    <td>Log Out</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>H</kbd></td>
+                    <td>Hide Zulip</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Option</kbd><kbd>${userOSKey}</kbd><kbd>H</kbd></td>
+                    <td>Hide Others</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>Q</kbd></td>
+                    <td>Quit Zulip</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+              <div class="title">Edit Shortcuts</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>Z</kbd></td>
+                    <td>Undo</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Shift</kbd><kbd>${userOSKey}</kbd><kbd>Z</kbd></td>
+                    <td>Redo</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>X</kbd></td>
+                    <td>Cut</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>C</kbd></td>
+                    <td>Copy</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>V</kbd></td>
+                    <td>Paste</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Shift</kbd><kbd>${userOSKey}</kbd><kbd>V</kbd></td>
+                    <td>Paste and Match Style</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>A</kbd></td>
+                    <td>Select All</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>F</kbd></td>
+                    <td>Find</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>G</kbd></td>
+                    <td>Find Next</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Control</kbd><kbd>${userOSKey}</kbd><kbd>Space</kbd></td>
+                    <td>Emoji & Symbols</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+              <div class="title">View Shortcuts</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>R</kbd></td>
+                    <td>Reload</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Shift</kbd><kbd>${userOSKey}</kbd><kbd>R</kbd></td>
+                    <td>Hard Reload</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Control</kbd><kbd>${userOSKey}</kbd><kbd>F</kbd></td>
+                    <td>Enter Full Screen</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>=</kbd></td>
+                    <td>Zoom In</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>-</kbd></td>
+                    <td>Zoom Out</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>0</kbd></td>
+                    <td>Actual Size</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>S</kbd></td>
+                    <td>Toggle Sidebar</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Option</kbd><kbd>${userOSKey}</kbd><kbd>I</kbd></td>
+                    <td>Toggle DevTools for Zulip App</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Option</kbd><kbd>${userOSKey}</kbd><kbd>U</kbd></td>
+                    <td>Toggle DevTools for Active Tab</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+              <div class="title">History Shortcuts</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd><kbd>←</kbd></td>
                     <td>Back</td>
                   </tr>
                   <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>]</kbd></td>
+                    <td><kbd>${userOSKey}</kbd><kbd>→</kbd></td>
                     <td>Forward</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-              <div class="title">Navigation</div>
+              <div class="title">Window Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>/</kbd></td>
-                    <td>Initiate a search</td>
+                    <td><kbd>${userOSKey}</kbd><kbd>M</kbd></td>
+                    <td>Minimize</td>
                   </tr>
                   <tr>
-                    <td><kbd>q</kbd></td>
-                    <td>Search people</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>w</kbd></td>
-                    <td>Search streams</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>↑</kbd>, <kbd>k</kbd></td>
-                    <td>Previous message</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>↓</kbd>, <kbd>j</kbd></td>
-                    <td>Next message</td>
-                  </tr>
-									<tr>
-                    <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
-                    <td>Scroll up</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>PgDn</kbd>, <kbd>Space</kbd>, <kbd>J</kbd></td>
-                    <td>Scroll down</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>End</kbd>, <kbd>G</kbd></td>
-                    <td>Last message</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>Home</kbd></td>
-                    <td>First message</td>
+                    <td><kbd>${userOSKey}</kbd><kbd>W</kbd></td>
+                    <td>Close</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-              <div class="title">Composing Messages</div>
+            </div>
+		`;
+	}
+
+	templateWinLin() {
+		const userOSKey = 'Ctrl';
+
+		return `
+            <div class="settings-pane">
+              <div class="title">Application Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>Enter</kbd>, <kbd>r</kbd></td>
-                    <td>Reply to message</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>,</kbd></td>
+                    <td>Settings</td>
                   </tr>
                   <tr>
-                    <td><kbd>R</kbd></td>
-                    <td>Reply to author</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>K</kbd></td>
+                    <td>Keyboard Shortcuts</td>
                   </tr>
                   <tr>
-                    <td><kbd>c</kbd></td>
-                    <td>New stream message</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>L</kbd></td>
+                    <td>Log Out</td>
                   </tr>
                   <tr>
-                    <td><kbd>C</kbd></td>
-                    <td>New private message</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>@</kbd></td>
-                    <td>Compose a reply @-mentioning author</td>
-                  </tr>
-									<tr>
-                    <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
-                    <td>Scroll up</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>Enter</kbd></td>
-                    <td>Send message</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>Shift</kbd> + <kbd>Enter</kbd></td>
-                    <td>Insert new line</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>Esc</kbd>, <kbd>Ctrl</kbd> + <kbd>[</kbd></td>
-                    <td>Cancel compose</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Q</kbd></td>
+                    <td>Quit Zulip</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-							<div class="title">Message Actions</div>
+              <div class="title">Edit Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>←</kbd></td>
-                    <td>Edit your last message</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Z</kbd></td>
+                    <td>Undo</td>
                   </tr>
                   <tr>
-                    <td><kbd>u</kbd></td>
-                    <td>Show message sender's profile</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Y</kbd></td>
+                    <td>Redo</td>
                   </tr>
                   <tr>
-                    <td><kbd>v</kbd></td>
-                    <td>Show images in thread</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>X</kbd></td>
+                    <td>Cut</td>
                   </tr>
                   <tr>
-                    <td><kbd>*</kbd></td>
-                    <td>Star selected message</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>C</kbd></td>
+                    <td>Copy</td>
                   </tr>
                   <tr>
-                    <td><kbd>+</kbd></td>
-                    <td>React to selected message with 👍</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>V</kbd></td>
+                    <td>Paste</td>
                   </tr>
                   <tr>
-                    <td><kbd>-</kbd></td>
-                    <td>Collapse/show selected message</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd></td>
+                    <td>Paste and Match Style</td>
                   </tr>
                   <tr>
-                    <td><kbd>M</kbd></td>
-                    <td>Toggle topic mute</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>A</kbd></td>
+                    <td>Select All</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-							<div class="title">Narrowing</div>
+              <div class="title">View Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>s</kbd></td>
-                    <td>Narrow by stream</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>R</kbd></td>
+                    <td>Reload</td>
                   </tr>
                   <tr>
-                    <td><kbd>S</kbd></td>
-                    <td>Narrow by topic</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd></td>
+                    <td>Hard Reload</td>
                   </tr>
                   <tr>
-                    <td><kbd>P</kbd></td>
-                    <td>Narrow to all private messages</td>
+                    <td><kbd>F11</kbd></td>
+                    <td>Toggle Full Screen</td>
                   </tr>
                   <tr>
-                    <td><kbd>n</kbd></td>
-                    <td>Narrow to next unread topic</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>=</kbd></td>
+                    <td>Zoom In</td>
                   </tr>
                   <tr>
-                    <td><kbd>A</kbd>, <kbd>D</kbd></td>
-                    <td>Cycle between stream narrows</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>-</kbd></td>
+                    <td>Zoom Out</td>
                   </tr>
                   <tr>
-                    <td><kbd>Esc</kbd>, <kbd>${userOSKey}</kbd> + <kbd>[</kbd></td>
-                    <td>Return to Home view</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>0</kbd></td>
+                    <td>Actual Size</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>S</kbd></td>
+                    <td>Toggle Sidebar</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd></td>
+                    <td>Toggle DevTools for Zulip App</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd></td>
+                    <td>Toggle DevTools for Active Tab</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-							<div class="title">Menus</div>
+              <div class="title">History Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>g</kbd></td>
-                    <td>Toggle the gear menu</td>
+                    <td><kbd>Alt</kbd> + <kbd>←</kbd></td>
+                    <td>Back</td>
                   </tr>
                   <tr>
-                    <td><kbd>i</kbd></td>
-                    <td>Open message menu</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>:</kbd></td>
-                    <td>Open reactions menu</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>?</kbd></td>
-                    <td>Show keyboard shortcuts</td>
+                    <td><kbd>Alt</kbd> + <kbd>→</kbd></td>
+                    <td>Forward</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
-							<div class="title">Drafts</div>
+              <div class="title">Window Shortcuts</div>
               <div class="settings-card">
                 <table>
                   <tr>
-                    <td><kbd>d</kbd></td>
-                    <td>View drafts</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>M</kbd></td>
+                    <td>Minimize</td>
                   </tr>
                   <tr>
-                    <td><kbd>↑</kbd></td>
-                    <td>Select previous draft</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>↓</kbd></td>
-                    <td>Select next draft</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>PgUp</kbd> (<kbd>Fn</kbd> + <kbd>↑</kbd>)</td>
-                    <td>Scroll up</td>
-                  </tr>
-									<tr>
-                    <td><kbd>Space</kbd>, <kbd>PgDn</kbd> (<kbd>Fn</kbd> + <kbd>↓</kbd>)</td>
-                    <td>Scroll down</td>
-                  </tr>
-									<tr>
-                    <td><kbd>Home</kbd> (<kbd>Fn</kbd> + <kbd>←</kbd>)</td>
-                    <td>Select first draft</td>
-                  </tr>
-									<tr>
-                    <td><kbd>End</kbd> (<kbd>Fn</kbd> + <kbd>→</kbd>), <kbd>G</kbd></td>
-                    <td>Select last draft</td>
-                  </tr>
-									<tr>
-                    <td><kbd>Enter</kbd> (<kbd>Return</kbd>)</td>
-                    <td>Edit selected draft</td>
-                  </tr>
-									<tr>
-                    <td><kbd>Backspace</kbd> (<kbd>Delete</kbd>)</td>
-                    <td>Delete selected draft</td>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>W</kbd></td>
+                    <td>Close</td>
                   </tr>
                 </table>
-                <div class="setting-control"></div>
-              </div>
-							<div class="title">Streams</div>
-              <div class="settings-card">
-                <table>
-                  <tr>
-                    <td><kbd>↑</kbd> and <kbd>↓</kbd></td>
-                    <td>Scroll through streams</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>←</kbd> and <kbd>→</kbd></td>
-                    <td>Switch between tabs</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>V</kbd></td>
-                    <td>View stream messages</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>S</kbd></td>
-                    <td>Subscribe/unsubscribe from selected stream</td>
-                  </tr>
-                  <tr>
-                    <td><kbd>n</kbd></td>
-                    <td>Create new stream</td>
-                  </tr>
-                </table>
-                <div class="setting-control"></div>
-              </div>
-							<div class="title">Documentation</div>
-              <div class="settings-card">
-								<span id="open-shortcuts-url">
-									Detailed keyboard shortcuts documentation found here
-									<i class="material-icons open-tab-button">open_in_new</i>
-								</span>
                 <div class="setting-control"></div>
               </div>
             </div>
@@ -287,15 +303,8 @@ class ShortcutsSection extends BaseSection {
 	}
 
 	init() {
-		this.props.$root.innerHTML = this.template();
-		this.openExternalShortcutsLink();
-	}
-
-	openExternalShortcutsLink() {
-		const externalShortcutsLink = document.getElementById('open-shortcuts-url');
-		externalShortcutsLink.addEventListener('click', () => {
-			shell.openExternal('https://chat.zulip.org/help/keyboard-shortcuts');
-		});
+		this.props.$root.innerHTML = (process.platform === 'darwin') ?
+			this.templateMac() : this.templateWinLin();
 	}
 }
 

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { shell } = require('electron');
+
 const BaseSection = require(__dirname + '/base-section.js');
 
 class ShortcutsSection extends BaseSection {
@@ -12,7 +14,7 @@ class ShortcutsSection extends BaseSection {
 		return `
             <div class="settings-pane">
               <div class="title">Desktop-specific</div>
-              <div id="appearance-option-settings" class="settings-card">
+              <div class="settings-card">
                 <table>
                   <tr>
                     <td><kbd>Ctrl/Cmd</kbd> + <kbd>,</kbd></td>
@@ -30,7 +32,7 @@ class ShortcutsSection extends BaseSection {
                 <div class="setting-control"></div>
               </div>
               <div class="title">Navigation</div>
-              <div id="appearance-option-settings" class="settings-card">
+              <div class="settings-card">
                 <table>
                   <tr>
                     <td><kbd>/</kbd></td>
@@ -52,6 +54,7 @@ class ShortcutsSection extends BaseSection {
                     <td><kbd>↓</kbd>, <kbd>j</kbd></td>
                     <td>Next message</td>
                   </tr>
+									<tr>
                     <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
                     <td>Scroll up</td>
                   </tr>
@@ -93,6 +96,7 @@ class ShortcutsSection extends BaseSection {
                     <td><kbd>@</kbd></td>
                     <td>Compose a reply @-mentioning author</td>
                   </tr>
+									<tr>
                     <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
                     <td>Scroll up</td>
                   </tr>
@@ -111,12 +115,182 @@ class ShortcutsSection extends BaseSection {
                 </table>
                 <div class="setting-control"></div>
               </div>
+							<div class="title">Message Actions</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>←</kbd></td>
+                    <td>Edit your last message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>u</kbd></td>
+                    <td>Show message sender's profile</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>v</kbd></td>
+                    <td>Show images in thread</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>*</kbd></td>
+                    <td>Star selected message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>+</kbd></td>
+                    <td>React to selected message with 👍</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>-</kbd></td>
+                    <td>Collapse/show selected message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>M</kbd></td>
+                    <td>Toggle topic mute</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+							<div class="title">Narrowing</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>s</kbd></td>
+                    <td>Narrow by stream</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>S</kbd></td>
+                    <td>Narrow by topic</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>P</kbd></td>
+                    <td>Narrow to all private messages</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>n</kbd></td>
+                    <td>Narrow to next unread topic</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>A</kbd>, <kbd>D</kbd></td>
+                    <td>Cycle between stream narrows</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Esc</kbd>, <kbd>Ctrl/Cmd</kbd> + <kbd>[</kbd></td>
+                    <td>Return to Home view</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+							<div class="title">Menus</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>g</kbd></td>
+                    <td>Toggle the gear menu</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>i</kbd></td>
+                    <td>Open message menu</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>:</kbd></td>
+                    <td>Open reactions menu</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>?</kbd></td>
+                    <td>Show keyboard shortcuts</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+							<div class="title">Drafts</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>d</kbd></td>
+                    <td>View drafts</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>↑</kbd></td>
+                    <td>Select previous draft</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>↓</kbd></td>
+                    <td>Select next draft</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>PgUp</kbd> (<kbd>Fn</kbd> + <kbd>↑</kbd>)</td>
+                    <td>Scroll up</td>
+                  </tr>
+									<tr>
+                    <td><kbd>Space</kbd>, <kbd>PgDn</kbd> (<kbd>Fn</kbd> + <kbd>↓</kbd>)</td>
+                    <td>Scroll down</td>
+                  </tr>
+									<tr>
+                    <td><kbd>Home</kbd> (<kbd>Fn</kbd> + <kbd>←</kbd>)</td>
+                    <td>Select first draft</td>
+                  </tr>
+									<tr>
+                    <td><kbd>End</kbd> (<kbd>Fn</kbd> + <kbd>→</kbd>), <kbd>G</kbd></td>
+                    <td>Select last draft</td>
+                  </tr>
+									<tr>
+                    <td><kbd>Enter</kbd> (<kbd>Return</kbd>)</td>
+                    <td>Edit selected draft</td>
+                  </tr>
+									<tr>
+                    <td><kbd>Backspace</kbd> (<kbd>Delete</kbd>)</td>
+                    <td>Delete selected draft</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+							<div class="title">Streams</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>↑</kbd> and <kbd>↓</kbd></td>
+                    <td>Scroll through streams</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>←</kbd> and <kbd>→</kbd></td>
+                    <td>Switch between tabs</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>V</kbd></td>
+                    <td>View stream messages</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>S</kbd></td>
+                    <td>Subscribe/unsubscribe from selected stream</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>n</kbd></td>
+                    <td>Create new stream</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+							<div class="title">Documentation</div>
+              <div class="settings-card">
+								<span id="open-shortcuts-url">
+									Detailed keyboard shortcuts documentation found here
+									<i class="material-icons open-tab-button">open_in_new</i>
+								</span>
+                <div class="setting-control"></div>
+              </div>
             </div>
 		`;
 	}
 
 	init() {
 		this.props.$root.innerHTML = this.template();
+		this.openExternalShortcutsLink();
+	}
+
+	openExternalShortcutsLink() {
+		const externalShortcutsLink = document.getElementById('open-shortcuts-url');
+		externalShortcutsLink.addEventListener('click', () => {
+			shell.openExternal('https://chat.zulip.org/help/keyboard-shortcuts');
+		});
 	}
 }
 

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const BaseSection = require(__dirname + '/base-section.js');
+
+class ShortcutsSection extends BaseSection {
+	constructor(props) {
+		super();
+		this.props = props;
+	}
+
+	template() {
+		return `
+            <div class="settings-pane">
+              <div class="title">Desktop-specific</div>
+              <div id="appearance-option-settings" class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>,</kbd></td>
+                    <td>Manage servers</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>[</kbd></td>
+                    <td>Back</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>]</kbd></td>
+                    <td>Forward</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+              <div class="title">Navigation</div>
+              <div id="appearance-option-settings" class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>/</kbd></td>
+                    <td>Initiate a search</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>q</kbd></td>
+                    <td>Search people</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>w</kbd></td>
+                    <td>Search streams</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>↑</kbd>, <kbd>k</kbd></td>
+                    <td>Previous message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>↓</kbd>, <kbd>j</kbd></td>
+                    <td>Next message</td>
+                  </tr>
+                    <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
+                    <td>Scroll up</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>PgDn</kbd>, <kbd>Space</kbd>, <kbd>J</kbd></td>
+                    <td>Scroll down</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>End</kbd>, <kbd>G</kbd></td>
+                    <td>Last message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Home</kbd></td>
+                    <td>First message</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+              <div class="title">Composing Messages</div>
+              <div class="settings-card">
+                <table>
+                  <tr>
+                    <td><kbd>Enter</kbd>, <kbd>r</kbd></td>
+                    <td>Reply to message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>R</kbd></td>
+                    <td>Reply to author</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>c</kbd></td>
+                    <td>New stream message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>C</kbd></td>
+                    <td>New private message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>@</kbd></td>
+                    <td>Compose a reply @-mentioning author</td>
+                  </tr>
+                    <td><kbd>PgUp</kbd>, <kbd>K</kbd></td>
+                    <td>Scroll up</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Ctrl/Cmd</kbd> + <kbd>Enter</kbd></td>
+                    <td>Send message</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Shift</kbd> + <kbd>Enter</kbd></td>
+                    <td>Insert new line</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>Esc</kbd>, <kbd>Ctrl</kbd> + <kbd>[</kbd></td>
+                    <td>Cancel compose</td>
+                  </tr>
+                </table>
+                <div class="setting-control"></div>
+              </div>
+            </div>
+		`;
+	}
+
+	init() {
+		this.props.$root.innerHTML = this.template();
+	}
+}
+
+module.exports = ShortcutsSection;


### PR DESCRIPTION
## Description:
This is the initial pass at adding keyboard shortcuts to the Settings page (see #276). Thus far, a `ShortcutsSection` class has been created and is applied to a
newly-added 'Keyboard Shortcuts' nav item. The template for ShortcutsSection
is essentially multiple `<div class="settings-cards">` elements containing one table of keyboard shortcuts organized by their underlying functionality (see attached screenshot).

![screen shot 2017-09-09 at 6 46 00 pm 2](https://user-images.githubusercontent.com/16343560/30245580-3d96430e-9593-11e7-9359-518a95a613a8.png)

The HTML `<kbd>` tag was defined in preference.css which styles the element to
look like a keyboard key.

## What's Next:
- [x] Add all keyboard shortcuts, currently only 3 categories have been added. (**updated 9/09** - 352b775)
)
- [x] Get feedback on design/layout, make any necessary changes

