### PR TITLE
domain-util: fix checkDomain, so it checks all error codes.

### DIFF
--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -121,11 +121,16 @@ class DomainUtil {
 						'Error: unable to verify the first certificate',
 						'Error: unable to get local issuer certificate'
 					];
+
 				// If the domain contains following strings we just bypass the server
 				const whitelistDomains = [
 					'zulipdev.org'
 				];
-				if (!error && response.statusCode !== 404) {
+
+				// make sure that error is a error or string not undefined
+				// so validation does not throw error.
+				error = error || '';
+				if (!error && response.statusCode < 400) {
 					// Correct
 					this.getServerSettings(domain).then(serverSettings => {
 						resolve(serverSettings);
@@ -165,7 +170,7 @@ class DomainUtil {
 					}
 				} else {
 					const invalidZulipServerError = `${domain} does not appear to be a valid Zulip server. Make sure that \
-					\n(1) you can connect to that URL in a web browser and \n (2) if you need a proxy to connect to the Internet, that you've configured your proxy in the Network settings`;
+					\n(1) you can connect to that URL in a web browser and \n (2) if you need a proxy to connect to the Internet, that you've configured your proxy in the Network settings \n (3) its a zulip server`;
 					reject(invalidZulipServerError);
 				}
 			});


### PR DESCRIPTION
This fixes a issue where if server send non 404 error code such
as 403 forbidden we marked them as zulip server eventhough they are
not now it checks for 400 error range.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes: #369 

**Screenshots?**
![screen shot 2017-12-30 at 1 19 19 pm](https://user-images.githubusercontent.com/23620441/34456463-e076fca2-ed64-11e7-8589-a3def2f041ad.png)

**You have tested this PR on:**
  - [X] macOS
