### PR TITLE
Make `checkDomain` fail when a non-Zulip URL is entered.

### DIFF
--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -125,7 +125,20 @@ class DomainUtil {
 				const whitelistDomains = [
 					'zulipdev.org'
 				];
-				if (!error && response.statusCode !== 404) {
+
+				// If error is falsy, convert it to an empty string to prevent an error
+				// during `error.toString()`.
+				error = error || '';
+
+				// `error` is only populated if there is an error with the `request`
+				// function itself, not an error in the response. Therefore, check both
+				// that there is no `request` error and no error status code. A
+				// status code error is most likely more common than the `request`
+				// error itself.
+				//
+				// For example, a 400 response would have a null `error` but a status
+				// code equal to 400, causing it to fail.
+				if (!error && response.statusCode < 400) {
 					// Correct
 					this.getServerSettings(domain).then(serverSettings => {
 						resolve(serverSettings);


### PR DESCRIPTION
Before, any URL without a status code response of 404 and without an
`error` in the `request` callback would fail. However, `error` doesn't
actually populate for error responses; it is populated when there is an
error with the request. Therefore, many websites that responded with
non-404 (but still error) status codes would be accepted. Instead, check
for all error status codes as well as the `request` error.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Properly checks that URLs are valid Zulip servers.

**Any background context you want to provide?**

This was done for the *Issue #369 Don't allow non-zulip servers to be entered.* Google Code-in task.

**Screenshots?**

<img width="1091" alt="screen shot 2018-01-06 at 10 52 13 am" src="https://user-images.githubusercontent.com/17259768/34642888-b5627e54-f2cf-11e7-8705-833fbc2a2341.png">

<img width="1098" alt="screen shot 2018-01-06 at 10 51 52 am" src="https://user-images.githubusercontent.com/17259768/34642892-bb52302a-f2cf-11e7-854e-62dbdfbbedba.png">

<img width="1092" alt="screen shot 2018-01-06 at 10 52 05 am" src="https://user-images.githubusercontent.com/17259768/34642891-b942cc04-f2cf-11e7-9e1e-8886d5f097a0.png">

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
