### PR TITLE
silent: Reflect changes in webview for silent option.

### DIFF
--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -11,7 +11,7 @@ const { shell, app } = require('electron').remote;
 
 const BaseComponent = require(__dirname + '/../components/base.js');
 
-const silentWebview = ConfigUtil.getConfigItem('silent');
+const shouldSilentWebview = ConfigUtil.getConfigItem('silent');
 class WebView extends BaseComponent {
 	constructor(props) {
 		super();
@@ -56,7 +56,7 @@ class WebView extends BaseComponent {
 			}
 		});
 
-		if (silentWebview) {
+		if (shouldSilentWebview) {
 			this.$el.addEventListener('dom-ready', () => {
 				this.$el.setAudioMuted(true);
 			});

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -4,12 +4,14 @@ const path = require('path');
 const fs = require('fs');
 
 const DomainUtil = require(__dirname + '/../utils/domain-util.js');
+const ConfigUtil = require(__dirname + '/../utils/config-util.js');
 const SystemUtil = require(__dirname + '/../utils/system-util.js');
 const LinkUtil = require(__dirname + '/../utils/link-util.js');
 const { shell, app } = require('electron').remote;
 
 const BaseComponent = require(__dirname + '/../components/base.js');
 
+const silentWebview = ConfigUtil.getConfigItem('silent');
 class WebView extends BaseComponent {
 	constructor(props) {
 		super();
@@ -53,6 +55,12 @@ class WebView extends BaseComponent {
 				shell.openExternal(url);
 			}
 		});
+
+		if (silentWebview) {
+			this.$el.addEventListener('dom-ready', () => {
+				this.$el.setAudioMuted(true);
+			});
+		}
 
 		this.$el.addEventListener('page-title-updated', event => {
 			const { title } = event;

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -277,6 +277,20 @@ class ServerManagerView {
 			const webContents = webview.getWebContents();
 			webContents.send('toggle-sidebar', state);
 		});
+
+		ipcRenderer.on('toogle-silent', (event, state) => {
+			const webviews = document.querySelectorAll('webview');
+			webviews.forEach(webview => {
+				try {
+					webview.setAudioMuted(state);
+				} catch (err) {
+					// webview is not ready yet
+					webview.addEventListener('dom-ready', () => {
+						webview.isAudioMuted();
+					});
+				}
+			});
+		});
 	}
 
 	destroyTab(name, index) {

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -1,11 +1,10 @@
 'use strict';
 const path = require('path');
-
-const { ipcRenderer } = require('electron');
-const { app, dialog } = require('electron').remote;
-
+const { ipcRenderer, remote } = require('electron');
 const fs = require('fs-extra');
 
+const { app, dialog } = remote;
+const currentBrowserWindow = remote.getCurrentWindow();
 const BaseSection = require(__dirname + '/base-section.js');
 const ConfigUtil = require(__dirname + '/../../utils/config-util.js');
 
@@ -160,6 +159,7 @@ class GeneralSection extends BaseSection {
 				const newValue = !ConfigUtil.getConfigItem('silent', true);
 				ConfigUtil.setConfigItem('silent', newValue);
 				this.updateSilentOption();
+				currentBrowserWindow.send('toogle-silent', newValue);
 			}
 		});
 	}


### PR DESCRIPTION
This silents the webview incase silent option is toggled, and
by default silent the webview when its create if needed.

Fixes: https://github.com/zulip/zulip-electron/issues/378

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [X] macOS
