### PR TITLE
Remove electron-localshortcut completely 

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const electron = require('electron');
 const electronLocalshortcut = require('electron-localshortcut');
 const windowStateKeeper = require('electron-window-state');
+const isDev = require('electron-is-dev');
 const appMenu = require('./menu');
 const { appUpdater } = require('./autoupdater');
 const { crashHandler } = require('./crash-reporter');
@@ -14,7 +15,10 @@ const { app, ipcMain } = electron;
 const BadgeSettings = require('./../renderer/js/pages/preference/badge-settings.js');
 
 // Adds debug features like hotkeys for triggering dev tools and reload
-require('electron-debug')();
+// in development mode
+if (isDev) {
+	require('electron-debug')();
+}
 
 // Prevent window being garbage collected
 let mainWindow;
@@ -125,11 +129,6 @@ function createMainWindow() {
 }
 
 function registerLocalShortcuts(page) {
-	// Somehow, reload action cannot be overwritten by the menu item
-	electronLocalshortcut.register(mainWindow, 'CommandOrControl+R', () => {
-		page.send('reload-current-viewer');
-	});
-
 	// Also adding these shortcuts because some users might want to use it instead of CMD/Left-Right
 	electronLocalshortcut.register(mainWindow, 'CommandOrControl+[', () => {
 		page.send('back');

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const path = require('path');
 const electron = require('electron');
-const electronLocalshortcut = require('electron-localshortcut');
 const windowStateKeeper = require('electron-window-state');
 const isDev = require('electron-is-dev');
 const appMenu = require('./menu');
@@ -98,9 +97,6 @@ function createMainWindow() {
 				win.hide();
 			}
 		}
-
-		// Unregister all the shortcuts so that they don't interfare with other apps
-		electronLocalshortcut.unregisterAll(mainWindow);
 	});
 
 	win.setTitle('Zulip');
@@ -128,26 +124,10 @@ function createMainWindow() {
 	return win;
 }
 
-function registerLocalShortcuts(page) {
-	// Also adding these shortcuts because some users might want to use it instead of CMD/Left-Right
-	electronLocalshortcut.register(mainWindow, 'CommandOrControl+[', () => {
-		page.send('back');
-	});
-
-	electronLocalshortcut.register(mainWindow, 'CommandOrControl+]', () => {
-		page.send('forward');
-	});
-}
-
 // eslint-disable-next-line max-params
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
 	event.preventDefault();
 	callback(true);
-});
-
-app.on('window-all-closed', () => {
-	// Unregister all the shortcuts so that they don't interfare with other apps
-	electronLocalshortcut.unregisterAll(mainWindow);
 });
 
 app.on('activate', () => {
@@ -163,8 +143,6 @@ app.on('ready', () => {
 	mainWindow = createMainWindow();
 
 	const page = mainWindow.webContents;
-
-	registerLocalShortcuts(page);
 
 	page.on('dom-ready', () => {
 		mainWindow.show();
@@ -231,28 +209,13 @@ app.on('ready', () => {
 	});
 
 	ipcMain.on('register-server-tab-shortcut', (event, index) => {
-		electronLocalshortcut.register(mainWindow, `CommandOrControl+${index}`, () => {
-			// Array index == Shown index - 1
-			page.send('switch-server-tab', index - 1);
-		});
-	});
-
-	ipcMain.on('local-shortcuts', (event, enable) => {
-		if (enable) {
-			registerLocalShortcuts(page);
-		} else {
-			electronLocalshortcut.unregisterAll(mainWindow);
-		}
+		// Array index == Shown index - 1
+		page.send('switch-server-tab', index - 1);
 	});
 
 	ipcMain.on('toggleAutoLauncher', (event, AutoLaunchValue) => {
 		setAutoLaunch(AutoLaunchValue);
 	});
-});
-
-app.on('will-quit', () => {
-	// Unregister all the shortcuts so that they don't interfare with other apps
-	electronLocalshortcut.unregisterAll(mainWindow);
 });
 
 app.on('before-quit', () => {

--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "electron-debug": "1.4.0",
     "electron-is-dev": "0.3.0",
-    "electron-localshortcut": "2.0.2",
     "electron-log": "2.2.7",
     "electron-spellchecker": "1.1.2",
     "electron-updater": "2.16.2",

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,6 @@
     "InstantMessaging"
   ],
   "dependencies": {
-    "electron-debug": "1.4.0",
     "electron-is-dev": "0.3.0",
     "electron-log": "2.2.7",
     "electron-spellchecker": "1.1.2",

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -83,7 +83,6 @@ class ServerManagerView {
 		} else {
 			this.openSettings('Servers');
 		}
-		ipcRenderer.send('local-shortcuts', true);
 	}
 
 	initServer(server, index) {
@@ -257,9 +256,6 @@ class ServerManagerView {
 		// Clear DOM elements
 		this.$tabsContainer.innerHTML = '';
 		this.$webviewsContainer.innerHTML = '';
-
-		// Destroy shortcuts
-		ipcRenderer.send('local-shortcuts', false);
 	}
 
 	reloadView() {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "chai": "4.1.1",
     "spectron": "3.7.2",
     "xo": "0.18.2",
-    "pre-commit": "1.2.2"
+    "pre-commit": "1.2.2",
+    "electron-debug": "1.4.0"
   },
   "xo": {
     "parserOptions": {


### PR DESCRIPTION
This PR removes the use of local shortcuts which is being done by `electron-localshortcut`. Now the app depends on menu accelerators to register keyboard shortcuts which is the safe method. The reason we have removed `electron-localshortcut` is that sometimes it hijacks the OS shortcut which is very annoying. More info about this issue can be found here - https://github.com/electron/electron/issues/1334 