### PR TITLE
Show server-info on hovering the server-icons

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -31,7 +31,6 @@ body {
 }
 
 .toggle-sidebar div {
-    transform: translateX(0);
     transition: all 0.5s ease-out;
 }
 

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -273,6 +273,31 @@ webview:focus {
     right: 68px;
 }
 
+.server-tooltip {
+    font-family: 'arial';
+    background: #222c31;
+    left: 56px;
+    padding: 10px 20px;
+    position: fixed;
+    margin-top: 8px;
+    z-index: 5000 !important;
+    color: #fff;
+    border-radius: 4px;
+    text-align: center;
+    width: max-content;
+    font-size: 14px;
+}
+
+.server-tooltip:after {
+    content: " ";
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-right: 8px solid #222c31;
+    position: absolute;
+    top: 10px;
+    left: -5px;
+}
+
 #collapse-button {
     bottom: 30px;
     left: 20px;

--- a/app/renderer/js/components/server-tab.js
+++ b/app/renderer/js/components/server-tab.js
@@ -8,6 +8,7 @@ const {ipcRenderer} = require('electron');
 class ServerTab extends Tab {
 	template() {
 		return `<div class="tab">
+					<div class="server-tooltip" style="display:none"></div>
 					<div class="server-tab-badge"></div>
 					<div class="server-tab">
 					<img class="server-icons" src='${this.props.icon}'/>

--- a/app/renderer/js/components/tab.js
+++ b/app/renderer/js/components/tab.js
@@ -21,6 +21,8 @@ class Tab extends BaseComponent {
 
 	registerListeners() {
 		this.$el.addEventListener('click', this.props.onClick);
+		this.$el.addEventListener('mouseover', this.props.onHover);
+		this.$el.addEventListener('mouseout', this.props.onHoverOut);
 	}
 
 	isLoading() {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -23,6 +23,8 @@ class ServerManagerView {
 
 		this.$reloadTooltip = $actionsContainer.querySelector('#reload-tooltip');
 		this.$settingsTooltip = $actionsContainer.querySelector('#setting-tooltip');
+		this.$serverIconTooltip = document.getElementsByClassName('server-tooltip');
+
 		this.$sidebar = document.getElementById('sidebar');
 
 		this.$fullscreenPopup = document.getElementById('fullscreen-popup');
@@ -90,6 +92,8 @@ class ServerManagerView {
 			$root: this.$tabsContainer,
 			onClick: this.activateTab.bind(this, index),
 			index,
+			onHover: this.onHover.bind(this, index, server.alias),
+			onHoverOut: this.onHoverOut.bind(this, index),
 			webview: new WebView({
 				$root: this.$webviewsContainer,
 				index,
@@ -128,6 +132,15 @@ class ServerManagerView {
 		SidebarButton.addEventListener('mouseout', () => {
 			SidebarTooltip.style.display = 'none';
 		});
+	}
+
+	onHover(index, serverName) {
+		this.$serverIconTooltip[index].innerHTML = serverName;
+		this.$serverIconTooltip[index].removeAttribute('style');
+	}
+
+	onHoverOut(index) {
+		this.$serverIconTooltip[index].style.display = 'none';
 	}
 
 	openFunctionalTab(tabProps) {


### PR DESCRIPTION
This PR adds a functionality to show server-info on hovering the server-icons in left sidebar. This makes easy to identify which server user is using!

![orginfo](https://user-images.githubusercontent.com/2263909/31049799-a68e205e-a658-11e7-8b27-af09f7bc8470.gif)
