### PR TITLE
add request options

### DIFF
--- a/app/renderer/js/utils/request-util.js
+++ b/app/renderer/js/utils/request-util.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const Logger = require('./logger-util');
+
+const CertificateUtil = require(__dirname + '/certificate-util.js');
+const ProxyUtil = require(__dirname + '/proxy-util.js');
+const ConfigUtil = require(__dirname + '/config-util.js');
+const SystemUtil = require(__dirname + '/../utils/system-util.js');
+
+const logger = new Logger({
+	file: `request-util.log`,
+	timestamp: true
+});
+
+let instance = null;
+
+class RequestUtil {
+	constructor() {
+		if (!instance) {
+			instance = this;
+		}
+		return instance;
+	}
+
+	// ignoreCerts parameter helps in fetching server icon and
+	// other server details when user chooses to ignore certificate warnings
+	requestOptions(domain, ignoreCerts) {
+		domain = this.formatUrl(domain);
+		const certificate = CertificateUtil.getCertificate(
+			encodeURIComponent(domain)
+		);
+		let certificateLocation = '';
+		if (certificate) {
+			// To handle case where certificate has been moved from the location in certificates.json
+			try {
+				certificateLocation = fs.readFileSync(certificate);
+			} catch (err) {
+				logger.warn('Error while trying to get certificate: ' + err);
+			}
+		}
+		const proxyEnabled = ConfigUtil.getConfigItem('useManualProxy') || ConfigUtil.getConfigItem('useSystemProxy');
+		// If certificate for the domain exists add it as a ca key in the request's parameter else consider only domain as the parameter for request
+		// Add proxy as a parameter if it is being used.
+		return {
+			ca: certificateLocation ? certificateLocation : '',
+			proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : '',
+			ecdhCurve: 'auto',
+			headers: { 'User-Agent': SystemUtil.getUserAgent() },
+			rejectUnauthorized: !ignoreCerts
+		};
+	}
+
+	formatUrl(domain) {
+		const hasPrefix = (domain.indexOf('http') === 0);
+		if (hasPrefix) {
+			return domain;
+		} else {
+			return (domain.indexOf('localhost:') >= 0) ? `http://${domain}` : `https://${domain}`;
+		}
+	}
+}
+
+module.exports = new RequestUtil();


### PR DESCRIPTION
**What's this PR do?**
This PR creates a new file request-util.js which replaces every request option in domain-util.js with requestOptions() as mentioned in #603 .

**Any background context you want to provide?**
 As mentioned in #598  it is better to write a requestOptions function that takes the domain as input and return the appropriate object according to domain and settings to be used request function,

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS

 closes #603 
