### PR TITLE
Add option to hide menu bar to View menu

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -251,6 +251,7 @@ app.on('ready', () => {
 	ipcMain.on('toggle-menubar', (event, showMenubar) => {
 		mainWindow.setAutoHideMenuBar(showMenubar);
 		mainWindow.setMenuBarVisibility(!showMenubar);
+		page.send('toggle-autohide-menubar', showMenubar, true);
 	});
 
 	ipcMain.on('update-badge', (event, messageCount) => {

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -165,6 +165,7 @@ class AppMenu {
 		}, {
 			label: 'Auto hide Menu bar',
 			checked: ConfigUtil.getConfigItem('autoHideMenubar'),
+			visible: process.platform !== 'darwin',
 			click(item, focusedWindow) {
 				if (focusedWindow) {
 					const newValue = !ConfigUtil.getConfigItem('autoHideMenubar');

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -171,6 +171,7 @@ class AppMenu {
 					const newValue = !ConfigUtil.getConfigItem('autoHideMenubar');
 					focusedWindow.setAutoHideMenuBar(newValue);
 					focusedWindow.setMenuBarVisibility(!newValue);
+					focusedWindow.webContents.send('toggle-autohide-menubar', newValue);
 					ConfigUtil.setConfigItem('autoHideMenubar', newValue);
 				}
 			},

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -162,6 +162,17 @@ class AppMenu {
 					ConfigUtil.setConfigItem('showSidebar', newValue);
 				}
 			}
+		}, {
+			label: 'Auto hide Menu bar',
+			accelerator: 'CommandOrControl+B',
+			click(item, focusedWindow) {
+				if (focusedWindow) {
+					const newValue = !ConfigUtil.getConfigItem('autoHideMenubar');
+					focusedWindow.setAutoHideMenuBar(newValue);
+					focusedWindow.setMenuBarVisibility(!newValue);
+					ConfigUtil.setConfigItem('autoHideMenubar', newValue);
+				}
+			}
 		}];
 	}
 

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -164,7 +164,7 @@ class AppMenu {
 			}
 		}, {
 			label: 'Auto hide Menu bar',
-			checked: ConfigUtil.getConfigItem('autoHideMenubar'),
+			checked: ConfigUtil.getConfigItem('autoHideMenubar', false),
 			visible: process.platform !== 'darwin',
 			click(item, focusedWindow) {
 				if (focusedWindow) {

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -164,7 +164,7 @@ class AppMenu {
 			}
 		}, {
 			label: 'Auto hide Menu bar',
-			accelerator: 'CommandOrControl+B',
+			checked: ConfigUtil.getConfigItem('autoHideMenubar'),
 			click(item, focusedWindow) {
 				if (focusedWindow) {
 					const newValue = !ConfigUtil.getConfigItem('autoHideMenubar');
@@ -172,7 +172,8 @@ class AppMenu {
 					focusedWindow.setMenuBarVisibility(!newValue);
 					ConfigUtil.setConfigItem('autoHideMenubar', newValue);
 				}
-			}
+			},
+			type: 'checkbox'
 		}];
 	}
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -503,6 +503,15 @@ class ServerManagerView {
 		ipcRenderer.send('update-badge', messageCountAll);
 	}
 
+	updateGeneralSettings(setting, value) {
+		const selector = 'webview:not([class*=disabled])';
+		const webview = document.querySelector(selector);
+		if (webview) {
+			const webContents = webview.getWebContents();
+			webContents.send(setting, value);
+		}
+	}
+
 	toggleSidebar(show) {
 		if (show) {
 			this.$sidebar.classList.remove('sidebar-hide');
@@ -634,12 +643,7 @@ class ServerManagerView {
 				});
 				return;
 			}
-			const selector = 'webview:not([class*=disabled])';
-			const webview = document.querySelector(selector);
-			if (webview) {
-				const webContents = webview.getWebContents();
-				webContents.send('toggle-menubar-setting', autoHideMenubar);
-			}
+			this.updateGeneralSettings('toggle-menubar-setting', autoHideMenubar);
 		});
 
 		ipcRenderer.on('toggle-dnd', (event, state, newSettings) => {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -625,6 +625,15 @@ class ServerManagerView {
 			});
 		});
 
+		ipcRenderer.on('toggle-autohide-menubar', (event, autoHideMenubar) => {
+			const selector = 'webview:not([class*=disabled])';
+			const webview = document.querySelector(selector);
+			if (webview) {
+				const webContents = webview.getWebContents();
+				webContents.send('toggle-menubar-setting', autoHideMenubar);
+			}
+		});
+
 		ipcRenderer.on('toggle-dnd', (event, state, newSettings) => {
 			this.toggleDNDButton(state);
 			ipcRenderer.send('forward-message', 'toggle-silent', newSettings.silent);

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -625,7 +625,14 @@ class ServerManagerView {
 			});
 		});
 
-		ipcRenderer.on('toggle-autohide-menubar', (event, autoHideMenubar) => {
+		ipcRenderer.on('toggle-autohide-menubar', (event, autoHideMenubar, updateMenu) => {
+			if (updateMenu) {
+				ipcRenderer.send('update-menu', {
+					tabs: this.tabsForIpc,
+					activeTabIndex: this.activeTabIndex
+				});
+				return;
+			}
 			const selector = 'webview:not([class*=disabled])';
 			const webview = document.querySelector(selector);
 			if (webview) {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -615,10 +615,7 @@ class ServerManagerView {
 			this.toggleSidebar(show);
 
 			// Toggle sidebar switch in the general settings
-			const selector = 'webview:not([class*=disabled])';
-			const webview = document.querySelector(selector);
-			const webContents = webview.getWebContents();
-			webContents.send('toggle-sidebar-setting', show);
+			this.updateGeneralSettings('toggle-sidebar-setting', show);
 		});
 
 		ipcRenderer.on('toggle-silent', (event, state) => {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -100,6 +100,7 @@ class ServerManagerView {
 	initDefaultSettings() {
 		// Default settings which should be respected
 		const settingOptions = {
+			autoHideMenubar: false,
 			trayIcon: true,
 			useManualProxy: false,
 			useSystemProxy: false,

--- a/app/renderer/js/pages/preference/preference.js
+++ b/app/renderer/js/pages/preference/preference.js
@@ -94,6 +94,10 @@ class PreferenceView extends BaseComponent {
 			this.handleToggle('sidebar-option', state);
 		});
 
+		ipcRenderer.on('toggle-menubar-setting', (event, state) => {
+			this.handleToggle('menubar-option', state);
+		});
+
 		ipcRenderer.on('toggletray', (event, state) => {
 			this.handleToggle('tray-option', state);
 		});


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Adds option to auto-hide the menu bar (previously found only in Preferences > General) to the View menu.

**Any background context you want to provide?**

I felt that the View menu should have this setting because it's more intuitive to find something like this there. This pattern is also present in multiple other apps, and as someone who hates menu bars, I'd love to have it easily accessible. 

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
