### PR TITLE
tray: Allow switching to a specific realm tab from the context menu

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -276,6 +276,10 @@ app.on('ready', () => {
 		page.send('update-tray', props.tabs);
 	});
 
+	ipcMain.on('update-tray', (event, tabs) => {
+		page.send('update-tray', tabs);
+	});
+
 	ipcMain.on('toggleAutoLauncher', (event, AutoLaunchValue) => {
 		setAutoLaunch(AutoLaunchValue);
 	});

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -186,8 +186,8 @@ app.on('ready', () => {
 
 	// Temporarily remove this event
 	// electron.powerMonitor.on('resume', () => {
-	// 	mainWindow.reload();
-	// 	page.send('destroytray');
+	//	mainWindow.reload();
+	//	page.send('destroytray');
 	// });
 
 	ipcMain.on('focus-app', () => {
@@ -273,6 +273,7 @@ app.on('ready', () => {
 		if (activeTab) {
 			mainWindow.setTitle(`Zulip - ${activeTab.webview.props.name}`);
 		}
+		page.send('update-tray', props.tabs);
 	});
 
 	ipcMain.on('toggleAutoLauncher', (event, AutoLaunchValue) => {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -395,6 +395,7 @@ class ServerManagerView {
 
 			tabClone.webview = { props: {} };
 			tabClone.webview.props.name = tab.webview.props.name;
+			tabClone.webview.props.badgeCount = tab.webview.badgeCount;
 			delete tabClone.props.webview;
 			tabs.push(tabClone);
 		});
@@ -493,7 +494,7 @@ class ServerManagerView {
 				this.tabs[i].updateBadge(count);
 			}
 		}
-
+		ipcRenderer.send('update-tray', this.tabsForIpc);
 		ipcRenderer.send('update-badge', messageCountAll);
 	}
 

--- a/app/renderer/js/tray.js
+++ b/app/renderer/js/tray.js
@@ -117,8 +117,10 @@ function sendAction(action, ...params) {
 
 const createContextMenuTemplate = function (tabs) {
 	const tabMenuItems = tabs.map(tab => {
+		const { name, badgeCount } = tab.webview.props;
+		const label = badgeCount === 0 ? name : `${name} (${badgeCount})`;
 		return {
-			label: tab.webview.props.name,
+			label,
 			click() {
 				ipcRenderer.send('focus-app');
 				sendAction('switch-server-tab', tab.props.index);


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

This PR adds functionality to be able to switch to a specific Realm tab from the system tray menu. 

**Screenshots?**

![screenshot-tray-menu](https://user-images.githubusercontent.com/315678/51453277-70ec9a00-1d64-11e9-9e26-8cd5ceef0ac7.jpg)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
