### PR TITLE
config-files: Move all the configuration files into config folder.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -54,7 +54,8 @@ function createMainWindow() {
 	// Load the previous state with fallback to defaults
 	const mainWindowState = windowStateKeeper({
 		defaultWidth: 1100,
-		defaultHeight: 720
+		defaultHeight: 720,
+		path: `${app.getPath('userData')}/config`
 	});
 
 	// Let's keep the window position global so that we can access it in other process

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -423,7 +423,7 @@ class AppMenu {
 		const resetAppSettingsMessage = 'By proceeding you will be removing all connected organizations and preferences from Zulip.';
 
 		// We save App's settings/configurations in following files
-		const settingFiles = ['window-state.json', 'domain.json', 'settings.json', 'certificates.json'];
+		const settingFiles = ['window-state.json', 'config/domain.json', 'config/settings.json', 'config/certificates.json'];
 
 		dialog.showMessageBox({
 			type: 'warning',

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -423,7 +423,7 @@ class AppMenu {
 		const resetAppSettingsMessage = 'By proceeding you will be removing all connected organizations and preferences from Zulip.';
 
 		// We save App's settings/configurations in following files
-		const settingFiles = ['window-state.json', 'config/domain.json', 'config/settings.json', 'config/certificates.json'];
+		const settingFiles = ['config/window-state.json', 'config/domain.json', 'config/settings.json', 'config/certificates.json'];
 
 		dialog.showMessageBox({
 			type: 'warning',

--- a/app/renderer/js/utils/certificate-util.js
+++ b/app/renderer/js/utils/certificate-util.js
@@ -64,7 +64,7 @@ class CertificateUtil {
 		this.reloadDB();
 	}
 	reloadDB() {
-		const settingsJsonPath = path.join(app.getPath('userData'), '/certificates.json');
+		const settingsJsonPath = path.join(app.getPath('userData'), '/config/certificates.json');
 		try {
 			const file = fs.readFileSync(settingsJsonPath, 'utf8');
 			JSON.parse(file);

--- a/app/renderer/js/utils/config-util.js
+++ b/app/renderer/js/utils/config-util.js
@@ -66,7 +66,7 @@ class ConfigUtil {
 	}
 
 	reloadDB() {
-		const settingsJsonPath = path.join(app.getPath('userData'), '/settings.json');
+		const settingsJsonPath = path.join(app.getPath('userData'), '/config/settings.json');
 		try {
 			const file = fs.readFileSync(settingsJsonPath, 'utf8');
 			JSON.parse(file);

--- a/app/renderer/js/utils/default-util.js
+++ b/app/renderer/js/utils/default-util.js
@@ -35,6 +35,7 @@ const initSetUp = () => {
 			const certificatesJson = `${zulipDir}/certificates.json`;
 			const settingsJson = `${zulipDir}/settings.json`;
 			const updatesJson = `${zulipDir}/updates.json`;
+			const windowStateJson = `${zulipDir}/window-state.json`;
 			if (fs.existsSync(domainJson)) {
 				fs.copyFileSync(domainJson, configDir + `domain.json`);
 				fs.unlinkSync(domainJson);
@@ -50,6 +51,9 @@ const initSetUp = () => {
 			if (fs.existsSync(updatesJson)) {
 				fs.copyFileSync(updatesJson, configDir + `updates.json`);
 				fs.unlinkSync(updatesJson);
+			}
+			if (fs.existsSync(windowStateJson)) {
+				fs.unlinkSync(windowStateJson);
 			}
 		}
 

--- a/app/renderer/js/utils/default-util.js
+++ b/app/renderer/js/utils/default-util.js
@@ -11,6 +11,7 @@ if (process.type === 'renderer') {
 const zulipDir = app.getPath('userData');
 const logDir = `${zulipDir}/Logs/`;
 const certificatesDir = `${zulipDir}/certificates/`;
+const configDir = `${zulipDir}/config/`;
 const initSetUp = () => {
 	// if it is the first time the app is running
 	// create zulip dir in userData folder to
@@ -26,6 +27,30 @@ const initSetUp = () => {
 
 		if (!fs.existsSync(certificatesDir)) {
 			fs.mkdirSync(certificatesDir);
+		}
+
+		if (!fs.existsSync(configDir)) {
+			fs.mkdirSync(configDir);
+			const domainJson = `${zulipDir}/domain.json`;
+			const certificatesJson = `${zulipDir}/certificates.json`;
+			const settingsJson = `${zulipDir}/settings.json`;
+			const updatesJson = `${zulipDir}/updates.json`;
+			if (fs.existsSync(domainJson)) {
+				fs.copyFileSync(domainJson, configDir + `domain.json`);
+				fs.unlinkSync(domainJson);
+			}
+			if (fs.existsSync(certificatesJson)) {
+				fs.copyFileSync(certificatesJson, configDir + `certificates.json`);
+				fs.unlinkSync(certificatesJson);
+			}
+			if (fs.existsSync(settingsJson)) {
+				fs.copyFileSync(settingsJson, configDir + `settings.json`);
+				fs.unlinkSync(settingsJson);
+			}
+			if (fs.existsSync(updatesJson)) {
+				fs.copyFileSync(updatesJson, configDir + `updates.json`);
+				fs.unlinkSync(updatesJson);
+			}
 		}
 
 		setupCompleted = true;

--- a/app/renderer/js/utils/default-util.js
+++ b/app/renderer/js/utils/default-util.js
@@ -29,6 +29,8 @@ const initSetUp = () => {
 			fs.mkdirSync(certificatesDir);
 		}
 
+		// Migrate config files from app data folder to config folder inside app
+		// data folder. This will be done once when a user updates to the new version.
 		if (!fs.existsSync(configDir)) {
 			fs.mkdirSync(configDir);
 			const domainJson = `${zulipDir}/domain.json`;
@@ -36,22 +38,32 @@ const initSetUp = () => {
 			const settingsJson = `${zulipDir}/settings.json`;
 			const updatesJson = `${zulipDir}/updates.json`;
 			const windowStateJson = `${zulipDir}/window-state.json`;
-			if (fs.existsSync(domainJson)) {
-				fs.copyFileSync(domainJson, configDir + `domain.json`);
-				fs.unlinkSync(domainJson);
-			}
-			if (fs.existsSync(certificatesJson)) {
-				fs.copyFileSync(certificatesJson, configDir + `certificates.json`);
-				fs.unlinkSync(certificatesJson);
-			}
-			if (fs.existsSync(settingsJson)) {
-				fs.copyFileSync(settingsJson, configDir + `settings.json`);
-				fs.unlinkSync(settingsJson);
-			}
-			if (fs.existsSync(updatesJson)) {
-				fs.copyFileSync(updatesJson, configDir + `updates.json`);
-				fs.unlinkSync(updatesJson);
-			}
+			const configData = [
+				{
+					path: domainJson,
+					fileName: `domain.json`
+				},
+				{
+					path: certificatesJson,
+					fileName: `certificates.json`
+				},
+				{
+					path: settingsJson,
+					fileName: `settings.json`
+				},
+				{
+					path: updatesJson,
+					fileName: `updates.json`
+				}
+			];
+			configData.forEach(data => {
+				if (fs.existsSync(data.path)) {
+					fs.copyFileSync(data.path, configDir + data.fileName);
+					fs.unlinkSync(data.path);
+				}
+			});
+			// window-state.json is only deleted not moved, as the electron-window-state
+			// package will recreate the file in the config folder.
 			if (fs.existsSync(windowStateJson)) {
 				fs.unlinkSync(windowStateJson);
 			}

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -251,7 +251,7 @@ class DomainUtil {
 	}
 
 	reloadDB() {
-		const domainJsonPath = path.join(app.getPath('userData'), '/domain.json');
+		const domainJsonPath = path.join(app.getPath('userData'), 'config/domain.json');
 		try {
 			const file = fs.readFileSync(domainJsonPath, 'utf8');
 			JSON.parse(file);

--- a/app/renderer/js/utils/linux-update-util.js
+++ b/app/renderer/js/utils/linux-update-util.js
@@ -52,7 +52,7 @@ class LinuxUpdateUtil {
 	}
 
 	reloadDB() {
-		const linuxUpdateJsonPath = path.join(app.getPath('userData'), '/updates.json');
+		const linuxUpdateJsonPath = path.join(app.getPath('userData'), '/config/updates.json');
 		try {
 			const file = fs.readFileSync(linuxUpdateJsonPath, 'utf8');
 			JSON.parse(file);


### PR DESCRIPTION
This PR moves all the configuration(.json) files into a config folder if the config folder doesn't already exists. It also updates the places where these files are being accessed with the new address.
The files are `updates.json`, `certificates.json`, `domain.json`, `settings.json`, `window-state.json`. `window-state.json` is moved by changing the path in the package `electron-window-state`.