### PR TITLE
sidebar: Add scrollbar for list of organizations on overflow.

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -45,6 +45,28 @@ body {
     transition: all 0.6s ease-out;
 }
 
+#view-controls-container {
+	height: calc(100% - 156px);
+	overflow-y: hidden;
+}
+
+#view-controls-container:hover {
+	overflow-y: overlay;
+}
+
+#view-controls-container::-webkit-scrollbar {
+	width: 4px;
+}
+
+#view-controls-container::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+}
+
+#view-controls-container::-webkit-scrollbar-thumb {
+  background-color: darkgrey;
+  outline: 1px solid slategrey;
+}
+
 @font-face {
     font-family: 'Material Icons';
     font-style: normal;

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -59,7 +59,7 @@ body {
 }
 
 #view-controls-container::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+    box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
 }
 
 #view-controls-container::-webkit-scrollbar-thumb {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -175,7 +175,7 @@ class ServerManagerView {
 			});
 		});
 
-		this.sidebarHoverEvent(this.$addServerButton, this.$addServerTooltip);
+		this.sidebarHoverEvent(this.$addServerButton, this.$addServerTooltip, true);
 		this.sidebarHoverEvent(this.$settingsButton, this.$settingsTooltip);
 		this.sidebarHoverEvent(this.$reloadButton, this.$reloadTooltip);
 		this.sidebarHoverEvent(this.$backButton, this.$backTooltip);
@@ -187,9 +187,17 @@ class ServerManagerView {
 		return currentIndex;
 	}
 
-	sidebarHoverEvent(SidebarButton, SidebarTooltip) {
+	sidebarHoverEvent(SidebarButton, SidebarTooltip, addServer = false) {
 		SidebarButton.addEventListener('mouseover', () => {
 			SidebarTooltip.removeAttribute('style');
+			// To handle position of add server tooltip due to scrolling of list of organizations
+			// This could not be handled using CSS, hence the top of the tooltip is made same
+			// as that of its parent element.
+			// This needs to handled only for the add server tooltip and not others.
+			if (addServer) {
+				const { top } = SidebarButton.getBoundingClientRect();
+				SidebarTooltip.style.top = top + 'px';
+			}
 		});
 		SidebarButton.addEventListener('mouseout', () => {
 			SidebarTooltip.style.display = 'none';
@@ -199,6 +207,11 @@ class ServerManagerView {
 	onHover(index, serverName) {
 		this.$serverIconTooltip[index].innerHTML = serverName;
 		this.$serverIconTooltip[index].removeAttribute('style');
+		// To handle position of servers' tooltip due to scrolling of list of organizations
+		// This could not be handled using CSS, hence the top of the tooltip is made same
+		// as that of its parent element.
+		const { top } = this.$serverIconTooltip[index].parentElement.getBoundingClientRect();
+		this.$serverIconTooltip[index].style.top = top + 'px';
 	}
 
 	onHoverOut(index) {


### PR DESCRIPTION
Adds scrollbar for list of organizations on overflow in the sidebar. Scrollbar visible on hover.
Issue discussed [here](https://chat.zulip.org/#narrow/stream/16-electron/topic/No.20scrollbar.20for.20Organisations.20within.20Zulip.20Desktop.20App).

**Screenshots?**
![peek 2018-04-09 13-26](https://user-images.githubusercontent.com/20434085/38486335-54bb1254-3bfa-11e8-9f48-c8a4c0f2dbf6.gif)
