### PR TITLE
Misc: Fix reinstall script for working across all platforms

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zulip",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "electron app --disable-http-cache --no-electron-connect",
-    "reinstall": "./tools/reinstall-node-modules",
+    "reinstall": "node ./tools/reinstall-node-modules.js",
     "postinstall": "electron-builder install-app-deps",
     "test": "xo",
     "test-e2e": "gulp test-e2e",

--- a/tools/reinstall-node-modules.js
+++ b/tools/reinstall-node-modules.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const {exec} = require('child_process');
+const path = require('path');
+
+const isWindows = process.platform === 'win32';
+const command = path.join(__dirname, `reinstall-node-modules${isWindows ? '.cmd' : ''}`);
+
+const proc = exec(command, error => {
+	if (error) {
+		console.error(error);
+	}
+});
+
+proc.stdout.on('data', data => console.log(data.toString()));
+proc.stderr.on('data', data => console.error(data.toString()));
+proc.on('exit', code => {
+	process.exit(code);
+});


### PR DESCRIPTION
This commit will add new /scripts/reinstall-node-modules.js
file which is using node's child_process and process.platform
to determine and add '.cmd' extension in case of win32 platform.
This way, running npm run reinstall will correctly determine
the OS and add the postfix if needed and then only run the script.

Fixes #440

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
