### PR TITLE
[WIP] Mute organization badge and server count

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -179,6 +179,11 @@ td:nth-child(odd) {
     margin-top: 10px;
 }
 
+.add-server-mute-notifications {
+    display: flex;
+    margin-top: 8px 0 0 0;
+}
+
 .sub-title {
     padding: 4px 0 6px 0;
     font-weight: bold;
@@ -351,6 +356,19 @@ img.server-info-icon {
 
 .green:hover {
     background-color: #3c9f8d;
+    color: #fff;
+}
+
+.gray {
+    color: #9E9E9E;
+    padding: 8px;
+    border: rgba(192, 192, 192, 0.3) solid 1px;
+    border-radius: 4px;
+    border-color: #fff;
+}
+
+.gray:hover {
+    background-color: rgba(192, 192, 192, 0.3);
     color: #fff;
 }
 

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -116,10 +116,15 @@ class WebView extends BaseComponent {
 		});
 	}
 
+	updateBadgeCount(count) {
+		this.badgeCount = count;
+		this.props.onTitleChange();
+	}
+
 	getBadgeCount(title) {
 		const mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
 		const { url } = this.props;
-		if (!!mutedOrganizations[url]) {
+		if (mutedOrganizations[url]) {
 			return 0;
 		}
 		const messageCountInTitle = (/\(([0-9]+)\)/).exec(title);

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -117,6 +117,11 @@ class WebView extends BaseComponent {
 	}
 
 	getBadgeCount(title) {
+		const mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
+		const { url } = this.props;
+		if (!!mutedOrganizations[url]) {
+			return 0;
+		}
 		const messageCountInTitle = (/\(([0-9]+)\)/).exec(title);
 		return messageCountInTitle ? Number(messageCountInTitle[1]) : 0;
 	}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -541,7 +541,7 @@ class ServerManagerView {
 							type: 'warning',
 							buttons: ['YES', 'NO'],
 							defaultId: 0,
-							message: 'Are you sure you want to ' + (!!url ? 'unmute' : 'mute') + ' this organization?'
+							message: 'Are you sure you want to ' + (!!mutedOrganizations[url] ? 'unmute' : 'mute') + ' this organization?'
 						}, response => {
 							if (response === 0) {
 								let server = DomainUtil.getDomain(index);

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -530,6 +530,24 @@ class ServerManagerView {
 							}
 						});
 					}
+				}, 
+				{
+					label: DomainUtil.getDomain(index).notify === true ? 'Mute' : 'Unmute' + ' organization',
+					click: () => {
+						dialog.showMessageBox({
+							type: 'warning',
+							buttons: ['YES', 'NO'],
+							defaultId: 0,
+							message: 'Are you sure you want to ' + (DomainUtil.getDomain(index).notify === true ? 'mute' : 'unmute') + ' this organization?'
+						}, response => {
+							if (response === 0) {
+								let server = DomainUtil.getDomain(index);
+								server.notify = !server.notify;
+								DomainUtil.updateDomain(index, server);
+								ipcRenderer.send('reload-full-app');
+							}
+						});
+					}
 				}
 			];
 			const contextMenu = Menu.buildFromTemplate(template);

--- a/app/renderer/js/pages/preference/connected-org-section.js
+++ b/app/renderer/js/pages/preference/connected-org-section.js
@@ -42,12 +42,13 @@ class ConnectedOrgSection extends BaseSection {
 		const noServerText = 'All the connected orgnizations will appear here';
 		// Show noServerText if no servers are there otherwise hide it
 		this.$existingServers.innerHTML = servers.length === 0 ? noServerText : '';
-
+		
 		for (let i = 0; i < servers.length; i++) {
 			new ServerInfoForm({
 				$root: this.$serverInfoContainer,
 				server: servers[i],
 				index: i,
+				muteText: servers[i].notify === true ? 'Mute' : 'Unmute',
 				onChange: this.reloadApp
 			}).init();
 		}

--- a/app/renderer/js/pages/preference/connected-org-section.js
+++ b/app/renderer/js/pages/preference/connected-org-section.js
@@ -44,13 +44,12 @@ class ConnectedOrgSection extends BaseSection {
 		const noServerText = 'All the connected orgnizations will appear here';
 		// Show noServerText if no servers are there otherwise hide it
 		this.$existingServers.innerHTML = servers.length === 0 ? noServerText : '';
-		
 		for (let i = 0; i < servers.length; i++) {
 			new ServerInfoForm({
 				$root: this.$serverInfoContainer,
 				server: servers[i],
 				index: i,
-				muteText: !!mutedOrganizations[servers[i].url] ? 'Unmute' : 'Mute',
+				muteText: mutedOrganizations[servers[i].url] ? 'Unmute' : 'Mute',
 				onChange: this.reloadApp
 			}).init();
 		}

--- a/app/renderer/js/pages/preference/connected-org-section.js
+++ b/app/renderer/js/pages/preference/connected-org-section.js
@@ -4,6 +4,7 @@ const BaseSection = require(__dirname + '/base-section.js');
 const DomainUtil = require(__dirname + '/../../utils/domain-util.js');
 const ServerInfoForm = require(__dirname + '/server-info-form.js');
 const AddCertificate = require(__dirname + '/add-certificate.js');
+const ConfigUtil = require(__dirname + '/../../utils/config-util.js');
 
 class ConnectedOrgSection extends BaseSection {
 	constructor(props) {
@@ -32,6 +33,7 @@ class ConnectedOrgSection extends BaseSection {
 		this.props.$root.innerHTML = '';
 
 		const servers = DomainUtil.getDomains();
+		const mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
 		this.props.$root.innerHTML = this.template();
 
 		this.$serverInfoContainer = document.getElementById('server-info-container');
@@ -48,7 +50,7 @@ class ConnectedOrgSection extends BaseSection {
 				$root: this.$serverInfoContainer,
 				server: servers[i],
 				index: i,
-				muteText: servers[i].notify === true ? 'Mute' : 'Unmute',
+				muteText: !!mutedOrganizations[servers[i].url] ? 'Unmute' : 'Mute',
 				onChange: this.reloadApp
 			}).init();
 		}

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -79,15 +79,16 @@ class ServerInfoForm extends BaseComponent {
 			}, response => {
 				if (response === 0) {
 					const url = this.props.server.url;
-					let mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
-					if (!!mutedOrganizations[url]) {
-						// server is already muted
-						delete mutedOrganizations[url];
+					const muteLabel = this.props.$root.children[this.props.index].children[1].children[1].children[0];
+					const mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
+					if (mutedOrganizations[url]) {
+						muteLabel.innerHTML = 'Mute';
+						this.props.muteText = 'Mute';
 					} else {
-						mutedOrganizations[url] = true;
+						muteLabel.innerHTML = 'Unmute';
+						this.props.muteText = 'Unmute';
 					}
-					ConfigUtil.setConfigItem('mutedOrganizations', mutedOrganizations);
-					ipcRenderer.send('reload-full-app');
+					ipcRenderer.send('forward-message', 'mute-org', this.props.index);
 				}
 			});
 		});

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -26,6 +26,10 @@ class ServerInfoForm extends BaseComponent {
 						<span class="server-url-info" title="${this.props.server.url}">${this.props.server.url}</span>
 					</div>
 					<div class="server-info-row">
+						<div class="action gray server-mute-notifications">
+						<span>${this.props.muteText}</span>
+					</div>
+					<div class="server-info-row">
 						<div class="action red server-delete-action">
 							<span>Disconnect</span>
 						</div>
@@ -46,6 +50,7 @@ class ServerInfoForm extends BaseComponent {
 		this.$serverIcon = this.$serverInfoForm.getElementsByClassName('server-info-icon')[0];
 		this.$deleteServerButton = this.$serverInfoForm.getElementsByClassName('server-delete-action')[0];
 		this.$openServerButton = this.$serverInfoForm.getElementsByClassName('open-tab-button')[0];
+		this.$muteServerButton = this.$serverInfoForm.getElementsByClassName('server-mute-notifications')[0];
 		this.props.$root.appendChild(this.$serverInfoForm);
 	}
 
@@ -59,6 +64,22 @@ class ServerInfoForm extends BaseComponent {
 			}, response => {
 				if (response === 0) {
 					DomainUtil.removeDomain(this.props.index);
+					this.props.onChange(this.props.index);
+				}
+			});
+		});
+
+		this.$muteServerButton.addEventListener('click', () => {
+			dialog.showMessageBox({
+				type: 'warning',
+				buttons: ['YES', 'NO'],
+				defaultId: 0,
+				message: 'Are you sure you want to ' + this.props.muteText.toLowerCase() + ' this organization?'
+			}, response => {
+				if (response === 0) {
+					let server = this.props.server;
+					server.notify = !server.notify;
+					DomainUtil.updateDomain(index, server);
 					this.props.onChange(this.props.index);
 				}
 			});

--- a/app/renderer/js/pages/preference/server-info-form.js
+++ b/app/renderer/js/pages/preference/server-info-form.js
@@ -4,6 +4,7 @@ const { ipcRenderer } = require('electron');
 
 const BaseComponent = require(__dirname + '/../../components/base.js');
 const DomainUtil = require(__dirname + '/../../utils/domain-util.js');
+const ConfigUtil = require(__dirname + '/../../utils/config-util.js');
 
 class ServerInfoForm extends BaseComponent {
 	constructor(props) {
@@ -77,10 +78,16 @@ class ServerInfoForm extends BaseComponent {
 				message: 'Are you sure you want to ' + this.props.muteText.toLowerCase() + ' this organization?'
 			}, response => {
 				if (response === 0) {
-					let server = this.props.server;
-					server.notify = !server.notify;
-					DomainUtil.updateDomain(index, server);
-					this.props.onChange(this.props.index);
+					const url = this.props.server.url;
+					let mutedOrganizations = ConfigUtil.getConfigItem('mutedOrganizations');
+					if (!!mutedOrganizations[url]) {
+						// server is already muted
+						delete mutedOrganizations[url];
+					} else {
+						mutedOrganizations[url] = true;
+					}
+					ConfigUtil.setConfigItem('mutedOrganizations', mutedOrganizations);
+					ipcRenderer.send('reload-full-app');
 				}
 			});
 		});


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Adds context menu and settings option to mute/unmute badge count of connected organizations. 

**Any background context you want to provide?**
https://github.com/zulip/zulip-electron/issues/623 should provide the required context. Please also have a look at the chat thread referenced.

**Screenshots?**
![image](https://user-images.githubusercontent.com/24617297/51103833-2e7a0900-180a-11e9-98d5-5e6a1a6dac41.png)
![image](https://user-images.githubusercontent.com/24617297/51103850-405bac00-180a-11e9-9129-9bc55624cfc6.png)

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
