### PR TITLE
design: Not create a new instance of setting tab

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -157,6 +157,11 @@ class AppMenu {
 				type: 'separator'
 			});
 			for (let i = 0; i < tabs.length; i++) {
+				// Do not add functional tab settings to list of windows in menu bar
+				if (tabs[i].props.role === 'function' && tabs[i].webview.props.name === 'Settings') {
+					continue;
+				}
+
 				initialSubmenu.push({
 					label: tabs[i].webview.props.name,
 					accelerator: tabs[i].props.role === 'function' ? '' : `${ShortcutKey} + ${tabs[i].props.index + 1}`,
@@ -166,7 +171,7 @@ class AppMenu {
 							AppMenu.sendAction('switch-server-tab', tabs[i].props.index);
 						}
 					},
-					type: 'radio'
+					type: 'checkbox'
 				});
 			}
 		}

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -113,6 +113,14 @@ body {
     color: #6c8592;
 }
 
+.action-button.active {
+    background-color: rgba(255, 255, 255, 0.25);
+}
+
+.action-button.active i {
+    color: #eee;
+}
+
 .tab:first-child {
     margin-top: 8px;
 }

--- a/app/renderer/js/components/functional-tab.js
+++ b/app/renderer/js/components/functional-tab.js
@@ -16,10 +16,11 @@ class FunctionalTab extends Tab {
 
 	init() {
 		this.$el = this.generateNodeFromTemplate(this.template());
-		this.props.$root.appendChild(this.$el);
-
-		this.$closeButton = this.$el.getElementsByClassName('server-tab-badge')[0];
-		this.registerListeners();
+		if (this.props.name !== 'Settings') {
+			this.props.$root.appendChild(this.$el);
+			this.$closeButton = this.$el.getElementsByClassName('server-tab-badge')[0];
+			this.registerListeners();
+		}
 	}
 
 	registerListeners() {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -119,6 +119,8 @@ class ServerManagerView {
 			}
 			// Open last active tab
 			this.activateTab(ConfigUtil.getConfigItem('lastActiveTab'));
+			// Remove focus from the settings icon at sidebar bottom
+			this.$settingsButton.classList.remove('active');
 		} else {
 			this.openSettings('Servers');
 		}
@@ -215,6 +217,7 @@ class ServerManagerView {
 		this.tabs.push(new FunctionalTab({
 			role: 'function',
 			materialIcon: tabProps.materialIcon,
+			name: tabProps.name,
 			$root: this.$tabsContainer,
 			index: this.functionalTabs[tabProps.name],
 			tabIndex,
@@ -235,7 +238,6 @@ class ServerManagerView {
 				preload: false
 			})
 		}));
-
 		this.activateTab(this.functionalTabs[tabProps.name]);
 	}
 
@@ -245,6 +247,7 @@ class ServerManagerView {
 			materialIcon: 'settings',
 			url: `file://${__dirname}/preference.html#${nav}`
 		});
+		this.$settingsButton.classList.add('active');
 		this.tabs[this.functionalTabs.Settings].webview.send('switch-settings-nav', nav);
 	}
 
@@ -280,6 +283,10 @@ class ServerManagerView {
 			if (this.activeTabIndex === index) {
 				return;
 			} else if (hideOldTab) {
+				// If old tab is functional tab Settings, remove focus from the settings icon at sidebar bottom
+				if (this.tabs[this.activeTabIndex].props.role === 'function' && this.tabs[this.activeTabIndex].props.name === 'Settings') {
+					this.$settingsButton.classList.remove('active');
+				}
 				this.tabs[this.activeTabIndex].deactivate();
 			}
 		}


### PR DESCRIPTION
Fixes: #418
The functionality works as expected, need review on approach.
Approach - For Settings functional tab, it is not appended to the sidebar and to the `windows menu`. The settings icon at bottom is given an active tab which is removed when some other tab is activated.
 
**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
