### PR TITLE
design: Add back button.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -368,7 +368,7 @@ class AppMenu {
 
 	static sendAction(action, ...params) {
 		const win = BrowserWindow.getAllWindows()[0];
-
+	
 		if (process.platform === 'darwin') {
 			win.restore();
 		}

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -246,6 +246,7 @@ webview:focus {
 
 /* Tooltip styling */
 
+#back-tooltip,
 #reload-tooltip,
 #setting-tooltip {
     font-family: sans-serif;
@@ -262,6 +263,7 @@ webview:focus {
     font-size: 14px;
 }
 
+#back-tooltip:after,
 #reload-tooltip:after,
 #setting-tooltip:after {
     content: " ";

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -20,11 +20,13 @@ class ServerManagerView {
 		this.$reloadButton = $actionsContainer.querySelector('#reload-action');
 		this.$settingsButton = $actionsContainer.querySelector('#settings-action');
 		this.$webviewsContainer = document.getElementById('webviews-container');
+		this.$backButton = $actionsContainer.querySelector('#back-action');
 
 		this.$addServerTooltip = document.getElementById('add-server-tooltip');
 		this.$reloadTooltip = $actionsContainer.querySelector('#reload-tooltip');
 		this.$settingsTooltip = $actionsContainer.querySelector('#setting-tooltip');
 		this.$serverIconTooltip = document.getElementsByClassName('server-tooltip');
+		this.$backTooltip = $actionsContainer.querySelector('#back-tooltip');
 
 		this.$sidebar = document.getElementById('sidebar');
 
@@ -158,6 +160,9 @@ class ServerManagerView {
 		this.$settingsButton.addEventListener('click', () => {
 			this.openSettings('General');
 		});
+		this.$backButton.addEventListener('click', () => {
+			this.tabs[this.activeTabIndex].webview.back();
+		});
 
 		const $serverImgs = document.querySelectorAll('.server-icons');
 		$serverImgs.forEach($serverImg => {
@@ -169,6 +174,7 @@ class ServerManagerView {
 		this.sidebarHoverEvent(this.$addServerButton, this.$addServerTooltip);
 		this.sidebarHoverEvent(this.$settingsButton, this.$settingsTooltip);
 		this.sidebarHoverEvent(this.$reloadButton, this.$reloadTooltip);
+		this.sidebarHoverEvent(this.$backButton, this.$backTooltip);
 	}
 
 	getTabIndex() {

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -28,6 +28,10 @@
         <i class="material-icons md-48">refresh</i>
         <span id="reload-tooltip" style="display:none">Reload</span>
       </div>
+      <div class="action-button" id="back-action">
+        <i class="material-icons md-48">arrow_back</i>
+        <span id="back-tooltip" style="display:none">Go Back</span>
+      </div>
       <div class="action-button" id="settings-action">
         <i class="material-icons md-48">settings</i>
         <span id="setting-tooltip" style="display:none">Settings</span>


### PR DESCRIPTION
Fixes: #208

Discussions related to design is [here](https://chat.zulip.org/#narrow/stream/design/topic/Use.20of.20back.20button). 

The back button moves back the active tab's webview. 

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
