### PR TITLE
certificates: Make default option "No" on enter key press to reject certificate.

### DIFF
--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -164,7 +164,7 @@ class DomainUtil {
 						dialog.showMessageBox({
 							type: 'warning',
 							buttons: ['Yes', 'No'],
-							defaultId: 0,
+							defaultId: 1,
 							message: certErrorMessage,
 							detail: certErrorDetail
 						}, response => {


### PR DESCRIPTION
This is done so that if a user just presses `enter` without reading the text, by default it'd  reject the text. 