### PR TITLE
Add URL copy/paster to left sidebar

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -420,20 +420,18 @@ webview.focus {
 .url-container {
     position: absolute;
     margin-left: 53px;
+    margin-top: 5px;
 }
 
 .url-input-value {
     flex-grow: 1;
+    margin-left: 2px;
     font-size: 14px;
     border-radius: 4px;
     padding: 6px 8px;
     border: #ededed 2px solid;
     background: #fff;
     max-width: 450px;
-}
-
-.url-input-value:focus {
-    border: #4EBFAC 2px solid;
 }
 
 

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -417,6 +417,25 @@ webview.focus {
     display: none !important;
 }
 
+.url-container {
+    position: absolute;
+    margin-left: 53px;
+}
+
+.url-input-value {
+    flex-grow: 1;
+    font-size: 14px;
+    border-radius: 4px;
+    padding: 6px 8px;
+    border: #ededed 2px solid;
+    background: #fff;
+    max-width: 450px;
+}
+
+.url-input-value:focus {
+    border: #4EBFAC 2px solid;
+}
+
 
 /* Full screen Popup container  */
 

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -331,6 +331,7 @@ webview.focus {
 #dnd-tooltip,
 #back-tooltip,
 #reload-tooltip,
+#url-tooltip,
 #setting-tooltip {
     font-family: sans-serif;
     background: #222c31;
@@ -349,6 +350,7 @@ webview.focus {
 #dnd-tooltip:after,
 #back-tooltip:after,
 #reload-tooltip:after,
+#url-tooltip:after,
 #setting-tooltip:after {
     content: " ";
     border-top: 8px solid transparent;

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -267,6 +267,10 @@ body {
     margin-bottom: 5px;
 }
 
+.invalid-input-value:focus {
+    border: #ef5350 2px solid;
+}
+
 
 /*******************
   *   Webview Area  *

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -31,6 +31,7 @@ class ServerManagerView {
 
 		const $actionsContainer = document.getElementById('actions-container');
 		this.$reloadButton = $actionsContainer.querySelector('#reload-action');
+		this.$urlButton = $actionsContainer.querySelector('#url-action');
 		this.$settingsButton = $actionsContainer.querySelector('#settings-action');
 		this.$webviewsContainer = document.getElementById('webviews-container');
 		this.$backButton = $actionsContainer.querySelector('#back-action');
@@ -38,6 +39,7 @@ class ServerManagerView {
 
 		this.$addServerTooltip = document.getElementById('add-server-tooltip');
 		this.$reloadTooltip = $actionsContainer.querySelector('#reload-tooltip');
+		this.$urlTooltip = $actionsContainer.querySelector('#url-tooltip');
 		this.$settingsTooltip = $actionsContainer.querySelector('#setting-tooltip');
 		this.$serverIconTooltip = document.getElementsByClassName('server-tooltip');
 		this.$backTooltip = $actionsContainer.querySelector('#back-tooltip');
@@ -236,6 +238,7 @@ class ServerManagerView {
 		});
 
 		this.sidebarHoverEvent(this.$addServerButton, this.$addServerTooltip, true);
+		this.sidebarHoverEvent(this.$urlButton, this.$urlTooltip);
 		this.sidebarHoverEvent(this.$settingsButton, this.$settingsTooltip);
 		this.sidebarHoverEvent(this.$reloadButton, this.$reloadTooltip);
 		this.sidebarHoverEvent(this.$backButton, this.$backTooltip);

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -468,7 +468,9 @@ class ServerManagerView {
 				this.tabs[this.activeTabIndex].deactivate();
 			}
 		}
-
+		if (this.urlEnabled) {
+			this.toggleUrlContainer();
+		}
 		try {
 			this.tabs[index].webview.canGoBackButton();
 		} catch (err) {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -251,13 +251,35 @@ class ServerManagerView {
 		this.sidebarHoverEvent(this.$dndButton, this.$dndTooltip);
 	}
 
+	isURLSaved(url) {
+		for (let i = 0; i < this.tabs.length; ++i) {
+			const tabURL = this.tabs[i].webview.props.url;
+			if (url === tabURL) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	initURLShortcut() {
+		this.$urlField.addEventListener('keypress', event => {
+			if (event.keyCode === 13) {
+				const url = this.$urlField.value;
+				const urlIndex = this.isURLSaved(url);
+				if (urlIndex >= 0) {
+					this.activateTab(urlIndex);
+				}
+			}
+		});
+	}
+
 	toggleUrlContainer() {
 		if (this.urlEnabled) {
 			this.$urlField.type = 'hidden';
 		} else {
+			this.initURLShortcut();
 			this.$urlField.value = this.tabs[this.activeTabIndex].webview.props.url;
 			const { top, height } = this.$urlButton.getBoundingClientRect();
-			this.$urlField.style.top = top + 'px';
 			this.$urlField.style.height = (height / 2) + 'px';
 			this.$urlField.type = 'url';
 		}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -45,6 +45,9 @@ class ServerManagerView {
 		this.$backTooltip = $actionsContainer.querySelector('#back-tooltip');
 		this.$dndTooltip = $actionsContainer.querySelector('#dnd-tooltip');
 
+		this.$urlField = document.getElementById('url-input-container').children[0];
+		this.urlEnabled = false;
+
 		this.$sidebar = document.getElementById('sidebar');
 
 		this.$fullscreenPopup = document.getElementById('fullscreen-popup');
@@ -230,6 +233,9 @@ class ServerManagerView {
 		this.$addServerButton.addEventListener('click', () => {
 			this.openSettings('AddServer');
 		});
+		this.$urlButton.addEventListener('click', () => {
+			this.toggleUrlContainer();
+		});
 		this.$settingsButton.addEventListener('click', () => {
 			this.openSettings('General');
 		});
@@ -243,6 +249,19 @@ class ServerManagerView {
 		this.sidebarHoverEvent(this.$reloadButton, this.$reloadTooltip);
 		this.sidebarHoverEvent(this.$backButton, this.$backTooltip);
 		this.sidebarHoverEvent(this.$dndButton, this.$dndTooltip);
+	}
+
+	toggleUrlContainer() {
+		if (this.urlEnabled) {
+			this.$urlField.type = 'hidden';
+		} else {
+			this.$urlField.value = this.tabs[this.activeTabIndex].webview.props.url;
+			const { top, height } = this.$urlButton.getBoundingClientRect();
+			this.$urlField.style.top = top + 'px';
+			this.$urlField.style.height = (height / 2) + 'px';
+			this.$urlField.type = 'url';
+		}
+		this.urlEnabled = !this.urlEnabled;
 	}
 
 	initDNDButton() {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer, remote, clipboard } = require('electron');
 const isDev = require('electron-is-dev');
 
 const { session, app, Menu, dialog } = remote;
@@ -279,9 +279,10 @@ class ServerManagerView {
 		} else {
 			this.initURLShortcut();
 			this.$urlField.value = this.tabs[this.activeTabIndex].webview.props.url;
-			const { top, height } = this.$urlButton.getBoundingClientRect();
+			const { height } = this.$urlButton.getBoundingClientRect();
 			this.$urlField.style.height = (height / 2) + 'px';
 			this.$urlField.type = 'url';
+			clipboard.writeText(this.$urlField.value);
 		}
 		this.urlEnabled = !this.urlEnabled;
 	}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -268,8 +268,14 @@ class ServerManagerView {
 				const urlIndex = this.isURLSaved(url);
 				if (urlIndex >= 0) {
 					this.activateTab(urlIndex);
+				} else {
+					this.$urlField.classList.add('invalid-input-value');
 				}
 			}
+		});
+
+		this.$urlField.addEventListener('input', () => {
+			this.$urlField.classList.remove('invalid-input-value');
 		});
 	}
 

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -36,6 +36,10 @@
         <i class="material-icons md-48">arrow_back</i>
         <span id="back-tooltip" style="display:none">Go Back</span>
       </div>
+      <div class="action-button" id="url-action">
+        <i class="material-icons md-48">link</i>
+        <span id="url-tooltip" style="display:none">Link</span>
+      </div>
       <div class="action-button" id="settings-action">
         <i class="material-icons md-48">settings</i>
         <span id="setting-tooltip" style="display:none">Settings</span>

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -24,6 +24,10 @@
       </div>
     </div>
     <div id="actions-container">
+      <div class="action-button" id="url-action">
+        <i class="material-icons md-48">link</i>
+        <span id="url-tooltip" style="display:none">Link</span>
+      </div>
       <div class="action-button" id="dnd-action">
         <i class="material-icons md-48">notifications</i>
         <span id="dnd-tooltip" style="display:none">Do Not Disturb</span>
@@ -36,13 +40,12 @@
         <i class="material-icons md-48">arrow_back</i>
         <span id="back-tooltip" style="display:none">Go Back</span>
       </div>
-      <div class="action-button" id="url-action">
-        <i class="material-icons md-48">link</i>
-        <span id="url-tooltip" style="display:none">Link</span>
-      </div>
       <div class="action-button" id="settings-action">
         <i class="material-icons md-48">settings</i>
         <span id="setting-tooltip" style="display:none">Settings</span>
+      </div>
+      <div class="url-container" id="url-input-container">
+        <input type="hidden" class="url-input-value" autofocus="autofocus" onfocus="this.select()" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Adds a URL container to the left sidebar that displays the URL of the active organization and copies it to the clipboard automatically.
Entering a URL into the container makes the app check if the domain is already saved and then switch to the relevant tab if that's the case. 

**Any background context you want to provide?**

Check out #578 for the same. 

**Screenshots?**

![image](https://user-images.githubusercontent.com/24617297/52773136-412d6b00-3060-11e9-856b-c6b04af9a4b9.png)

**Possible improvements**
#578 shows a suggestion for a copy button. I couldn't design it as intended (inside the input field), and I think it could make for a nice improvement. 

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
