### PR TITLE
notifications: Adds bots mention support to reply option.

### DIFF
--- a/app/renderer/js/notification/index.js
+++ b/app/renderer/js/notification/index.js
@@ -5,7 +5,7 @@ const {
 } = require('electron');
 
 const DefaultNotification = require('./default-notification');
-const { appId } = require('./helpers');
+const { appId, loadBots } = require('./helpers');
 
 // From https://github.com/felixrieseberg/electron-windows-notifications#appusermodelid
 // On windows 8 we have to explicitly set the appUserModelId otherwise notification won't work.
@@ -16,3 +16,7 @@ if (process.platform === 'darwin') {
 	const DarwinNotification = require('./darwin-notifications');
 	window.Notification = DarwinNotification;
 }
+
+window.addEventListener('load', () => {
+	loadBots();
+});


### PR DESCRIPTION
Fixes: zulip/zulip-desktop#391 

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Adds bots mention support to reply option in notifications.
**Any background context you want to provide?**
Make a  ```getJSON``` request to ```/json/users/``` to get list of members and  filter out bots using ```is_bots``` property.  