### PR TITLE
menu: Update menu items on setting page.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -232,7 +232,7 @@ class AppMenu {
 	}
 
 	getDarwinTpl(props) {
-		const { tabs, activeTabIndex } = props;
+		const { tabs, activeTabIndex, enableMenu } = props;
 
 		return [{
 			label: `${app.getName()}`,
@@ -247,6 +247,7 @@ class AppMenu {
 			}, {
 				label: 'Keyboard Shortcuts',
 				accelerator: 'Cmd+Shift+K',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('shortcut');
@@ -264,6 +265,7 @@ class AppMenu {
 			}, {
 				label: 'Log Out',
 				accelerator: 'Cmd+L',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('log-out');
@@ -325,7 +327,7 @@ class AppMenu {
 	}
 
 	getOtherTpl(props) {
-		const { tabs, activeTabIndex } = props;
+		const { tabs, activeTabIndex, enableMenu } = props;
 
 		return [{
 			label: '&File',
@@ -342,6 +344,7 @@ class AppMenu {
 			}, {
 				label: 'Keyboard Shortcuts',
 				accelerator: 'Ctrl+Shift+K',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('shortcut');
@@ -359,6 +362,7 @@ class AppMenu {
 			}, {
 				label: 'Log Out',
 				accelerator: 'Ctrl+L',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('log-out');

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -308,6 +308,7 @@ class ServerManagerView {
 		this.functionalTabs[tabProps.name] = this.tabs.length;
 
 		const tabIndex = this.getTabIndex();
+
 		this.tabs.push(new FunctionalTab({
 			role: 'function',
 			materialIcon: tabProps.materialIcon,
@@ -332,9 +333,11 @@ class ServerManagerView {
 				preload: false
 			})
 		}));
+
 		// To show loading indicator the first time a functional tab is opened, indicator is
 		// closed when the functional tab DOM is ready, handled in webview.js
 		this.$webviewsContainer.classList.remove('loaded');
+
 		this.activateTab(this.functionalTabs[tabProps.name]);
 	}
 
@@ -398,7 +401,8 @@ class ServerManagerView {
 
 		ipcRenderer.send('update-menu', {
 			tabs: this.tabs,
-			activeTabIndex: this.activeTabIndex
+			activeTabIndex: this.activeTabIndex,
+			enableMenu: this.tabs[index].props.role === 'server'
 		});
 	}
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -402,6 +402,7 @@ class ServerManagerView {
 		ipcRenderer.send('update-menu', {
 			tabs: this.tabs,
 			activeTabIndex: this.activeTabIndex,
+			// Following flag controls whether a menu item should be enabled or not
 			enableMenu: this.tabs[index].props.role === 'server'
 		});
 	}


### PR DESCRIPTION
This PR adds a functionality to update the menu items.
Some menu items like logout, shortcut etc are not needed
on setting page.

Fixes: #587.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
