### PR TITLE
[WIP] config-util: Use package reload instead of custom reload.

### DIFF
--- a/app/renderer/js/utils/config-util.js
+++ b/app/renderer/js/utils/config-util.js
@@ -39,7 +39,12 @@ class ConfigUtil {
 	}
 
 	getConfigItem(key, defaultValue = null) {
-		this.reloadDB();
+		try {
+			this.db.reload();
+		} catch (err) {
+			logger.error('Error while reloading settings.json: ');
+			logger.error(err);
+		}
 		const value = this.db.getData('/')[key];
 		if (value === undefined) {
 			this.setConfigItem(key, defaultValue);
@@ -50,19 +55,24 @@ class ConfigUtil {
 	}
 	// This function returns whether a key exists in the configuration file (settings.json)
 	isConfigItemExists(key) {
-		this.reloadDB();
+		try {
+			this.db.reload();
+		} catch (err) {
+			logger.error('Error while reloading settings.json: ');
+			logger.error(err);
+		}
 		const value = this.db.getData('/')[key];
 		return (value !== undefined);
 	}
 
 	setConfigItem(key, value) {
 		this.db.push(`/${key}`, value, true);
-		this.reloadDB();
+		this.db.save();
 	}
 
 	removeConfigItem(key) {
 		this.db.delete(`/${key}`);
-		this.reloadDB();
+		this.db.save();
 	}
 
 	reloadDB() {


### PR DESCRIPTION
This is a WIP commit to fix the errors while saving settings that occur from reloadDB function.
Here I have changed using `reloadDB` to use the reload function offered by the `node-json-db` package itself. 
Also, have removed the reloading db where we are writing to the database and replaced it with saving the db. Since we are using `saveOnPush` already, this part is actually redundant and not necessary, but for safety purposes I have put in now.
Regarding reloading the db,I don't think it is necessary at all, because `config-util` is the only file where changes to `settings-json` is being done, meaning no exterior change to the database file, so the database variable in it would be up to date and no conflict would occur. Removing reload would reduce the chances of causing db errors significantly.