### PR TITLE
menu: Add option to check for updates.

### DIFF
--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -47,7 +47,7 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 				detail: 'You are running the latest version of Zulip Desktop.'
 			});
 		}
-	}, {once: true});
+	});
 
 	autoUpdater.on('error', () => {
 		if (updateFromMenu) {

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -17,6 +17,8 @@ function appUpdater(updateFromMenu = false) {
 		return;
 	}
 
+	let updateAvailable = false;
+
 	// Create Logs directory
 	const LogsDir = `${app.getPath('userData')}/Logs`;
 
@@ -35,9 +37,10 @@ function appUpdater(updateFromMenu = false) {
 		if (updateFromMenu) {
 			dialog.showMessageBox({
 				message: `A new version ${info.version}, of Zulip Desktop is available`,
-				detail: `The update will be downloaded in the background. You will be notified when it is ready to be installed.
-Alternatively you can download it manually from https://zulipchat.com/apps/`
+				detail: 'The update will be downloaded in the background. You will be notified when it is ready to be installed.'
 			});
+
+			updateAvailable = true;
 
 			// This is to prevent removal of 'update-downloaded' and 'error' event listener.
 			eventsListenerRemove.forEach(event => {
@@ -60,9 +63,10 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 
 	autoUpdater.on('error', () => {
 		if (updateFromMenu) {
+			const messageText = (updateAvailable) ? ('Unable to download the updates') : ('Unable to check for updates');
 			dialog.showMessageBox({
 				buttons: ['Manual Download'],
-				message: 'Unable to check for updates',
+				message: messageText,
 				detail: `The latest version of Zulip Desktop is available at -\nhttps://zulipchat.com/apps/.\n
 Current Version: ${app.getVersion()}`
 			}, () => {

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -30,12 +30,18 @@ function appUpdater(updateFromMenu = false) {
 	// Handle auto updates for beta/pre releases
 	autoUpdater.allowPrerelease = ConfigUtil.getConfigItem('betaUpdate') || false;
 
+	const eventsListenerRemove = ['update-available', 'update-not-available'];
 	autoUpdater.on('update-available', () => {
 		if (updateFromMenu) {
 			dialog.showMessageBox({
 				message: 'A new version fo Zulip Desktop is available.',
 				detail: `The update will be downloaded in the background. You will be notified when it is ready to be installed.
 Alternatively you can download it manually from https://zulipchat.com/apps/`
+			});
+
+			// This is to prevent removal of 'update-downloaded' and 'error' event listener.
+			eventsListenerRemove.forEach(event => {
+				autoUpdater.removeAllListeners(event);
 			});
 		}
 	});
@@ -46,6 +52,9 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 				message: 'No update available.',
 				detail: 'You are running the latest version of Zulip Desktop.'
 			});
+			// Remove all autoUpdator listeners so that next time autoUpdator is manually called these
+			// listeners don't trigger multiple times.
+			autoUpdater.removeAllListeners();
 		}
 	});
 
@@ -59,6 +68,9 @@ don't worry you can still download the update manually`
 			}, () => {
 				shell.openExternal('https://zulipchat.com/apps/');
 			});
+			// Remove all autoUpdator listeners so that next time autoUpdator is manually called these
+			// listeners don't trigger multiple times.
+			autoUpdater.removeAllListeners();
 		}
 	});
 

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -50,7 +50,7 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 		if (updateFromMenu) {
 			dialog.showMessageBox({
 				message: 'No update available.',
-				detail: 'You are running the latest version of Zulip Desktop.'
+				detail: `You are running the latest version of Zulip Desktop.\nVersion: ${app.getVersion()}`
 			});
 			// Remove all autoUpdator listeners so that next time autoUpdator is manually called these
 			// listeners don't trigger multiple times.

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -61,14 +61,14 @@ function appUpdater(updateFromMenu = false) {
 		}
 	});
 
-	autoUpdater.on('error', () => {
+	autoUpdater.on('error', error => {
 		if (updateFromMenu) {
 			const messageText = (updateAvailable) ? ('Unable to download the updates') : ('Unable to check for updates');
 			dialog.showMessageBox({
 				type: 'error',
 				buttons: ['Manual Download', 'Cancel'],
 				message: messageText,
-				detail: `The latest version of Zulip Desktop is available at -\nhttps://zulipchat.com/apps/.\n
+				detail: (error).toString() + `\n\nThe latest version of Zulip Desktop is available at -\nhttps://zulipchat.com/apps/.\n
 Current Version: ${app.getVersion()}`
 			}, response => {
 				if (response === 0) {

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -31,10 +31,10 @@ function appUpdater(updateFromMenu = false) {
 	autoUpdater.allowPrerelease = ConfigUtil.getConfigItem('betaUpdate') || false;
 
 	const eventsListenerRemove = ['update-available', 'update-not-available'];
-	autoUpdater.on('update-available', () => {
+	autoUpdater.on('update-available', info => {
 		if (updateFromMenu) {
 			dialog.showMessageBox({
-				message: 'A new version fo Zulip Desktop is available.',
+				message: `A new version ${info.version}, of Zulip Desktop is available`,
 				detail: `The update will be downloaded in the background. You will be notified when it is ready to be installed.
 Alternatively you can download it manually from https://zulipchat.com/apps/`
 			});
@@ -49,7 +49,7 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 	autoUpdater.on('update-not-available', () => {
 		if (updateFromMenu) {
 			dialog.showMessageBox({
-				message: 'No update available.',
+				message: 'No updates available',
 				detail: `You are running the latest version of Zulip Desktop.\nVersion: ${app.getVersion()}`
 			});
 			// Remove all autoUpdator listeners so that next time autoUpdator is manually called these
@@ -62,9 +62,9 @@ Alternatively you can download it manually from https://zulipchat.com/apps/`
 		if (updateFromMenu) {
 			dialog.showMessageBox({
 				buttons: ['Manual Download'],
-				message: 'Oh no!',
-				detail: `Something bad happened and the app can't auto-update itself; 
-don't worry you can still download the update manually`
+				message: 'Unable to check for updates',
+				detail: `The latest version of Zulip Desktop is available at -\nhttps://zulipchat.com/apps/.\n
+Current Version: ${app.getVersion()}`
 			}, () => {
 				shell.openExternal('https://zulipchat.com/apps/');
 			});

--- a/app/main/autoupdater.js
+++ b/app/main/autoupdater.js
@@ -65,12 +65,15 @@ function appUpdater(updateFromMenu = false) {
 		if (updateFromMenu) {
 			const messageText = (updateAvailable) ? ('Unable to download the updates') : ('Unable to check for updates');
 			dialog.showMessageBox({
-				buttons: ['Manual Download'],
+				type: 'error',
+				buttons: ['Manual Download', 'Cancel'],
 				message: messageText,
 				detail: `The latest version of Zulip Desktop is available at -\nhttps://zulipchat.com/apps/.\n
 Current Version: ${app.getVersion()}`
-			}, () => {
-				shell.openExternal('https://zulipchat.com/apps/');
+			}, response => {
+				if (response === 0) {
+					shell.openExternal('https://zulipchat.com/apps/');
+				}
 			});
 			// Remove all autoUpdator listeners so that next time autoUpdator is manually called these
 			// listeners don't trigger multiple times.

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { app, shell, BrowserWindow, Menu, dialog } = require('electron');
 
 const fs = require('fs-extra');
+const { appUpdater } = require('./autoupdater');
 
 const ConfigUtil = require(__dirname + '/../renderer/js/utils/config-util.js');
 const DNDUtil = require(__dirname + '/../renderer/js/utils/dnd-util.js');
@@ -124,6 +125,12 @@ class AppMenu {
 				label: `What's New...`,
 				click() {
 					shell.openExternal(`https://github.com/zulip/zulip-electron/releases/tag/v${app.getVersion()}`);
+				}
+			},
+			{
+				label: `Check for Update`,
+				click() {
+					AppMenu.checkForUpdate();
 				}
 			},
 			{
@@ -399,6 +406,9 @@ class AppMenu {
 		win.webContents.send(action, ...params);
 	}
 
+	static checkForUpdate() {
+		appUpdater(true);
+	}
 	static resetAppSettings() {
 		const resetAppSettingsMessage = 'By proceeding you will be removing all connected organizations and preferences from Zulip.';
 

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -128,12 +128,6 @@ class AppMenu {
 				}
 			},
 			{
-				label: `Check for Update`,
-				click() {
-					AppMenu.checkForUpdate();
-				}
-			},
-			{
 				label: `${appName} Help`,
 				click() {
 					shell.openExternal('https://zulipchat.com/help/');
@@ -202,7 +196,12 @@ class AppMenu {
 						AppMenu.sendAction('open-about');
 					}
 				}
-			}, {
+			},	{
+				label: `Check for Update`,
+				click() {
+					AppMenu.checkForUpdate();
+				}
+			},	{
 				type: 'separator'
 			}, {
 				label: 'Desktop App Settings',
@@ -309,7 +308,12 @@ class AppMenu {
 						AppMenu.sendAction('open-about');
 					}
 				}
-			}, {
+			}, 	{
+				label: `Check for Update`,
+				click() {
+					AppMenu.checkForUpdate();
+				}
+			},	{
 				type: 'separator'
 			}, {
 				label: 'Desktop App Settings',


### PR DESCRIPTION
On clicking the check for update, app calls `appUpdator` which checks for update and shows a dialog according to updates availability, also handles error in case it fails 

Fixes: #479.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**Screenshots?**
![screenshot from 2018-05-08 00-15-00](https://user-images.githubusercontent.com/20434085/39724392-4a13eb3c-5266-11e8-9db1-4bf07a28ffbe.png)
![peek-2018-05-08-01-16](https://user-images.githubusercontent.com/20434085/39724493-8d701e96-5266-11e8-9c6a-8e0fcfbac09c.gif)
