### PR TITLE
macOS: Add dock bouncing effect on macOS.

### DIFF
--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -75,11 +75,16 @@ class WebView extends BaseComponent {
 
 		this.$el.addEventListener('page-favicon-updated', event => {
 			const { favicons } = event;
+
 			// This returns a string of favicons URL. If there is a PM counts in unread messages then the URL would be like
 			// https://chat.zulip.org/static/images/favicon/favicon-pms.png
 			if (favicons[0].indexOf('favicon-pms') > 0 && process.platform === 'darwin') {
 				// This api is only supported on macOS
 				app.dock.setBadge('●');
+				// bounce the dock
+				if (ConfigUtil.getConfigItem('dockBouncing')) {
+					app.dock.bounce();
+				}
 			}
 		});
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -127,6 +127,11 @@ class ServerManagerView {
 			settingOptions.dndPreviousSettings.flashTaskbarOnMessage = true;
 		}
 
+		if (process.platform === 'darwin') {
+			// Only available on macOS
+			settingOptions.dockBouncing = true;
+		}
+
 		for (const i in settingOptions) {
 			if (ConfigUtil.getConfigItem(i) === null) {
 				ConfigUtil.setConfigItem(i, settingOptions[i]);

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -31,6 +31,10 @@ class GeneralSection extends BaseSection {
 						<div class="setting-description">Show app unread badge</div>
 						<div class="setting-control"></div>
 					</div>
+					<div class="setting-row" id="dock-bounce-option">
+						<div class="setting-description">Bounce dock on new private message</div>
+						<div class="setting-control"></div>
+					</div>
 					<div class="setting-row" id="flash-taskbar-option" style= "display:${process.platform === 'win32' ? '' : 'none'}">
 						<div class="setting-description">Flash taskbar on new message</div>
 						<div class="setting-control"></div>
@@ -121,9 +125,14 @@ class GeneralSection extends BaseSection {
 		this.removeCustomCSS();
 
 		// Platform specific settings
+
 		// Flashing taskbar on Windows
 		if (process.platform === 'win32') {
 			this.updateFlashTaskbar();
+		}
+		// Dock bounce on macOS
+		if (process.platform === 'darwin') {
+			this.updateDockBouncing();
 		}
 	}
 
@@ -149,6 +158,18 @@ class GeneralSection extends BaseSection {
 				ConfigUtil.setConfigItem('badgeOption', newValue);
 				ipcRenderer.send('toggle-badge-option', newValue);
 				this.updateBadgeOption();
+			}
+		});
+	}
+
+	updateDockBouncing() {
+		this.generateSettingOption({
+			$element: document.querySelector('#dock-bounce-option .setting-control'),
+			value: ConfigUtil.getConfigItem('dockBouncing', true),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('dockBouncing');
+				ConfigUtil.setConfigItem('dockBouncing', newValue);
+				this.updateDockBouncing();
 			}
 		});
 	}

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -31,7 +31,7 @@ class GeneralSection extends BaseSection {
 						<div class="setting-description">Show app unread badge</div>
 						<div class="setting-control"></div>
 					</div>
-					<div class="setting-row" id="dock-bounce-option">
+					<div class="setting-row" id="dock-bounce-option" style= "display:${process.platform === 'darwin' ? '' : 'none'}">
 						<div class="setting-description">Bounce dock on new private message</div>
 						<div class="setting-control"></div>
 					</div>


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Add a new setting option to control the dock boucing on macOS. 



**Screenshots?**

<img src="https://camo.githubusercontent.com/74eb01932119012e5204e302720e6d19f21179ec/68747470733a2f2f647a776f6e73656d72697368372e636c6f756466726f6e742e6e65742f6974656d732f323133383179337230433339313730303143316a2f53637265656e2532305265636f7264696e67253230323031382d30372d3035253230617425323030372e3034253230504d2e676966"/>


**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [X] macOS
