### PR TITLE
proxy-setting: Feature to use system proxy settings.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -13,6 +13,7 @@ const { app, ipcMain } = electron;
 
 const BadgeSettings = require('./../renderer/js/pages/preference/badge-settings.js');
 const ConfigUtil = require('./../renderer/js/utils/config-util.js');
+const ProxyUtil = require('./../renderer/js/utils/proxy-util.js');
 
 // Adds debug features like hotkeys for triggering dev tools and reload
 // in development mode
@@ -153,55 +154,9 @@ app.on('ready', () => {
 	});
 	mainWindow = createMainWindow();
 
+	ProxyUtil.resolveSystemProxy(mainWindow);
+
 	const page = mainWindow.webContents;
-
-	const ses = page.session;
-
-	const resolveProxyUrl = 'chat.zulip.org';
-	let proxyString = '';
-
-	// Check HTTP Proxy
-	ses.resolveProxy('http://' + resolveProxyUrl, proxy => {
-		if (proxy !== 'DIRECT') {
-			// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
-			// for all other HTTP or direct url:port both uses PROXY
-			if (proxy.includes('PROXY') || proxy.includes('HTTPS')) {
-				proxyString += 'http=' + proxy.split('PROXY')[1] + ';';
-			}
-		}
-	});
-	// Check HTTPS Proxy
-	ses.resolveProxy('https://' + resolveProxyUrl, proxy => {
-		if (proxy !== 'DIRECT' || proxy.includes('HTTPS')) {
-			// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
-			// for all other HTTP or direct url:port both uses PROXY
-			if (proxy.includes('PROXY' || proxy.includes('HTTPS'))) {
-				proxyString += 'https=' + proxy.split('PROXY')[1] + ';';
-			}
-		}
-	});
-
-	// Check FTP Proxy
-	ses.resolveProxy('ftp://' + resolveProxyUrl, proxy => {
-		if (proxy !== 'DIRECT') {
-			if (proxy.includes('PROXY')) {
-				proxyString += 'ftp=' + proxy.split('PROXY')[1] + ';';
-			}
-		}
-	});
-
-	// Check SOCKS Proxy
-	ses.resolveProxy('socks4://' + resolveProxyUrl, proxy => {
-		if (proxy !== 'DIRECT') {
-			if (proxy.includes('SOCKS5')) {
-				proxyString += 'socks=' + proxy.split('SOCKS5')[1] + ';';
-			} else if (proxy.includes('SOCKS4')) {
-				proxyString += 'socks=' + proxy.split('SOCKS4')[1] + ';';
-			}
-		}
-		// proxyString is written here so that empty string is not written as resolveProxy is async
-		ConfigUtil.setConfigItem('systemProxyRules', proxyString);
-	});
 
 	page.on('dom-ready', () => {
 		if (ConfigUtil.getConfigItem('startMinimized')) {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -155,6 +155,54 @@ app.on('ready', () => {
 
 	const page = mainWindow.webContents;
 
+	const ses = page.session;
+
+	const resolveProxyUrl = 'chat.zulip.org';
+	let proxyString = '';
+
+	// Check HTTP Proxy
+	ses.resolveProxy('http://' + resolveProxyUrl, proxy => {
+		if (proxy !== 'DIRECT') {
+			// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+			// for all other HTTP or direct url:port both uses PROXY
+			if (proxy.includes('PROXY') || proxy.includes('HTTPS')) {
+				proxyString += 'http=' + proxy.split('PROXY')[1] + ';';
+			}
+		}
+	});
+	// Check HTTPS Proxy
+	ses.resolveProxy('https://' + resolveProxyUrl, proxy => {
+		if (proxy !== 'DIRECT' || proxy.includes('HTTPS')) {
+			// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+			// for all other HTTP or direct url:port both uses PROXY
+			if (proxy.includes('PROXY' || proxy.includes('HTTPS'))) {
+				proxyString += 'https=' + proxy.split('PROXY')[1] + ';';
+			}
+		}
+	});
+
+	// Check FTP Proxy
+	ses.resolveProxy('ftp://' + resolveProxyUrl, proxy => {
+		if (proxy !== 'DIRECT') {
+			if (proxy.includes('PROXY')) {
+				proxyString += 'ftp=' + proxy.split('PROXY')[1] + ';';
+			}
+		}
+	});
+
+	// Check SOCKS Proxy
+	ses.resolveProxy('socks4://' + resolveProxyUrl, proxy => {
+		if (proxy !== 'DIRECT') {
+			if (proxy.includes('SOCKS5')) {
+				proxyString += 'socks=' + proxy.split('SOCKS5')[1] + ';';
+			} else if (proxy.includes('SOCKS4')) {
+				proxyString += 'socks=' + proxy.split('SOCKS4')[1] + ';';
+			}
+		}
+		// proxyString is written here so that empty string is not written as resolveProxy is async
+		ConfigUtil.setConfigItem('systemProxyRules', proxyString);
+	});
+
 	page.on('dom-ready', () => {
 		if (ConfigUtil.getConfigItem('startMinimized')) {
 			mainWindow.minimize();

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -154,7 +154,11 @@ app.on('ready', () => {
 	});
 	mainWindow = createMainWindow();
 
-	ProxyUtil.resolveSystemProxy(mainWindow);
+	const isSystemProxy = ConfigUtil.getConfigItem('useSystemProxy');
+
+	if (isSystemProxy) {
+		ProxyUtil.resolveSystemProxy(mainWindow);
+	}
 
 	const page = mainWindow.webContents;
 

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -258,8 +258,8 @@ img.server-info-icon {
     border: #4EBFAC 2px solid;
 }
 
-.setting-block {
-    width: 100%;
+.manual-proxy-block {
+    width: 96%;
 }
 
 .actions-container {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -58,7 +58,7 @@ class ServerManagerView {
 
 	loadProxy() {
 		return new Promise(resolve => {
-			const proxyEnabled = ConfigUtil.getConfigItem('useProxy', false);
+			const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy', false) || ConfigUtil.getConfigItem('useSystemProxy', false);
 			if (proxyEnabled) {
 				session.fromPartition('persist:webviewsession').setProxy({
 					pacScript: ConfigUtil.getConfigItem('proxyPAC', ''),
@@ -82,7 +82,8 @@ class ServerManagerView {
 		// Default settings which should be respected
 		const settingOptions = {
 			trayIcon: true,
-			useProxy: false,
+			useManualProxy: false,
+			useSystemProxy: false,
 			showSidebar: true,
 			badgeOption: true,
 			startAtLogin: false,

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -58,6 +58,16 @@ class ServerManagerView {
 
 	loadProxy() {
 		return new Promise(resolve => {
+			// To change proxyEnable to useManualProxy in older versions
+			const proxyEnabledOld = ConfigUtil.isConfigItemExists('useProxy');
+			if (proxyEnabledOld) {
+				const proxyEnableOldState = ConfigUtil.getConfigItem('useProxy');
+				if (proxyEnableOldState) {
+					ConfigUtil.setConfigItem('useManualProxy', true);
+				}
+				ConfigUtil.removeConfigItem('useProxy');
+			}
+
 			const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy', false) || ConfigUtil.getConfigItem('useSystemProxy', false);
 			if (proxyEnabled) {
 				session.fromPartition('persist:webviewsession').setProxy({

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -506,6 +506,7 @@ class ServerManagerView {
 			this.loadProxy().then(() => {
 				if (showAlert) {
 					alert('Proxy settings saved!');
+					ipcRenderer.send('reload-full-app');
 				}
 			});
 		});

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -68,7 +68,7 @@ class ServerManagerView {
 				ConfigUtil.removeConfigItem('useProxy');
 			}
 
-			const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy', false) || ConfigUtil.getConfigItem('useSystemProxy', false);
+			const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy') || ConfigUtil.getConfigItem('useSystemProxy');
 			if (proxyEnabled) {
 				session.fromPartition('persist:webviewsession').setProxy({
 					pacScript: ConfigUtil.getConfigItem('proxyPAC', ''),

--- a/app/renderer/js/pages/preference/network-section.js
+++ b/app/renderer/js/pages/preference/network-section.js
@@ -17,7 +17,7 @@ class NetworkSection extends BaseSection {
                 <div class="title">Proxy</div>
                 <div id="appearance-option-settings" class="settings-card">
 					<div class="setting-row" id="use-system-settings">
-						<div class="setting-description">Use system proxy settings</div>
+						<div class="setting-description">Use system proxy settings (requires restart)</div>
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="use-manual-settings">
@@ -105,7 +105,7 @@ class NetworkSection extends BaseSection {
 					// Reload proxy system proxy settings
 					const systemSettings = ConfigUtil.getConfigItem('systemProxyRules');
 					ConfigUtil.setConfigItem('proxyRules', systemSettings);
-					ipcRenderer.send('forward-message', 'reload-proxy', true);
+					ipcRenderer.send('forward-message', 'reload-proxy', false);
 				}
 				ConfigUtil.setConfigItem('useSystemProxy', newValue);
 				this.updateProxyOption();

--- a/app/renderer/js/pages/preference/network-section.js
+++ b/app/renderer/js/pages/preference/network-section.js
@@ -123,7 +123,8 @@ class NetworkSection extends BaseSection {
 				}
 				ConfigUtil.setConfigItem('proxyRules', '');
 				ConfigUtil.setConfigItem('useManualProxy', newValue);
-				ipcRenderer.send('forward-message', 'reload-proxy', false);
+				// Reload app only when turning manual proxy off, hence !newValue
+				ipcRenderer.send('forward-message', 'reload-proxy', !newValue);
 				this.updateProxyOption();
 			}
 		});

--- a/app/renderer/js/pages/preference/network-section.js
+++ b/app/renderer/js/pages/preference/network-section.js
@@ -16,11 +16,15 @@ class NetworkSection extends BaseSection {
             <div class="settings-pane">
                 <div class="title">Proxy</div>
                 <div id="appearance-option-settings" class="settings-card">
-					<div class="setting-row" id="use-proxy-option">
-						<div class="setting-description">Connect servers through a proxy</div>
+					<div class="setting-row" id="use-system-settings">
+						<div class="setting-description">Use system proxy settings</div>
 						<div class="setting-control"></div>
 					</div>
-					<div class="setting-block">
+					<div class="setting-row" id="use-manual-settings">
+						<div class="setting-description">Manual proxy configuration</div>
+						<div class="setting-control"></div>
+					</div>
+					<div class="manual-proxy-block">
 						<div class="setting-row" id="proxy-pac-option">
 							<span class="setting-input-key">PAC script</span>
 							<input class="setting-input-value" placeholder="e.g. foobar.com/pacfile.js"/>
@@ -51,7 +55,7 @@ class NetworkSection extends BaseSection {
 		this.$proxyRules = document.querySelector('#proxy-rules-option .setting-input-value');
 		this.$proxyBypass = document.querySelector('#proxy-bypass-option .setting-input-value');
 		this.$proxySaveAction = document.getElementById('proxy-save-action');
-		this.$settingBlock = this.props.$root.querySelector('.setting-block');
+		this.$manualProxyBlock = this.props.$root.querySelector('.manual-proxy-block');
 		this.initProxyOption();
 
 		this.$proxyPAC.value = ConfigUtil.getConfigItem('proxyPAC', '');
@@ -68,31 +72,58 @@ class NetworkSection extends BaseSection {
 	}
 
 	initProxyOption() {
-		const proxyEnabled = ConfigUtil.getConfigItem('useProxy', false);
-		this.toggleProxySettings(proxyEnabled);
+		const manualProxyEnabled = ConfigUtil.getConfigItem('useManualProxy', false);
+		this.toggleManualProxySettings(manualProxyEnabled);
+
 		this.updateProxyOption();
 	}
 
-	toggleProxySettings(option) {
+	toggleManualProxySettings(option) {
 		if (option) {
-			this.$settingBlock.classList.remove('hidden');
+			this.$manualProxyBlock.classList.remove('hidden');
 		} else {
-			this.$settingBlock.classList.add('hidden');
+			this.$manualProxyBlock.classList.add('hidden');
 		}
 	}
 
 	updateProxyOption() {
 		this.generateSettingOption({
-			$element: document.querySelector('#use-proxy-option .setting-control'),
-			value: ConfigUtil.getConfigItem('useProxy', false),
+			$element: document.querySelector('#use-system-settings .setting-control'),
+			value: ConfigUtil.getConfigItem('useSystemProxy', false),
 			clickHandler: () => {
-				const newValue = !ConfigUtil.getConfigItem('useProxy');
-				ConfigUtil.setConfigItem('useProxy', newValue);
-				this.toggleProxySettings(newValue);
-				if (newValue === false) {
-					// Reload proxy if the proxy is turned off
-					ipcRenderer.send('forward-message', 'reload-proxy', false);
+				const newValue = !ConfigUtil.getConfigItem('useSystemProxy');
+				const manualProxyValue = ConfigUtil.getConfigItem('useManualProxy');
+				if (manualProxyValue && newValue) {
+					ConfigUtil.setConfigItem('useManualProxy', !manualProxyValue);
+					this.toggleManualProxySettings(!manualProxyValue);
 				}
+				if (newValue === false) {
+					// Remove proxy system proxy settings
+					ConfigUtil.setConfigItem('proxyRules', '');
+					ipcRenderer.send('forward-message', 'reload-proxy', true);
+				} else {
+					// Reload proxy system proxy settings
+					const systemSettings = ConfigUtil.getConfigItem('systemProxyRules');
+					ConfigUtil.setConfigItem('proxyRules', systemSettings);
+					ipcRenderer.send('forward-message', 'reload-proxy', true);
+				}
+				ConfigUtil.setConfigItem('useSystemProxy', newValue);
+				this.updateProxyOption();
+			}
+		});
+		this.generateSettingOption({
+			$element: document.querySelector('#use-manual-settings .setting-control'),
+			value: ConfigUtil.getConfigItem('useManualProxy', false),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('useManualProxy');
+				const systemProxyValue = ConfigUtil.getConfigItem('useSystemProxy');
+				this.toggleManualProxySettings(newValue);
+				if (systemProxyValue && newValue) {
+					ConfigUtil.setConfigItem('useSystemProxy', !systemProxyValue);
+				}
+				ConfigUtil.setConfigItem('proxyRules', '');
+				ConfigUtil.setConfigItem('useManualProxy', newValue);
+				ipcRenderer.send('forward-message', 'reload-proxy', false);
 				this.updateProxyOption();
 			}
 		});

--- a/app/renderer/js/pages/preference/network-section.js
+++ b/app/renderer/js/pages/preference/network-section.js
@@ -101,11 +101,6 @@ class NetworkSection extends BaseSection {
 					// Remove proxy system proxy settings
 					ConfigUtil.setConfigItem('proxyRules', '');
 					ipcRenderer.send('forward-message', 'reload-proxy', true);
-				} else {
-					// Reload proxy system proxy settings
-					const systemSettings = ConfigUtil.getConfigItem('systemProxyRules');
-					ConfigUtil.setConfigItem('proxyRules', systemSettings);
-					ipcRenderer.send('forward-message', 'reload-proxy', false);
 				}
 				ConfigUtil.setConfigItem('useSystemProxy', newValue);
 				this.updateProxyOption();

--- a/app/renderer/js/utils/proxy-util.js
+++ b/app/renderer/js/utils/proxy-util.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const ConfigUtil = require('./config-util.js');
+
+let instance = null;
+
+class ProxyUtil {
+	constructor() {
+		if (instance) {
+			return instance;
+		} else {
+			instance = this;
+		}
+
+		return instance;
+	}
+
+	resolveSystemProxy(mainWindow) {
+		const page = mainWindow.webContents;
+		const ses = page.session;
+		const resolveProxyUrl = 'chat.zulip.org';
+
+		let proxyString = '';
+
+		// Check HTTP Proxy
+		ses.resolveProxy('http://' + resolveProxyUrl, proxy => {
+			if (proxy !== 'DIRECT') {
+				// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+				// for all other HTTP or direct url:port both uses PROXY
+				if (proxy.includes('PROXY') || proxy.includes('HTTPS')) {
+					proxyString += 'http=' + proxy.split('PROXY')[1] + ';';
+				}
+			}
+		});
+		// Check HTTPS Proxy
+		ses.resolveProxy('https://' + resolveProxyUrl, proxy => {
+			if (proxy !== 'DIRECT' || proxy.includes('HTTPS')) {
+				// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+				// for all other HTTP or direct url:port both uses PROXY
+				if (proxy.includes('PROXY' || proxy.includes('HTTPS'))) {
+					proxyString += 'https=' + proxy.split('PROXY')[1] + ';';
+				}
+			}
+		});
+
+		// Check FTP Proxy
+		ses.resolveProxy('ftp://' + resolveProxyUrl, proxy => {
+			if (proxy !== 'DIRECT') {
+				if (proxy.includes('PROXY')) {
+					proxyString += 'ftp=' + proxy.split('PROXY')[1] + ';';
+				}
+			}
+		});
+
+		// Check SOCKS Proxy
+		ses.resolveProxy('socks4://' + resolveProxyUrl, proxy => {
+			if (proxy !== 'DIRECT') {
+				if (proxy.includes('SOCKS5')) {
+					proxyString += 'socks=' + proxy.split('SOCKS5')[1] + ';';
+				} else if (proxy.includes('SOCKS4')) {
+					proxyString += 'socks=' + proxy.split('SOCKS4')[1] + ';';
+				}
+			}
+			// proxyString is written here so that empty string is not written as resolveProxy is async
+			ConfigUtil.setConfigItem('systemProxyRules', proxyString);
+		});
+	}
+}
+
+module.exports = new ProxyUtil();

--- a/app/renderer/js/utils/proxy-util.js
+++ b/app/renderer/js/utils/proxy-util.js
@@ -18,7 +18,7 @@ class ProxyUtil {
 	resolveSystemProxy(mainWindow) {
 		const page = mainWindow.webContents;
 		const ses = page.session;
-		const resolveProxyUrl = 'chat.zulip.org';
+		const resolveProxyUrl = 'www.google.com';
 
 		let proxyString = '';
 

--- a/app/renderer/js/utils/proxy-util.js
+++ b/app/renderer/js/utils/proxy-util.js
@@ -20,49 +20,75 @@ class ProxyUtil {
 		const ses = page.session;
 		const resolveProxyUrl = 'www.google.com';
 
-		let proxyString = '';
-
 		// Check HTTP Proxy
-		ses.resolveProxy('http://' + resolveProxyUrl, proxy => {
-			if (proxy !== 'DIRECT') {
-				// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
-				// for all other HTTP or direct url:port both uses PROXY
-				if (proxy.includes('PROXY') || proxy.includes('HTTPS')) {
-					proxyString += 'http=' + proxy.split('PROXY')[1] + ';';
+		const httpProxy = new Promise(resolve => {
+			ses.resolveProxy('http://' + resolveProxyUrl, proxy => {
+				let httpString = '';
+				if (proxy !== 'DIRECT') {
+					// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+					// for all other HTTP or direct url:port both uses PROXY
+					if (proxy.includes('PROXY') || proxy.includes('HTTPS')) {
+						httpString = 'http=' + proxy.split('PROXY')[1] + ';';
+					}
 				}
-			}
+				resolve(httpString);
+			});
 		});
 		// Check HTTPS Proxy
-		ses.resolveProxy('https://' + resolveProxyUrl, proxy => {
-			if (proxy !== 'DIRECT' || proxy.includes('HTTPS')) {
-				// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
-				// for all other HTTP or direct url:port both uses PROXY
-				if (proxy.includes('PROXY' || proxy.includes('HTTPS'))) {
-					proxyString += 'https=' + proxy.split('PROXY')[1] + ';';
+		const httpsProxy = new Promise(resolve => {
+			ses.resolveProxy('https://' + resolveProxyUrl, proxy => {
+				let httpsString = '';
+				if (proxy !== 'DIRECT' || proxy.includes('HTTPS')) {
+					// in case of proxy HTTPS url:port, windows gives first word as HTTPS while linux gives PROXY
+					// for all other HTTP or direct url:port both uses PROXY
+					if (proxy.includes('PROXY' || proxy.includes('HTTPS'))) {
+						httpsString += 'https=' + proxy.split('PROXY')[1] + ';';
+					}
 				}
-			}
+				resolve(httpsString);
+			});
 		});
 
 		// Check FTP Proxy
-		ses.resolveProxy('ftp://' + resolveProxyUrl, proxy => {
-			if (proxy !== 'DIRECT') {
-				if (proxy.includes('PROXY')) {
-					proxyString += 'ftp=' + proxy.split('PROXY')[1] + ';';
+		const ftpProxy = new Promise(resolve => {
+			ses.resolveProxy('ftp://' + resolveProxyUrl, proxy => {
+				let ftpString = '';
+				if (proxy !== 'DIRECT') {
+					if (proxy.includes('PROXY')) {
+						ftpString += 'ftp=' + proxy.split('PROXY')[1] + ';';
+					}
 				}
-			}
+				resolve(ftpString);
+			});
 		});
 
 		// Check SOCKS Proxy
-		ses.resolveProxy('socks4://' + resolveProxyUrl, proxy => {
-			if (proxy !== 'DIRECT') {
-				if (proxy.includes('SOCKS5')) {
-					proxyString += 'socks=' + proxy.split('SOCKS5')[1] + ';';
-				} else if (proxy.includes('SOCKS4')) {
-					proxyString += 'socks=' + proxy.split('SOCKS4')[1] + ';';
+		const socksProxy = new Promise(resolve => {
+			ses.resolveProxy('socks4://' + resolveProxyUrl, proxy => {
+				let socksString = '';
+				if (proxy !== 'DIRECT') {
+					if (proxy.includes('SOCKS5')) {
+						socksString += 'socks=' + proxy.split('SOCKS5')[1] + ';';
+					} else if (proxy.includes('SOCKS4')) {
+						socksString += 'socks=' + proxy.split('SOCKS4')[1] + ';';
+					} else if (proxy.includes('PROXY')) {
+						socksString += 'socks=' + proxy.split('PROXY')[1] + ';';
+					}
 				}
-			}
-			// proxyString is written here so that empty string is not written as resolveProxy is async
+				resolve(socksString);
+			});
+		});
+
+		Promise.all([httpProxy, httpsProxy, ftpProxy, socksProxy]).then(values => {
+			let proxyString = '';
+			values.forEach(proxy => {
+				proxyString += proxy;
+			});
 			ConfigUtil.setConfigItem('systemProxyRules', proxyString);
+			const useSystemProxy = ConfigUtil.getConfigItem('useSystemProxy');
+			if (useSystemProxy) {
+				ConfigUtil.setConfigItem('proxyRules', proxyString);
+			}
 		});
 	}
 }


### PR DESCRIPTION
This commit uses resolveProxy to to read system proxy settings by requesting to a url namely `google.com` using the 4 protocols `http`, `https`, `ftp`, `socks`, this causes the main process to return the system used proxy for this particular protocol. We store this proxies in proper proxy format string using ConfigUtil into settings.json as `systemProxySettings`.
On turning on the use system proxy settings this value of `systemProxySettings`is written into the proxy rules and the webview session and is reloaded as done previously with only manual settings.
It removes the previous use proxy option and replaces it with use system proxy and manual proxy
options.

Fixes: #296
**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
