### PR TITLE
server-name: Unescape server name in window menu item.

### DIFF
--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -14,6 +14,8 @@ const ConfigUtil = require(__dirname + '/js/utils/config-util.js');
 const DNDUtil = require(__dirname + '/js/utils/dnd-util.js');
 const ReconnectUtil = require(__dirname + '/js/utils/reconnect-util.js');
 const Logger = require(__dirname + '/js/utils/logger-util.js');
+const CommonUtil = require(__dirname + '/js/utils/common-util.js');
+
 const { feedbackHolder } = require(__dirname + '/js/feedback.js');
 
 const logger = new Logger({
@@ -177,7 +179,7 @@ class ServerManagerView {
 				index,
 				tabIndex,
 				url: server.url,
-				name: server.alias,
+				name: CommonUtil.decodeString(server.alias),
 				isActive: () => {
 					return index === this.activeTabIndex;
 				},

--- a/app/renderer/js/utils/common-util.js
+++ b/app/renderer/js/utils/common-util.js
@@ -1,0 +1,25 @@
+'use strict';
+
+let instance = null;
+
+class CommonUtil {
+	constructor() {
+		if (instance) {
+			return instance;
+		} else {
+			instance = this;
+		}
+		return instance;
+	}
+
+	// unescape already encoded/escaped strings
+	decodeString(string) {
+		const parser = new DOMParser();
+		const dom = parser.parseFromString(
+			'<!doctype html><body>' + string,
+			'text/html');
+		return dom.body.textContent;
+	}
+}
+
+module.exports = new CommonUtil();


### PR DESCRIPTION
Escaping is necessary to avoid any security risk but we need
to unescape those strings in order to show them in the frontend
otherwise it will have ugly special characters.

We already escape server name in the db and unesacoe it in
the left-sidebar. This PR adds the decodeString function in
order to unescape strings in the menu items.

Fixes: #554.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
