### PR TITLE
menus: Rename a few menu items.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -125,22 +125,22 @@ class AppMenu {
 	getHelpSubmenu() {
 		return [
 			{
-				label: `${appName + ' Desktop-'} v${app.getVersion()}`,
+				label: `${appName + ' Desktop '} v${app.getVersion()}`,
 				enabled: false
 			},
 			{
-				label: `What's New...`,
+				label: `What's New`,
 				click() {
 					shell.openExternal(`https://github.com/zulip/zulip-electron/releases/tag/v${app.getVersion()}`);
 				}
 			},
 			{
-				label: `${appName} Help`,
+				label: `Help Center`,
 				click() {
 					shell.openExternal('https://zulipchat.com/help/');
 				}
 			}, {
-				label: 'Show App Logs',
+				label: 'Download App Logs',
 				click() {
 					const zip = new AdmZip();
 					let date = new Date();
@@ -158,7 +158,7 @@ class AppMenu {
 					shell.showItemInFolder(logFilePath);
 				}
 			}, {
-				label: 'Report an Issue...',
+				label: 'Report an Issue',
 				click() {
 					// the goal is to notify the main.html BrowserWindow
 					// which may not be the focused window.
@@ -217,7 +217,7 @@ class AppMenu {
 					}
 				}
 			}, {
-				label: `Check for Update`,
+				label: `Check for Updates`,
 				click() {
 					AppMenu.checkForUpdate();
 				}

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -125,7 +125,7 @@ class AppMenu {
 	getHelpSubmenu() {
 		return [
 			{
-				label: `${appName + ' Desktop '} v${app.getVersion()}`,
+				label: `${appName + ' Desktop'} v${app.getVersion()}`,
 				enabled: false
 			},
 			{

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -124,16 +124,10 @@ const createTray = function () {
 		}
 	},
 	{
-		type: 'separator'
-	},
-	{
 		label: 'Focus',
 		click() {
 			ipcRenderer.send('focus-app');
 		}
-	},
-	{
-		type: 'separator'
 	},
 	{
 		label: 'Settings',
@@ -141,9 +135,6 @@ const createTray = function () {
 			ipcRenderer.send('focus-app');
 			sendAction('open-settings');
 		}
-	},
-	{
-		type: 'separator'
 	},
 	{
 		label: 'Quit',

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -137,6 +137,9 @@ const createTray = function () {
 		}
 	},
 	{
+		type: 'separator'
+	},
+	{
 		label: 'Quit',
 		click() {
 			ipcRenderer.send('quit-app');


### PR DESCRIPTION
Have a few more suggestions to make, but these were faster to propose this way. Feel free to remove any changes you disagree with. 

The reason for the tray changes is that it currently just looks like the line spacing is broken.