### PR TITLE
fixes: Fix null of downloadPath when settings.json fails.

### DIFF
--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -105,7 +105,7 @@ class GeneralSection extends BaseSection {
 					</div>
 					<div class="setting-row">
 						<div class="setting-description">
-							<div class="download-folder-path">${ConfigUtil.getConfigItem('downloadsPath')}</div>
+							<div class="download-folder-path">${ConfigUtil.getConfigItem('downloadsPath', `${app.getPath('downloads')}`)}</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Fixes for bug reported here https://chat.zulip.org/#narrow/stream/16-desktop/subject/No.20Alert.20for.20configuration.20not.20being.20saved.2E/near/615826