### PR TITLE
activetab: Fix broken last active tab.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -221,11 +221,6 @@ app.on('ready', () => {
 		appMenu.setMenu(props);
 	});
 
-	ipcMain.on('register-server-tab-shortcut', (event, index) => {
-		// Array index == Shown index - 1
-		page.send('switch-server-tab', index - 1);
-	});
-
 	ipcMain.on('toggleAutoLauncher', (event, AutoLaunchValue) => {
 		setAutoLaunch(AutoLaunchValue);
 	});

--- a/app/renderer/js/components/server-tab.js
+++ b/app/renderer/js/components/server-tab.js
@@ -50,7 +50,8 @@ class ServerTab extends Tab {
 			shortcutText = `Ctrl+${shownIndex}`;
 		}
 
-		ipcRenderer.send('register-server-tab-shortcut', shownIndex);
+		// Array index == Shown index - 1
+		ipcRenderer.send('switch-server-tab', shownIndex - 1);
 
 		return shortcutText;
 	}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -419,7 +419,7 @@ class ServerManagerView {
 		});
 
 		ipcRenderer.on('switch-server-tab', (event, index) => {
-			this.activateTab(index);
+			this.activateLastTab(index);
 		});
 
 		ipcRenderer.on('reload-proxy', (event, showAlert) => {


### PR DESCRIPTION
This fixes an issue where the server tabs were not loading
according to the last active tab. This used to load last server
no matter what the last used server is.

Fixes - #416.

