### PR TITLE
proxy: Set environment proxy variables as per proxyRules.

### DIFF
--- a/app/main/linuxupdater.js
+++ b/app/main/linuxupdater.js
@@ -4,6 +4,7 @@ const { Notification } = require('electron');
 const request = require('request');
 const semver = require('semver');
 const ConfigUtil = require('../renderer/js/utils/config-util');
+const ProxyUtil = require('../renderer/js/utils/proxy-util');
 const LinuxUpdateUtil = require('../renderer/js/utils/linux-update-util');
 const Logger = require('../renderer/js/utils/logger-util');
 
@@ -15,10 +16,12 @@ const logger = new Logger({
 function linuxUpdateNotification() {
 	let	url = 'https://api.github.com/repos/zulip/zulip-electron/releases';
 	url = ConfigUtil.getConfigItem('betaUpdate') ? url : url + '/latest';
+	const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy') || ConfigUtil.getConfigItem('useSystemProxy');
 
 	const options = {
 		url,
-		headers: {'User-Agent': 'request'}
+		headers: {'User-Agent': 'request'},
+		proxy: proxyEnabled ? ProxyUtil.getProxy(url) : ''
 	};
 
 	request(options, (error, response, body) => {


### PR DESCRIPTION
Fixes: #534.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
This commit sets the http and https proxy environment variable as per proxyRules so that the request module can use these rules while sending a request.

**Any background context you want to provide?**
`request` module is used in many places in the codebase. It respects the environment proxy variables so usually it used to work as whenever proxy is set in the system using GUI the environment variables are usually written as usual. However, sometimes the environment proxy variables maybe incorrect or not written due to some OS issues. Hence we are are writing the environment variables temporarily for the duration of app run with the proxy rules that we are using for the webview.

Fixes: #534 

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
