### PR TITLE
package.json: Move adm dependecy to app/package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@electron-elements/send-feedback": "1.0.7",
     "escape-html": "1.0.3",
+    "adm-zip": "0.4.11",
     "auto-launch": "5.0.5",
     "electron-is-dev": "0.3.0",
     "electron-log": "2.2.14",

--- a/package.json
+++ b/package.json
@@ -181,8 +181,5 @@
       "browser",
       "mocha"
     ]
-  },
-  "dependencies": {
-    "adm-zip": "^0.4.11"
   }
 }


### PR DESCRIPTION
This fixes wrong placement of `adm` dependency (in #509) in `package.json` to `app/package.json` . 