### PR TITLE
sidebar and menu: add option to copy zulip url

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -263,6 +263,14 @@ class AppMenu {
 					AppMenu.sendAction('toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
 				}
 			}, {
+				label: 'Copy Zulip URL',
+				accelerator: 'Cmd+Shift+C',
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('copy-zulip-url');
+					}
+				}
+			}, {
 				label: 'Log Out',
 				accelerator: 'Cmd+L',
 				enabled: enableMenu,
@@ -358,6 +366,14 @@ class AppMenu {
 				click() {
 					const dndUtil = DNDUtil.toggle();
 					AppMenu.sendAction('toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
+				}
+			}, {
+				label: 'Copy Zulip URL',
+				accelerator: 'Ctrl+Shift+C',
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('copy-zulip-url');
+					}
 				}
 			}, {
 				label: 'Log Out',

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer, remote, clipboard } = require('electron');
 const isDev = require('electron-is-dev');
 
 const { session, app, Menu, dialog } = remote;
@@ -534,6 +534,12 @@ class ServerManagerView {
 								ipcRenderer.send('reload-full-app');
 							}
 						});
+					}
+				},
+				{
+					label: 'Copy Zulip URL',
+					click: () => {
+						clipboard.writeText(DomainUtil.getDomain(index).url);
 					}
 				}
 			];

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -730,6 +730,10 @@ class ServerManagerView {
 		ipcRenderer.on('open-feedback-modal', () => {
 			feedbackHolder.classList.add('show');
 		});
+
+		ipcRenderer.on('copy-zulip-url', () => {
+			clipboard.writeText(DomainUtil.getDomain(this.activeTabIndex).url);
+		});
 	}
 }
 


### PR DESCRIPTION
**What's this PR do?**
For the right click menu on the organization logo, adds "Copy Zulip URL" option.
closes #649 

**Screenshots?**
![screenshot from 2019-02-14 19-18-45](https://user-images.githubusercontent.com/21038781/52790763-67b5cb00-308d-11e9-93d7-66a7af287116.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
