### PR TITLE
pdf-view: add pdfjs implementation for opening pdfs

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const electron = require('electron');
 const windowStateKeeper = require('electron-window-state');
 const isDev = require('electron-is-dev');
+const PDFWindow = require('electron-pdf-window');
 const appMenu = require('./menu');
 const { appUpdater } = require('./autoupdater');
 
@@ -198,31 +199,31 @@ app.on('ready', () => {
 		app.quit();
 	});
 
-	// Code to show pdf in a new BrowserWindow (currently commented out due to bug-upstream)
-	// ipcMain.on('pdf-view', (event, url) => {
-	// 	// Paddings for pdfWindow so that it fits into the main browserWindow
-	// 	const paddingWidth = 55;
-	// 	const paddingHeight = 22;
+	// Show pdf in a new BrowserWindow
+	ipcMain.on('pdf-view', (event, url) => {
+		// Paddings for pdfWindow so that it fits into the main browserWindow
+		const paddingWidth = 55;
+		const paddingHeight = 22;
 
-	// 	// Get the config of main browserWindow
-	// 	const mainWindowState = global.mainWindowState;
+		// Get the config of main browserWindow
+		const mainWindowState = global.mainWindowState;
 
-	// 	// Window to view the pdf file
-	// 	const pdfWindow = new electron.BrowserWindow({
-	// 		x: mainWindowState.x + paddingWidth,
-	// 		y: mainWindowState.y + paddingHeight,
-	// 		width: mainWindowState.width - paddingWidth,
-	// 		height: mainWindowState.height - paddingHeight,
-	// 		webPreferences: {
-	// 			plugins: true,
-	// 			partition: 'persist:webviewsession'
-	// 		}
-	// 	});
-	// 	pdfWindow.loadURL(url);
+		// Window to view the pdf file
+		const pdfWindow = new PDFWindow({
+			x: mainWindowState.x + paddingWidth,
+			y: mainWindowState.y + paddingHeight,
+			width: mainWindowState.width - paddingWidth,
+			height: mainWindowState.height - paddingHeight,
+			webPreferences: {
+				plugins: true,
+				partition: 'persist:webviewsession'
+			}
+		});
+		pdfWindow.loadURL(url);
 
-	// 	// We don't want to have the menu bar in pdf window
-	// 	pdfWindow.setMenu(null);
-	// });
+		// We don't want to have the menu bar in pdf window
+		pdfWindow.setMenu(null);
+	});
 
 	// Reload full app not just webview, useful in debugging
 	ipcMain.on('reload-full-app', () => {

--- a/app/renderer/js/components/handle-external-link.js
+++ b/app/renderer/js/components/handle-external-link.js
@@ -21,21 +21,19 @@ function handleExternalLink(event) {
 	if (isWhiteListURL) {
 		event.preventDefault();
 
-		// Code to show pdf in a new BrowserWindow (currently commented out due to bug-upstream)
 		// Show pdf attachments in a new window
-		// if (LinkUtil.isPDF(url) && isUploadsURL) {
-		// 	ipcRenderer.send('pdf-view', url);
-		// 	return;
-		// }
+		if (LinkUtil.isPDF(url) && isUploadsURL) {
+			ipcRenderer.send('pdf-view', url);
+			return;
+		}
 
 		// download txt, mp3, mp4 etc.. by using downloadURL in the
 		// main process which allows the user to save the files to their desktop
 		// and not trigger webview reload while image in webview will
 		// do nothing and will not save it
 
-			// Code to show pdf in a new BrowserWindow (currently commented out due to bug-upstream)
-		// if (!LinkUtil.isImage(url) && !LinkUtil.isPDF(url) && isUploadsURL) {
-		if (!LinkUtil.isImage(url) && isUploadsURL) {
+		// Show pdf in a new BrowserWindow
+		if (!LinkUtil.isImage(url) && !LinkUtil.isPDF(url) && isUploadsURL) {
 			ipcRenderer.send('downloadFile', url, downloadPath);
 			ipcRenderer.once('downloadFileCompleted', (event, filePath, fileName) => {
 				const downloadNotification = new Notification('Download Complete', {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "electron-builder": "20.38.4",
     "electron-connect": "0.6.2",
     "electron-debug": "1.4.0",
+    "electron-pdf-window": "^1.0.12",
     "google-translate-api": "2.3.0",
     "gulp": "^4.0.0",
     "gulp-tape": "0.0.9",


### PR DESCRIPTION
fixes #664.

**What's this PR do?**
Adds the module electron-pdf-window which is an implementation of pdf.js for electron apps. 

**Screenshots?**
![screenshot from 2019-02-28 01-48-13](https://user-images.githubusercontent.com/21038781/53520145-f0575100-3afa-11e9-930e-bf99ee2cc394.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
