### PR TITLE
Disable beta updates if auto updates disabled

### DIFF
--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -233,6 +233,10 @@ class GeneralSection extends BaseSection {
 			clickHandler: () => {
 				const newValue = !ConfigUtil.getConfigItem('autoUpdate');
 				ConfigUtil.setConfigItem('autoUpdate', newValue);
+				if (!newValue) {
+					ConfigUtil.setConfigItem('betaUpdate', false);
+					this.betaUpdateOption();
+				}
 				this.autoUpdateOption();
 			}
 		});

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -248,8 +248,10 @@ class GeneralSection extends BaseSection {
 			value: ConfigUtil.getConfigItem('betaUpdate', false),
 			clickHandler: () => {
 				const newValue = !ConfigUtil.getConfigItem('betaUpdate');
-				ConfigUtil.setConfigItem('betaUpdate', newValue);
-				this.betaUpdateOption();
+				if (ConfigUtil.getConfigItem('autoUpdate')) {
+					ConfigUtil.setConfigItem('betaUpdate', newValue);
+					this.betaUpdateOption();
+				}
 			}
 		});
 	}


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**If a user disables automatic updates in Preferences > General, they will no longer receive beta updates either.**

**Fixes issue #585**

As of now, the default behavior in the General pane allows the following setting:

<img width="525" alt="old" src="https://user-images.githubusercontent.com/24617297/47349280-ec40a000-d6d0-11e8-8091-27bf6c956f8d.PNG">


This PR disallows the above and enforces the following:

<img width="526" alt="new" src="https://user-images.githubusercontent.com/24617297/47349188-b4d1f380-d6d0-11e8-8749-14c2775d3d70.PNG">


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
