### PR TITLE
settings: Fix app settings overriding issue.

### DIFF
--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -268,10 +268,10 @@ class ServerManagerView {
 	}
 
 	activateLastTab(index) {
-		// Open last active tab
-		ConfigUtil.setConfigItem('lastActiveTab', index);
-		// Open all the tabs in background
+		// Open all the tabs in background, also activate the tab based on the index
 		this.activateTab(index);
+		// Save last active tab
+		ConfigUtil.setConfigItem('lastActiveTab', index);
 	}
 
 	activateTab(index, hideOldTab = true) {


### PR DESCRIPTION
This fixes an issue which was caused by saving the last active tab
before a functional tab activates. This was a regression in https://github.com/zulip/zulip-electron/commit/f409bb0449a9fdbba81e418a256d0a1da14f5cd4.
It was unnoticed from v1.5.0 to the latest v1.8.2.

The bug causes a serious issue where the app can't change the app settings and all settings were
getting overridden when a user switches back to setting page.

Fixes #448.