### PR TITLE
menu: Rename Settings to Desktop App Settings

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -182,7 +182,7 @@ class AppMenu {
 			}, {
 				type: 'separator'
 			}, {
-				label: 'Settings',
+				label: 'Desktop App Settings',
 				accelerator: 'Cmd+,',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
@@ -282,7 +282,7 @@ class AppMenu {
 			}, {
 				type: 'separator'
 			}, {
-				label: 'Settings',
+				label: 'Desktop App Settings',
 				accelerator: 'Ctrl+,',
 				click(item, focusedWindow) {
 					if (focusedWindow) {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Rename Settings to **Desktop App Settings** in the menu.
**Any background context you want to provide?**
As per discussion [here](https://chat.zulip.org/#narrow/stream/electron/subject/System.20Tray.20Icon.20notification/near/479082).
**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [x] macOS
