### PR TITLE
network: Fix `request` ecdhCurve mismatch errors

### DIFF
--- a/app/main/linuxupdater.js
+++ b/app/main/linuxupdater.js
@@ -21,7 +21,8 @@ function linuxUpdateNotification() {
 	const options = {
 		url,
 		headers: {'User-Agent': 'request'},
-		proxy: proxyEnabled ? ProxyUtil.getProxy(url) : ''
+		proxy: proxyEnabled ? ProxyUtil.getProxy(url) : '',
+		ecdhCurve: 'auto'
 	};
 
 	request(options, (error, response, body) => {

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -129,7 +129,8 @@ class DomainUtil {
 		const checkDomain = {
 			url: domain + '/static/audio/zulip.ogg',
 			ca: (certificateLocation) ? certificateLocation : '',
-			proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : ''
+			proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : '',
+			ecdhCurve: 'auto'
 		};
 
 		const serverConf = {
@@ -206,7 +207,8 @@ class DomainUtil {
 		const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy') || ConfigUtil.getConfigItem('useSystemProxy');
 		const serverSettingsOptions = {
 			url: domain + '/api/v1/server_settings',
-			proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : ''
+			proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : '',
+			ecdhCurve: 'auto'
 		};
 		return new Promise((resolve, reject) => {
 			request(serverSettingsOptions, (error, response) => {
@@ -232,7 +234,8 @@ class DomainUtil {
 		const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy') || ConfigUtil.getConfigItem('useSystemProxy');
 		const serverIconOptions = {
 			url,
-			proxy: proxyEnabled ? ProxyUtil.getProxy(url) : ''
+			proxy: proxyEnabled ? ProxyUtil.getProxy(url) : '',
+			ecdhCurve: 'auto'
 		};
 		// The save will always succeed. If url is invalid, downgrade to default icon.
 		return new Promise(resolve => {


### PR DESCRIPTION
Fix `request` ecdhCurve mismatch errors by passing `ecdhCurve: 'auto'` to options

As investigated in #594, adding a self-hosted organisation fails if the app is behing a [Nginx >= 1.10.0 ](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ecdh_curve) reverse proxy with config `ssl_ecdh_curve secp384r1;` which is [the recommended ecdh curve](https://cipherli.st/) and if Node > 8.5 is used. 

Setting `ecdhCurve` to `"auto"` leaves the ecdh curve choice and its security outcomes on the hosting server admin.  
I suppose this could lead to weak ecdh curves used - I don't know a bit about whether this exists and is supported - so maybe we could try to detect this, but I don't know if we can, and how.
So I guess the best option is to ensure secure ecdh curves are properly supported thanks to the 'auto' option, without breaking for other users using weaker curves.

Tested on 2.3.82 Mac OS Mojave 10.14.1, running smooth, added, removed and re-added my org without any issue.
