### PR TITLE
Shorcut section horizontal alignment fix

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -287,6 +287,7 @@ img.server-info-icon {
 
 .settings-pane {
     flex-grow: 1;
+	min-width: 550px;
 }
 
 .action:hover {


### PR DESCRIPTION

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
the horizontal alignment of shortcut section deteriorate when window size is less but this PR fix this problem and user can navigate shortcut's through horizontal scrollbar when window size is low 

**Screenshots?**
**before**
![screenshot from 2019-02-18 10-49-28](https://user-images.githubusercontent.com/36422396/52929583-06327c80-336b-11e9-8f63-613ae1d1397b.png)

**after**
![screenshot from 2019-02-14 00-35-28](https://user-images.githubusercontent.com/36422396/52736732-8dd95d80-2ff0-11e9-8063-c33bbdb4ab77.png)

**tested this PR on:**
  - [ ] Ubuntu 18.10
