### PR TITLE
files: Handle downloading files failure.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -250,6 +250,7 @@ app.on('ready', () => {
 				switch (state) {
 					case 'interrupted' : {
 						// Can interrupted to due to network error, cancel download then
+						console.log('Download interrupted, cancelling and fallback to dialog download.');
 						item.cancel();
 						break;
 					}
@@ -269,6 +270,7 @@ app.on('ready', () => {
 				if (state === 'completed') {
 					page.send('downloadFileCompleted', item.getSavePath(), item.getFilename());
 				} else {
+					console.log('Download failed state: ', state);
 					page.send('downloadFileFailed');
 				}
 				// To stop item for listening to updated events of this file

--- a/app/renderer/js/components/handle-external-link.js
+++ b/app/renderer/js/components/handle-external-link.js
@@ -39,6 +39,14 @@ function handleExternalLink(event) {
 				downloadNotification.onclick = () => {
 					shell.openItem(filePath);
 				};
+				ipcRenderer.removeAllListeners('downloadFileFailed');
+			});
+
+			ipcRenderer.once('downloadFileFailed', () => {
+				// Automatic download failed, so show save dialog prompt and download
+				// through webview
+				this.$el.downloadURL(url);
+				ipcRenderer.removeAllListeners('downloadFileCompleted');
 			});
 			return;
 		}


### PR DESCRIPTION
Previously users used to get download complete notification even if downloaded has been failed. This PR puts a download failed notification in that case. It also handles cases where download might have been interrupted due to connectivity issues and resumes it.