### PR TITLE
about: Remove Found bug button.

### DIFF
--- a/app/renderer/about.html
+++ b/app/renderer/about.html
@@ -19,7 +19,6 @@
 				Available under the
 				<a onclick="linkInBrowser('license')">Apache 2.0 License</a>
 			</p>
-			<a class="bug" onclick="linkInBrowser('bug')" href="#">Found bug?</a>
 		</div>
 	</div>
 	<script>
@@ -38,9 +37,6 @@
 				case 'license':
 					url = "https://github.com/zulip/zulip-electron/blob/master/LICENSE";
 					break;
-				default:
-					url = 'https://github.com/zulip/zulip-electron/issues/new?body=' +
-						'%3C!--Please%20describe%20your%20issue%20and%20steps%20to%20reproduce%20it.--%3E';
 			}
 			shell.openExternal(url);
 		}

--- a/app/renderer/css/about.css
+++ b/app/renderer/css/about.css
@@ -57,22 +57,6 @@ body {
 	width: 100%;
 }
 
-.maintenance-info .bug {
-	display: inline-block;
-	padding: 8px 15px;
-	margin-top: 30px;
-	text-decoration: none;
-	background-color: #52c2af;
-	color: #fff;
-	border-radius: 4px;
-
-	transition: background-color 0.2s ease;
-}
-
-.maintenance-info .bug:hover {
-	background-color: #32a692;
-}
-
 p.detail a {
 	color: #355f4c;
 }


### PR DESCRIPTION
Haven't tested this out. Was going to open an issue, but realized opening a PR was just as fast.

I think the about page is not a typical place for a "report issue" button, and it looks sort of off to see it there. 