### PR TITLE
notification: Ensure backward compatibilty when using narrow.by_topic.

### DIFF
--- a/app/renderer/js/notification/helpers.js
+++ b/app/renderer/js/notification/helpers.js
@@ -141,7 +141,8 @@ function parseReply(reply) {
 
 function setupReply(id) {
 	const { narrow } = window;
-	narrow.by_topic(id, { trigger: 'notification' });
+	const narrowByTopic = narrow.by_topic || narrow.by_subject;
+	narrowByTopic(id, { trigger: 'notification' });
 }
 
 module.exports = {


### PR DESCRIPTION
We should ensure backward compatibilty when using narrow.by_topic since
the recent rename in the webapp of the function narrow.by_subject to
narrow.by_topic is only in master and not in any stable release yet it
could break the notification function for many people. Furthermore this ensure
general backward-compatibilty.