### PR TITLE
Rename menu label Zulip Desktop as About Zulip.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -173,7 +173,7 @@ class AppMenu {
 		return [{
 			label: `${app.getName()}`,
 			submenu: [{
-				label: 'Zulip Desktop',
+				label: 'About Zulip',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('open-about');
@@ -273,7 +273,7 @@ class AppMenu {
 		return [{
 			label: 'File',
 			submenu: [{
-				label: 'Zulip Desktop',
+				label: 'About Zulip',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('open-about');


### PR DESCRIPTION
This fix changes the menu label 'Zulip Desktop' to 'About Zulip' for clarity, ('About' is more descriptive of the content in the view associated with the label). Also to have the menu conform to convention regarding naming menu labels for Mac OS applications.

Fixes #306