### PR TITLE
internal-links: Download file attachment links using downloadURL.

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -284,11 +284,6 @@ webview {
     flex-direction: column;
 }
 
-webview.download-webview {
-  z-index: -1;
-  pointer-events: none;
-}
-
 webview.onload {
     transition: opacity 1s cubic-bezier(0.95, 0.05, 0.795, 0.035);
 }

--- a/app/renderer/js/components/handle-external-link.js
+++ b/app/renderer/js/components/handle-external-link.js
@@ -1,7 +1,6 @@
 const { shell } = require('electron').remote;
 const LinkUtil = require('../utils/link-util');
 const DomainUtil = require('../utils/domain-util');
-const hiddenWebView = require('../components/hidden-webview');
 
 function handleExternalLink(event) {
 	const { url } = event;
@@ -16,12 +15,12 @@ function handleExternalLink(event) {
 	if (isWhiteListURL) {
 		event.preventDefault();
 
-    // only open the  pdf, mp3, mp4 etc.. in hidden webview since opening the
-    // image in webview will do nothing and will not save it
-    // whereas the pdf will be saved to user desktop once openened in
-    // in the hidden webview and will not trigger webview reload
+    // download txt, pdf, mp3, mp4 etc.. by using downloadURL in the
+    // main process which allows the user to save the files to their desktop
+    // and not trigger webview reload while image in webview will
+    // do nothing and will not save it
 		if (!LinkUtil.isImage(url) && isUploadsURL) {
-			hiddenWebView.loadURL(url);
+			this.$el.downloadURL(url);
 			return;
 		}
 

--- a/app/renderer/js/components/hidden-webview.js
+++ b/app/renderer/js/components/hidden-webview.js
@@ -1,9 +1,0 @@
-// this hidden webview will be used to open pdf url and
-// save it to user's computer without triggering a reload
-// when navigating to pdf url to download it.
-const hiddenWebView = document.createElement('webview');
-hiddenWebView.classList.add('download-webview');
-hiddenWebView.src = 'about:blank';
-document.querySelector('#content').appendChild(hiddenWebView);
-
-module.exports = hiddenWebView;


### PR DESCRIPTION
This commit download file attachments using [downloadURL](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#contentsdownloadurlurl) method of web-contents, the same way loadrURL opens internal links. This removes the use of hidden webview add in f70432f4e3cdc86ae610bf3d77bfa2e784fabdf3. 

Improves: #469. Works for txt files as well.

Currently, I have not removed the `hidden-webview.js` file and its CSS. If this method is approved, I will amend the commit removing the file and CSS.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
