### PR TITLE
settings: Update reference to toggle sidebar shortcut in general section

### DIFF
--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -24,7 +24,7 @@ class GeneralSection extends BaseSection {
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="sidebar-option">
-						<div class="setting-description">Show sidebar (<span class="code">Cmd Or Ctrl+S</span>)</div>
+						<div class="setting-description">Show sidebar (<span class="code">Cmd Or Ctrl+Shift+S</span>)</div>
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="badge-option">


### PR DESCRIPTION
**What's this PR do?**
Updates the reference to the toggle sidebar shortcut, in the General section of Settings/preference, under Appearance, for the Show sidebar setting.

**Any background context you want to provide?**
Cmd/Ctrl+S no longer works, as the toggle sidebar shortcut was updated in https://github.com/zulip/zulip-electron/commit/8bd02cc7e469f899111af0875a9b21219eabdf03.

**Screenshots?**
Current Appearance:
![image](https://user-images.githubusercontent.com/9403740/44600470-fc0a3980-a79e-11e8-95b5-db8a63fcbdc2.png)