### PR TITLE
settings: Add option to add custom certificates

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -417,7 +417,7 @@ class AppMenu {
 		const resetAppSettingsMessage = 'By proceeding you will be removing all connected organizations and preferences from Zulip.';
 
 		// We save App's settings/configurations in following files
-		const settingFiles = ['window-state.json', 'domain.json', 'settings.json'];
+		const settingFiles = ['window-state.json', 'domain.json', 'settings.json', 'certificates.json'];
 
 		dialog.showMessageBox({
 			type: 'warning',

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -557,6 +557,31 @@ input.toggle-round:checked+label:after {
     background: #329588;
 }
 
+.certificates-card {
+     width:70%
+}
+
+.certificate-input {
+     width:100%;
+     margin-top: 10px; 
+     display:inline-flex;
+}
+
+.certificate-input div {
+    align-self:center;
+}
+
+.certificate-input .setting-input-value {
+    margin-left:10px;
+    max-width: 100%;
+}
+
+#add-certificate-button {
+    width:20%;
+    margin-right:0px;
+    height: 35px;
+}
+
 .tip {
     background-color: hsl(46,63%,95%);
     border: 1px solid hsl(46,63%,84%);

--- a/app/renderer/js/pages/preference/add-certificate.js
+++ b/app/renderer/js/pages/preference/add-certificate.js
@@ -1,0 +1,92 @@
+'use-strict';
+
+const { dialog } = require('electron').remote;
+
+const BaseComponent = require(__dirname + '/../../components/base.js');
+const CertificateUtil = require(__dirname + '/../../utils/certificate-util.js');
+const DomainUtil = require(__dirname + '/../../utils/domain-util.js');
+
+class AddCertificate extends BaseComponent {
+	constructor(props) {
+		super();
+		this.props = props;
+		this._certFile = '';
+	}
+
+	template() {
+		return `			
+			<div class="settings-card server-center certificates-card">
+				<div class="certificate-input">
+					<div>Organization URL :</div> 
+					<input class="setting-input-value" autofocus placeholder="your-organization.zulipchat.com or zulip.your-organization.com"/>
+				</div>
+				<div class="certificate-input">
+					<div>Custom CA's certificate file :</div> 
+					<button id="add-certificate-button">Add</button>
+				</div>
+			</div>
+		`;
+	}
+
+	init() {
+		this.$addCertificate = this.generateNodeFromTemplate(this.template());
+		this.props.$root.appendChild(this.$addCertificate);
+		this.addCertificateButton = this.$addCertificate.querySelector('#add-certificate-button');
+		this.serverUrl = this.$addCertificate.querySelectorAll('input.setting-input-value')[0];
+		this.initListeners();
+	}
+
+	validateAndAdd() {
+		const certificate = this._certFile;
+		const serverUrl = this.serverUrl.value;
+		if (certificate !== '' && serverUrl !== '') {
+			const server = encodeURIComponent(DomainUtil.formatUrl(serverUrl));
+			const fileName = certificate.substring(certificate.lastIndexOf('/') + 1);
+			const copy = CertificateUtil.copyCertificate(server, certificate, fileName);
+			if (!copy) {
+				console.log('We encountered error while saving the certificate.');
+				return;
+			}
+			CertificateUtil.setCertificate(server, fileName);
+			dialog.showMessageBox({
+				title: 'Success',
+				message: `Certificate saved!`
+			});
+			this.serverUrl.value = '';
+		} else {
+			dialog.showErrorBox('Error', `Please, ${serverUrl === '' ?
+      'Enter an Organization URL' : 'Choose certificate file'}`);
+		}
+	}
+
+	addHandler() {
+		const showDialogOptions = {
+			title: 'Select file',
+			defaultId: 1,
+			properties: ['openFile'],
+			filters: [{ name: 'crt, pem', extensions: ['crt', 'pem'] }]
+		};
+		dialog.showOpenDialog(showDialogOptions, selectedFile => {
+			if (selectedFile) {
+				this._certFile = selectedFile[0] || '';
+				this.validateAndAdd();
+			}
+		});
+	}
+
+	initListeners() {
+		this.addCertificateButton.addEventListener('click', () => {
+			this.addHandler();
+		});
+
+		this.serverUrl.addEventListener('keypress', event => {
+			const EnterkeyCode = event.keyCode;
+
+			if (EnterkeyCode === 13) {
+				this.addHandler();
+			}
+		});
+	}
+}
+
+module.exports = AddCertificate;

--- a/app/renderer/js/pages/preference/connected-org-section.js
+++ b/app/renderer/js/pages/preference/connected-org-section.js
@@ -3,6 +3,7 @@
 const BaseSection = require(__dirname + '/base-section.js');
 const DomainUtil = require(__dirname + '/../../utils/domain-util.js');
 const ServerInfoForm = require(__dirname + '/server-info-form.js');
+const AddCertificate = require(__dirname + '/add-certificate.js');
 
 class ConnectedOrgSection extends BaseSection {
 	constructor(props) {
@@ -16,6 +17,9 @@ class ConnectedOrgSection extends BaseSection {
 				<div class="page-title">Connected organizations</div>
 				<div class="title" id="existing-servers">All the connected orgnizations will appear here.</div>
 				<div id="server-info-container"></div>
+
+				<div class="page-title">Add Custom Certificates</div>
+				<div id="add-certificate-container"></div>
 			</div>
 		`;
 	}
@@ -44,6 +48,15 @@ class ConnectedOrgSection extends BaseSection {
 				onChange: this.reloadApp
 			}).init();
 		}
+
+		this.$addCertificateContainer = document.getElementById('add-certificate-container');
+		this.initAddCertificate();
+	}
+
+	initAddCertificate() {
+		new AddCertificate({
+			$root: this.$addCertificateContainer
+		}).init();
 	}
 
 }

--- a/app/renderer/js/utils/certificate-util.js
+++ b/app/renderer/js/utils/certificate-util.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { app, dialog } = require('electron').remote;
+const fs = require('fs');
+const path = require('path');
+const JsonDB = require('node-json-db');
+const Logger = require('./logger-util');
+const { initSetUp } = require('./default-util');
+
+initSetUp();
+
+const logger = new Logger({
+	file: `certificate-util.log`,
+	timestamp: true
+});
+
+let instance = null;
+const certificatesDir = `${app.getPath('userData')}/certificates`;
+
+class CertificateUtil {
+	constructor() {
+		if (instance) {
+			return instance;
+		} else {
+			instance = this;
+		}
+
+		this.reloadDB();
+		return instance;
+	}
+	getCertificate(server, defaultValue = null) {
+		this.reloadDB();
+		const value = this.db.getData('/')[server];
+		if (value === undefined) {
+			return defaultValue;
+		} else {
+			return value;
+		}
+	}
+	// Function to copy the certificate to userData folder
+	copyCertificate(server, location, fileName) {
+		let copied = false;
+		const filePath = `${certificatesDir}/${fileName}`;
+		try {
+			fs.copyFileSync(location, filePath);
+			copied = true;
+		} catch (err) {
+			dialog.showErrorBox(
+				'Error saving certificate',
+				'We encountered error while saving the certificate.'
+			);
+			logger.error('Error while copying the certificate to certificates folder.');
+			logger.error(err);
+			console.log(err);
+		}
+		return copied;
+	}
+	setCertificate(server, fileName) {
+		const filePath = `${certificatesDir}/${fileName}`;
+		this.db.push(`/${server}`, filePath, true);
+		this.reloadDB();
+	}
+	removeCertificate(server) {
+		this.db.delete(`/${server}`);
+		this.reloadDB();
+	}
+	reloadDB() {
+		const settingsJsonPath = path.join(app.getPath('userData'), '/certificates.json');
+		try {
+			const file = fs.readFileSync(settingsJsonPath, 'utf8');
+			JSON.parse(file);
+		} catch (err) {
+			if (fs.existsSync(settingsJsonPath)) {
+				fs.unlinkSync(settingsJsonPath);
+				dialog.showErrorBox(
+					'Error saving settings',
+					'We encountered error while saving the certificate.'
+				);
+				logger.error('Error while JSON parsing certificates.json: ');
+				logger.error(err);
+			}
+		}
+		this.db = new JsonDB(settingsJsonPath, true, true);
+	}
+}
+
+module.exports = new CertificateUtil();

--- a/app/renderer/js/utils/default-util.js
+++ b/app/renderer/js/utils/default-util.js
@@ -10,6 +10,7 @@ if (process.type === 'renderer') {
 
 const zulipDir = app.getPath('userData');
 const logDir = `${zulipDir}/Logs/`;
+const certificatesDir = `${zulipDir}/certificates/`;
 const initSetUp = () => {
 	// if it is the first time the app is running
 	// create zulip dir in userData folder to
@@ -22,6 +23,11 @@ const initSetUp = () => {
 		if (!fs.existsSync(logDir)) {
 			fs.mkdirSync(logDir);
 		}
+
+		if (!fs.existsSync(certificatesDir)) {
+			fs.mkdirSync(certificatesDir);
+		}
+
 		setupCompleted = true;
 	}
 };


### PR DESCRIPTION
To validate custom/self-signed certificates for servers by saving the certificate location and then passing the certificate in the request used to validate the server when adding. The validation is done
by the [request](https://www.npmjs.com/package/request#tlsssl-protocol) module itself.

Fixes: #126 

This PR now stores the location of the cert when the user adds it, a better option could be if we copy the certificate to the `appData` folder of the user in a certificates subfolder. This would prevent errors due to removal of the original file and seems something more like a behavior that a user would expect. Thoughts?