### PR TITLE
Change the window title to contain active Realm's name

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -269,6 +269,10 @@ app.on('ready', () => {
 
 	ipcMain.on('update-menu', (event, props) => {
 		appMenu.setMenu(props);
+		const activeTab = props.tabs[props.activeTabIndex];
+		if (activeTab) {
+			mainWindow.setTitle(`Zulip - ${activeTab.webview.props.name}`);
+		}
 	});
 
 	ipcMain.on('toggleAutoLauncher', (event, AutoLaunchValue) => {


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Change the window title to display the currently active Realm's name. 

**Any background context you want to provide?**

It helps human readers, and also makes data more useful if using a window title based logger (like RescueTime or ActivityWatch)

**Screenshots?**
![image](https://user-images.githubusercontent.com/315678/51543624-02066280-1e84-11e9-8683-6b3239bf5695.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
