### PR TITLE
realm name: Update sidebar realm name when it's changed in webapp.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -306,6 +306,10 @@ app.on('ready', () => {
 		});
 	});
 
+	ipcMain.on('realm-name-changed', (event, serverURL, realmName) => {
+		page.send('update-realm-name', serverURL, realmName);
+	});
+
 	ipcMain.on('realm-icon-changed', (event, serverURL, iconURL) => {
 		page.send('update-realm-icon', serverURL, iconURL);
 	});

--- a/app/renderer/js/components/server-tab.js
+++ b/app/renderer/js/components/server-tab.js
@@ -8,7 +8,7 @@ const {ipcRenderer} = require('electron');
 class ServerTab extends Tab {
 	template() {
 		return `<div class="tab" data-tab-id="${this.props.tabIndex}">
-					<div class="server-tooltip" style="display:none"></div>
+					<div class="server-tooltip" style="display:none">${this.props.name}</div>
 					<div class="server-tab-badge"></div>
 					<div class="server-tab">
 					<img class="server-icons" src='${this.props.icon}'/>

--- a/app/renderer/js/electron-bridge.js
+++ b/app/renderer/js/electron-bridge.js
@@ -21,8 +21,9 @@ electron_bridge.on('total_unread_count', (...args) => {
 	ipcRenderer.send('unread-count', ...args);
 });
 
-electron_bridge.on('realm_name', (...args) => {
-	ipcRenderer.send('realm-name-changed', ...args);
+electron_bridge.on('realm_name', realmName => {
+	const serverURL = location.origin;
+	ipcRenderer.send('realm-name-changed', serverURL, realmName);
 });
 
 electron_bridge.on('realm_icon_url', iconURL => {


### PR DESCRIPTION
This PR updates the realm name in the sidebar tooltip and domains.json when it is updated in the server through electron_bridge.

This PR  also removes the server.alias parameter from the tooltip `onHover` function and inserts it in the the innerHTML of the tooltip DOM, This helps to easily update the tooltip text when the realm name is changed. Since this text is never removed this is a good way to do this as we now simply leverage `display:none` to hide/show the tooltip.

Fixes: #425
