### PR TITLE
hidden-webview: Move hidden webview so it does't get deleted.

### DIFF
--- a/app/renderer/js/components/hidden-webview.js
+++ b/app/renderer/js/components/hidden-webview.js
@@ -4,6 +4,6 @@
 const hiddenWebView = document.createElement('webview');
 hiddenWebView.classList.add('download-webview');
 hiddenWebView.src = 'about:blank';
-document.querySelector('#webviews-container').appendChild(hiddenWebView);
+document.querySelector('#content').appendChild(hiddenWebView);
 
 module.exports = hiddenWebView;


### PR DESCRIPTION
It turns out if you add/remove an org the hidden webview get deleted
since its in #webview-container where other sidebar webviews like which
get remove and readded through that process.

This Fixes: https://github.com/zulip/zulip-electron/issues/469