### PR TITLE
settings: Add a setting option to start the app in background.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -12,6 +12,7 @@ const { setAutoLaunch } = require('./startup');
 const { app, ipcMain } = electron;
 
 const BadgeSettings = require('./../renderer/js/pages/preference/badge-settings.js');
+const ConfigUtil = require('./../renderer/js/utils/config-util.js');
 
 // Adds debug features like hotkeys for triggering dev tools and reload
 // in development mode
@@ -81,7 +82,11 @@ function createMainWindow() {
 	});
 
 	win.once('ready-to-show', () => {
-		win.show();
+		if (ConfigUtil.getConfigItem('startMinimized')) {
+			win.minimize();
+		} else {
+			win.show();
+		}
 	});
 
 	win.loadURL(mainURL);
@@ -145,7 +150,11 @@ app.on('ready', () => {
 	const page = mainWindow.webContents;
 
 	page.on('dom-ready', () => {
-		mainWindow.show();
+		if (ConfigUtil.getConfigItem('startMinimized')) {
+			mainWindow.minimize();
+		} else {
+			mainWindow.show();
+		}
 	});
 
 	page.once('did-frame-finish-load', () => {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -77,6 +77,7 @@ class ServerManagerView {
 			showSidebar: true,
 			badgeOption: true,
 			startAtLogin: false,
+			startMinimized: false,
 			enableSpellchecker: true,
 			showNotification: true,
 			betaUpdate: false,

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -61,10 +61,14 @@ class GeneralSection extends BaseSection {
 						<div class="setting-description">Start app at login</div>
 						<div class="setting-control"></div>
 					</div>
+					<div class="setting-row" id="start-minimize-option">
+						<div class="setting-description">Always start minimized</div>
+						<div class="setting-control"></div>
+					</div>
 					<div class="setting-row" id="enable-spellchecker-option">
-					<div class="setting-description">Enable Spellchecker (requires restart)</div>
-					<div class="setting-control"></div>
-				</div>
+						<div class="setting-description">Enable Spellchecker (requires restart)</div>
+						<div class="setting-control"></div>
+					</div>
 				</div>
 				<div class="title">Reset Application Data</div>
                 <div class="settings-card">
@@ -89,6 +93,7 @@ class GeneralSection extends BaseSection {
 		this.updateResetDataOption();
 		this.showDesktopNotification();
 		this.enableSpellchecker();
+		this.minimizeOnStart();
 
 		// Platform specific settings
 		// Flashing taskbar on Windows
@@ -231,6 +236,18 @@ class GeneralSection extends BaseSection {
 		const resetDataButton = document.querySelector('#resetdata-option .reset-data-button');
 		resetDataButton.addEventListener('click', () => {
 			this.clearAppDataDialog();
+		});
+	}
+
+	minimizeOnStart() {
+		this.generateSettingOption({
+			$element: document.querySelector('#start-minimize-option .setting-control'),
+			value: ConfigUtil.getConfigItem('startMinimized', false),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('startMinimized');
+				ConfigUtil.setConfigItem('startMinimized', newValue);
+				this.minimizeOnStart();
+			}
 		});
 	}
 


### PR DESCRIPTION
Fixes #314.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
- This PR adds a setting option to start the app in background.

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
