### PR TITLE
preference page: Loading indication for new server button.

### DIFF
--- a/app/renderer/js/pages/preference/new-server-form.js
+++ b/app/renderer/js/pages/preference/new-server-form.js
@@ -43,11 +43,13 @@ class NewServerForm extends BaseComponent {
 	}
 
 	submitFormHandler() {
+		this.$saveServerButton.children[1].innerHTML = 'Adding...';
 		DomainUtil.checkDomain(this.$newServerUrl.value).then(serverConf => {
 			DomainUtil.addDomain(serverConf).then(() => {
 				this.props.onChange(this.props.index);
 			});
 		}, errorMessage => {
+			this.$saveServerButton.children[1].innerHTML = 'Add';
 			alert(errorMessage);
 		});
 	}

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -99,8 +99,7 @@ class DomainUtil {
 	checkDomain(domain, silent = false) {
 		if (!silent && this.duplicateDomain(domain)) {
 			// Do not check duplicate in silent mode
-			alert('This server has been added.');
-			return;
+			return Promise.reject('This server has been added.');
 		}
 
 		domain = this.formatUrl(domain);


### PR DESCRIPTION

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Changes the text of "Add" button to "Adding..." when user clicks on Add button for adding new server by chanding the ```innerHTML``` of the ```span``` dom element responsible for the text "Add". 
Fixes: #396 

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
