### PR TITLE
proxy: Change proxy input placeholder

### DIFF
--- a/app/renderer/js/pages/preference/network-section.js
+++ b/app/renderer/js/pages/preference/network-section.js
@@ -27,7 +27,7 @@ class NetworkSection extends BaseSection {
 						</div>
 						<div class="setting-row" id="proxy-rules-option">
 							<span class="setting-input-key">Proxy rules</span>
-							<input class="setting-input-value" placeholder="e.g. http=foopy:80;ftp=foopy2"/>
+							<input class="setting-input-value" placeholder="e.g. http_proxy:80;ftp_proxy:2121"/>
 						</div>
 						<div class="setting-row" id="proxy-bypass-option">
 							<span class="setting-input-key">Proxy bypass rules</span>


### PR DESCRIPTION
This follows from the discussion [here](https://chat.zulip.org/#narrow/stream/electron/topic/Proxy).
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Change proxy input placeholder to http_proxy:80;ftp_proxy:2121 to better suggest usage of multiple proxies