### PR TITLE
Fixed:Broken image icon in left sidebar and typo in classname #630

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -170,6 +170,19 @@ body {
     border-radius: 4px;
 }
 
+.tab .server-icons:not(.alt-icon):before { 
+    content: attr(data-content);
+    font-family: Verdana;
+    font-weight: 600;
+    font-size: 22px;
+    border: 2px solid #222c31;
+    position: absolute;
+    left: 0;
+    width: 35px;
+    margin-left: 17%;
+    border-radius: 4px;
+}
+
 .tab .server-tab {
     width: 100%;
     height: 35px;

--- a/app/renderer/js/components/server-tab.js
+++ b/app/renderer/js/components/server-tab.js
@@ -11,7 +11,7 @@ class ServerTab extends Tab {
 					<div class="server-tooltip" style="display:none">${this.props.name}</div>
 					<div class="server-tab-badge"></div>
 					<div class="server-tab">
-					<img class="server-icons" src='${this.props.icon}'/>
+					<img class="server-icons" src='${this.props.icon}' alt="" data-content='${this.props.name[0]}'/>
 					</div>
 					<div class="server-tab-shortcut">${this.generateShortcutText()}</div>
 				</div>`;

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -267,11 +267,12 @@ class ServerManagerView {
 		}
 
 		$altIcon.textContent = realmName.charAt(0) || 'Z';
-		$altIcon.classList.add('server-icon');
+		$altIcon.classList.add('server-icons');
 		$altIcon.classList.add('alt-icon');
 
 		$parent.removeChild($img);
 		$parent.appendChild($altIcon);
+		$parent.setAttribute('data-content', '');
 
 		this.addContextMenu($altIcon, $webview.getAttribute('data-tab-id'));
 	}


### PR DESCRIPTION
**What's this PR do?**
The initial letter of Organistaion's name is shown instead of broken image when the app starts and typing mistake in main.js file in classname is fixed.

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
Fixes #562 