### PR TITLE
internal-links: open image link in webapp lightbox.

### DIFF
--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -4,6 +4,7 @@ const { ipcRenderer } = require('electron');
 const SetupSpellChecker = require('./spellchecker');
 
 const ConfigUtil = require(__dirname + '/utils/config-util.js');
+const LinkUtil = require(__dirname + '/utils/link-util.js');
 
 // eslint-disable-next-line import/no-unassigned-import
 require('./notification');
@@ -55,6 +56,24 @@ document.addEventListener('DOMContentLoaded', () => {
 			ipcRenderer.send('forward-message', 'reload-viewer');
 		});
 	}
+
+	// Open image attachment link in the lightbox instead of opening in the default browser
+	const { $, lightbox } = window;
+
+	$('#main_div').on('click', '.message_content p a', function (e) {
+		const url = $(this).attr('href');
+
+		if (LinkUtil.isImage(url)) {
+			const $img = $(this).parent().siblings('.message_inline_image').find('img');
+
+			// prevent the image link from opening in a new page.
+			e.preventDefault();
+			// prevent the message compose dialog from happening.
+			e.stopPropagation();
+
+			lightbox.open($img);
+		}
+	});
 });
 
 // Clean up spellchecker events after you navigate away from this page;

--- a/app/renderer/js/utils/link-util.js
+++ b/app/renderer/js/utils/link-util.js
@@ -21,6 +21,12 @@ class LinkUtil {
 
 		return (currentDomain === newDomain) && newUrl.includes('/#narrow');
 	}
+
+	isImage(url) {
+		// test for images extension as well as urls like .png?s=100
+		const isImageUrl = /\.(bmp|gif|jpg|jpeg|png|webp)\?*.*$/i;
+		return isImageUrl.test(url);
+	}
 }
 
 module.exports = new LinkUtil();


### PR DESCRIPTION
This will open the image in the webapp lightbox, shows the same behavior
that happens when clicking on the image preview.
Implemented almost the same way webapp handles opening lightbox on clicking image preview.

Fixes: #469.

Facing two lint errors:
1.`lightbox  is not defined.`
2. `$ is not defined.`
**You have tested this PR on:**
  - [x] Linux/Ubuntu
  