### PR TITLE
fix: New organisation link overlapping existing servers.

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -337,13 +337,11 @@ i.open-tab-button {
 }
 
 #server-info-container {
-    min-height: calc(100% - 235px);
+    min-height: calc(100% - 260px);
 }
 
 #create-organization-container {
     font-size: 1.15em;
-    position: fixed;
-    bottom: 15px;
 }
 
 #create-organization-container i {


### PR DESCRIPTION
fixes: #427

---
<!--
Remove the fields that are not appropriate
Please include:
-->
Removed the `position: fixed` css property from the add organisation div.

**Screenshots?**
![screenshot from 2018-02-26 14-45-46](https://user-images.githubusercontent.com/20434085/36669191-0c5590ee-1b1a-11e8-8218-2da6d74b645d.png)
![screenshot from 2018-02-26 14-33-41](https://user-images.githubusercontent.com/20434085/36669194-0f4e5c68-1b1a-11e8-8a21-890be540a2cc.png)

