### PR TITLE
certificate: Use path.sep for path separator to support Windows.

### DIFF
--- a/app/renderer/js/pages/preference/add-certificate.js
+++ b/app/renderer/js/pages/preference/add-certificate.js
@@ -1,6 +1,7 @@
 'use-strict';
 
 const { dialog } = require('electron').remote;
+const path = require('path');
 
 const BaseComponent = require(__dirname + '/../../components/base.js');
 const CertificateUtil = require(__dirname + '/../../utils/certificate-util.js');
@@ -41,7 +42,7 @@ class AddCertificate extends BaseComponent {
 		const serverUrl = this.serverUrl.value;
 		if (certificate !== '' && serverUrl !== '') {
 			const server = encodeURIComponent(DomainUtil.formatUrl(serverUrl));
-			const fileName = certificate.substring(certificate.lastIndexOf('/') + 1);
+			const fileName = certificate.substring(certificate.lastIndexOf(path.sep) + 1);
 			const copy = CertificateUtil.copyCertificate(server, certificate, fileName);
 			if (!copy) {
 				return;


### PR DESCRIPTION
Earlier path separator was hard-code to "/" which failed in Windows. Now, [`path.sep`](https://nodejs.org/api/path.html#path_path_sep) return `/` for POSIX and `\` for Windows.