### PR TITLE
webview: Work around buggy focus switching in Electron 3.0.10

### DIFF
--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -170,7 +170,13 @@ class WebView extends BaseComponent {
 	focus() {
 		// focus Webview and it's contents when Window regain focus.
 		const webContents = this.$el.getWebContents();
-		if (webContents && !webContents.isFocused()) {
+		// HACK: webContents.isFocused() seems to be true even without the element
+		// being in focus. So, we check against `document.activeElement`.
+		if (webContents && this.$el !== document.activeElement) {
+			// HACK: Looks like blur needs to be called on the previously focused
+			// element to transfer focus correctly, in Electron v3.0.10
+			// See https://github.com/electron/electron/issues/15718
+			document.activeElement.blur();
 			this.$el.focus();
 			webContents.focus();
 		}


### PR DESCRIPTION
This commit works around a couple of bugs, which seem to be upstream bugs in the
current version of Electron.

First, `webContents.isFocused()` seems to be true even if we just switched to
a tab, and are trying to set it as the focused element. To workaround this, we
check if the `webview` element is the same as `document.activeElement`.

Also, as per https://github.com/electron/electron/issues/15718, it looks like
`blur` needs to be called on the currently active element, before switching
focus to another element i.e., calling `focus` on it.

Closes #634 