### PR TITLE
loading-indicator: Fix to hide loading indicator when server is loaded

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -13,9 +13,6 @@ body {
 #content {
     display: flex;
     height: 100%;
-    background: #fff url(../img/ic_loading.gif) no-repeat;
-    background-size: 60px 60px;
-    background-position: center;
 }
 
 .toggle-sidebar {
@@ -271,6 +268,25 @@ body {
     display: flex;
     height: 100%;
     width: 100%;
+}
+
+/*Pseudo element for loading indicator*/
+#webviews-container::before {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    background: #fff url(../img/ic_loading.gif) no-repeat;
+    background-size: 60px 60px;
+    background-position: center;
+    width: 100%;
+    height: 100%;
+}
+
+/*When the active webview is loaded*/
+#webviews-container.loaded::before {
+    opacity: 0;
+    z-index: -1;
+    visibility: hidden;
 }
 
 webview {

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -18,7 +18,7 @@ class WebView extends BaseComponent {
 		this.props = props;
 
 		this.zoomFactor = 1.0;
-		this.loading = false;
+		this.loading = true;
 		this.badgeCount = 0;
 		this.customCSS = ConfigUtil.getConfigItem('customCSS');
 	}
@@ -86,6 +86,7 @@ class WebView extends BaseComponent {
 			if (this.props.role === 'server') {
 				this.$el.classList.add('onload');
 			}
+			this.loading = false;
 			this.show();
 		});
 
@@ -119,6 +120,13 @@ class WebView extends BaseComponent {
 			return;
 		}
 
+		// To show or hide the loading indicator in the the active tab
+		if (this.loading) {
+			document.querySelector('#webviews-container').classList.remove('loaded');
+		} else {
+			document.querySelector('#webviews-container').classList.add('loaded');
+		}
+
 		this.$el.classList.remove('disabled');
 		this.$el.classList.add('active');
 		setTimeout(() => {
@@ -127,7 +135,6 @@ class WebView extends BaseComponent {
 			}
 		}, 1000);
 		this.focus();
-		this.loading = false;
 		this.props.onTitleChange();
 		// Injecting preload css in webview to override some css rules
 		this.$el.insertCSS(fs.readFileSync(path.join(__dirname, '/../../css/preload.css'), 'utf8'));
@@ -220,6 +227,9 @@ class WebView extends BaseComponent {
 
 	reload() {
 		this.hide();
+		// Shows the loading indicator till the webview is reloaded
+		document.querySelector('#webviews-container').classList.remove('loaded');
+		this.loading = true;
 		this.$el.reload();
 	}
 

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -21,6 +21,7 @@ class WebView extends BaseComponent {
 		this.loading = true;
 		this.badgeCount = 0;
 		this.customCSS = ConfigUtil.getConfigItem('customCSS');
+		this.$webviewsContainer = document.querySelector('#webviews-container').classList;
 	}
 
 	template() {
@@ -122,9 +123,9 @@ class WebView extends BaseComponent {
 
 		// To show or hide the loading indicator in the the active tab
 		if (this.loading) {
-			document.querySelector('#webviews-container').classList.remove('loaded');
+			this.$webviewsContainer.remove('loaded');
 		} else {
-			document.querySelector('#webviews-container').classList.add('loaded');
+			this.$webviewsContainer.add('loaded');
 		}
 
 		this.$el.classList.remove('disabled');
@@ -228,7 +229,7 @@ class WebView extends BaseComponent {
 	reload() {
 		this.hide();
 		// Shows the loading indicator till the webview is reloaded
-		document.querySelector('#webviews-container').classList.remove('loaded');
+		this.$webviewsContainer.remove('loaded');
 		this.loading = true;
 		this.$el.reload();
 	}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -272,6 +272,9 @@ class ServerManagerView {
 				preload: false
 			})
 		}));
+		// To show loading indicator the first time a functional tab is opened, indicator is
+		// closed when the functional tab DOM is ready, handled in webview.js
+		document.querySelector('#webviews-container').classList.remove('loaded');
 		this.activateTab(this.functionalTabs[tabProps.name]);
 	}
 
@@ -386,6 +389,9 @@ class ServerManagerView {
 	}
 
 	destroyView() {
+		// Show loading indicator
+		document.querySelector('#webviews-container').classList.remove('loaded');
+
 		// Clear global variables
 		this.activeTabIndex = -1;
 		this.tabs = [];

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -274,7 +274,7 @@ class ServerManagerView {
 		}));
 		// To show loading indicator the first time a functional tab is opened, indicator is
 		// closed when the functional tab DOM is ready, handled in webview.js
-		document.querySelector('#webviews-container').classList.remove('loaded');
+		this.$webviewsContainer.classList.remove('loaded');
 		this.activateTab(this.functionalTabs[tabProps.name]);
 	}
 
@@ -390,7 +390,7 @@ class ServerManagerView {
 
 	destroyView() {
 		// Show loading indicator
-		document.querySelector('#webviews-container').classList.remove('loaded');
+		this.$webviewsContainer.classList.remove('loaded');
 
 		// Clear global variables
 		this.activeTabIndex = -1;


### PR DESCRIPTION
Moved the loading indicator to `webviews-container` as a pseudo element to it. The indicator is hidden once the active tabs `DOM` is loaded. In case of loading of functional tab and adding/removing servers(`DestroyView`) is explicitly handled in `main.js`.

Fixes: #482.
