### PR TITLE
Fix flashing icons of servers in sidebar

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -312,11 +312,24 @@ class ServerManagerView {
 		if (servers.length > 0) {
 			for (let i = 0; i < servers.length; i++) {
 				this.initServer(servers[i], i);
-				DomainUtil.updateSavedServer(servers[i].url, i);
-				this.activateTab(i);
 			}
 			// Open last active tab
-			this.activateTab(ConfigUtil.getConfigItem('lastActiveTab'));
+			let lastActiveTab = ConfigUtil.getConfigItem('lastActiveTab');
+			if (lastActiveTab >= servers.length) {
+				lastActiveTab = 0;
+			}
+			// checkDomain() and webview.load() for lastActiveTab before the others
+			DomainUtil.updateSavedServer(servers[lastActiveTab].url, lastActiveTab);
+			this.activateTab(lastActiveTab);
+			for (let i = 0; i < servers.length; i++) {
+				// after the lastActiveTab is activated, we load the others in the background
+				// without activating them, to prevent flashing of server icons
+				if (i === lastActiveTab) {
+					continue;
+				}
+				DomainUtil.updateSavedServer(servers[i].url, i);
+				this.tabs[i].webview.load();
+			}
 			// Remove focus from the settings icon at sidebar bottom
 			this.$settingsButton.classList.remove('active');
 		} else if (this.presetOrgs.length === 0) {


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Changes order in which servers are loaded and rendered in the sidebar. I'd like to stop doing the latter half by retaining the server tabs

**Any background context you want to provide?**
#551 should provide the required context. 
I've changed the order of loading servers, but rendering items in the sidebar according to the old order is turning out to be a problem (my understanding of how `initServer()` works is faulty here. Does it not render `this.tabs` in `app/renderer/js/main.js` according to the order in which the elements are present in the array?)

This problem is similar to the one I'm currently facing in https://github.com/zulip/zulip-electron/pull/617. 

**Screenshots?** (according to https://github.com/zulip/zulip-electron/pull/621/commits/3ec20ca9f96a633d9229e746adf0144d0bb62d94, last updated on Jan 7)

![zulip0701201905_05_54pm](https://user-images.githubusercontent.com/24617297/50766441-392f1e00-129f-11e9-94cb-1d0dad769211.gif)

The refresh you see has been forced by me. 

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
