### PR TITLE
Switch to next server on Ctrl+Tab

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -226,6 +226,18 @@ class AppMenu {
 					type: 'checkbox'
 				});
 			}
+			initialSubmenu.push({
+				type: 'separator'
+			});
+			initialSubmenu.push({
+				label: 'Switch to next organization',
+				accelerator: `${ShortcutKey} + Tab`,
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('switch-server-tab', (activeTabIndex + 1) % tabs.length);
+					}
+				}
+			});
 		}
 
 		return initialSubmenu;

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -237,6 +237,14 @@ class AppMenu {
 						AppMenu.sendAction('switch-server-tab', (activeTabIndex + 1) % tabs.length);
 					}
 				}
+			}, {
+				label: 'Switch to previous organization',
+				accelerator: `${ShortcutKey} + Shift + Tab`,
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('switch-server-tab', (activeTabIndex - 1) % tabs.length);
+					}
+				}
 			});
 		}
 

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -231,7 +231,7 @@ class AppMenu {
 			});
 			initialSubmenu.push({
 				label: 'Switch to next organization',
-				accelerator: `${ShortcutKey} + Tab`,
+				accelerator: `Ctrl + Tab`,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('switch-server-tab', (activeTabIndex + 1) % tabs.length);
@@ -239,7 +239,7 @@ class AppMenu {
 				}
 			}, {
 				label: 'Switch to previous organization',
-				accelerator: `${ShortcutKey} + Shift + Tab`,
+				accelerator: `Ctrl + Shift + Tab`,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('switch-server-tab', (activeTabIndex - 1) % tabs.length);

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -131,11 +131,11 @@ class ShortcutsSection extends BaseSection {
                     <td>Toggle DevTools for Active Tab</td>
                   </tr>
                   <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>Tab</kbd></td>
+                    <td><kbd>Ctrl</kbd> + <kbd>Tab</kbd></td>
                     <td>Switch to next organization</td>
                   </tr>
                   <tr>
-                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
+                    <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
                     <td>Switch to previous organization</td>
                   </tr>
                 </table>

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -130,6 +130,14 @@ class ShortcutsSection extends BaseSection {
                     <td><kbd>Option</kbd><kbd>${userOSKey}</kbd><kbd>U</kbd></td>
                     <td>Toggle DevTools for Active Tab</td>
                   </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Tab</kbd></td>
+                    <td>Switch to next organization</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
+                    <td>Switch to previous organization</td>
+                  </tr>
                 </table>
                 <div class="setting-control"></div>
               </div>
@@ -268,6 +276,14 @@ class ShortcutsSection extends BaseSection {
                   <tr>
                     <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd></td>
                     <td>Toggle DevTools for Active Tab</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Tab</kbd></td>
+                    <td>Switch to next organization</td>
+                  </tr>
+                  <tr>
+                    <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
+                    <td>Switch to previous organization</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Adds a new option to the Window menu that allows users to change to the
next organization cyclically. Activated by Ctrl/Cmd + Tab.

**Any background context you want to provide?**

Please have a look at #659. 

**Screenshots?**

![ezgif com-crop](https://user-images.githubusercontent.com/24617297/53291604-dad0e700-37db-11e9-9f6b-0b9c04f2eb68.gif)

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [x] macOS
