### PR TITLE
attachments: Fix failing attached file downloads.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -73,7 +73,8 @@ function createMainWindow() {
 		minHeight: 400,
 		webPreferences: {
 			plugins: true,
-			nodeIntegration: true
+			nodeIntegration: true,
+			partition: 'persist:webviewsession'
 		},
 		show: false
 	});


### PR DESCRIPTION
This commit fixes the failing download files that had occured due to session not being same in the browserWindow and the webview. This made the uploaded files unavailable to browserWindow for download. 
This fix adds the persist session to the browserWindow, and should now work for all servers. It'd still revert back to the dialog download in case the download fails for some other reason.
Fixes: #523 