### PR TITLE
Make org tabs draggable in sidebar

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "node-json-db": "0.9.2",
     "request": "2.85.0",
     "semver": "5.4.1",
+    "sortablejs": "1.10.0-rc3",
     "wurl": "2.5.0"
   },
   "optionalDependencies": {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -253,6 +253,7 @@ class ServerManagerView {
 			el.setAttribute('data-tab-id', index.toString());
 		});
 		this.servers = newServers;
+		DomainUtil.batchUpdateDomain(this.servers);
 		this.reloadView(false);
 	}
 

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -64,6 +64,13 @@ class DomainUtil {
 		this.db.push(`/domains[${index}]`, server, true);
 	}
 
+	batchUpdateDomain(servers: Domain[]): void {
+		this.db.delete('/domains');
+		for (const server of servers) {
+			this.db.push('/domains[]', server, true);
+		}
+	}
+
 	addDomain(server: any): Promise<void> {
 		const { ignoreCerts } = server;
 		return new Promise(resolve => {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -54,3 +54,10 @@ interface ZulipWebWindow extends Window {
     $: any;
     lightbox: any;
 }
+
+interface Domain {
+  icon: string;
+  url: string;
+  alias: string;
+  ignoreCerts: boolean;
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,6 +12,7 @@ declare module 'escape-html';
 declare module 'fs-extra';
 declare module 'wurl';
 declare module 'i18n';
+declare module 'sortablejs';
 
 interface PageParamsObject {
     realm_uri: string;


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Updates `domains.json` on dragging server tabs and (intends to) reorder server tooltips along with that. 

**Any background context you want to provide?**
Please refer to the discussion in #548.

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS

**Current behaviour on Windows 10 (CSS animations by `sortablejs` not recorded by Windows Game Bar)**
![zulip1001201902_01_27am](https://user-images.githubusercontent.com/24617297/50927160-f4f97480-147c-11e9-8c55-e08bb7775975.gif)

**Problems in current version**
On my computer, the server tab freezes for a bit before I can switch tabs again. 

**Other possible solutions that I considered**
1. We could just change the server names if we're able to also map the hoverable area of a server tab properly. 
2. We could swap the tooltips' nodes in the DOM (they're just sibling nodes, we should be able to `replaceChild()` as long as we maintain clones of the old tooltip node. 