### PR TITLE
"Organizations" settings page fixes and tweaks

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -198,7 +198,11 @@ img.server-info-icon {
 
 .server-info-right {
     margin-top: 4px;
-    min-width: 55%;
+    width: 55%;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-grow: 1;
 }
 
 .server-info-row {
@@ -214,7 +218,9 @@ img.server-info-icon {
 }
 
 .server-url {
-    min-width: 60%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .server-info-alias {
@@ -304,7 +310,6 @@ img.server-info-icon {
 }
 
 .settings-card:hover {
-    border-left: 8px solid #bcbcbc;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 0px 0px rgba(0, 0, 0, 0.12);
 }
 

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -23,7 +23,7 @@ class ServerInfoForm extends BaseComponent {
 				</div>
 				<div class="server-info-right">
 					<div class="server-info-row server-url">
-						<span class="server-url-info">${this.props.server.url}</span>
+						<span class="server-url-info" title="${this.props.server.url}">${this.props.server.url}</span>
 					</div>
 					<div class="server-info-row">
 						<div class="action red server-delete-action">


### PR DESCRIPTION
* Remove right transition on hover on settings cards.
* Move disconnect button to extreme right using flex.
* Text-overflow for server urls using ellipsis.

Partly fixes #456 . 