### PR TITLE
Add loading indicator to sidebar

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -267,6 +267,18 @@ body {
     margin-bottom: 5px;
 }
 
+.refresh {
+    animation: rotate-loader 1s linear infinite;
+}
+
+@keyframes rotate-loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(-360deg);
+    }
+}
 
 /*******************
   *   Webview Area  *
@@ -328,6 +340,7 @@ webview.focus {
 
 /* Tooltip styling */
 
+#loading-tooltip,
 #dnd-tooltip,
 #back-tooltip,
 #reload-tooltip,
@@ -346,6 +359,7 @@ webview.focus {
     font-size: 14px;
 }
 
+#loading-tooltip::after,
 #dnd-tooltip::after,
 #back-tooltip::after,
 #reload-tooltip::after,

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -94,6 +94,7 @@ class WebView extends BaseComponent {
 				this.$el.classList.add('onload');
 			}
 			this.loading = false;
+			this.props.switchLoading(false, this.props.url);
 			this.show();
 
 			// Refocus text boxes after reload
@@ -112,12 +113,20 @@ class WebView extends BaseComponent {
 		});
 
 		this.$el.addEventListener('did-start-loading', () => {
+			const isSettingPage = this.props.url.includes('renderer/preference.html');
+			if (!isSettingPage) {
+				this.props.switchLoading(true, this.props.url);
+			}
 			let userAgent = SystemUtil.getUserAgent();
 			if (!userAgent) {
 				SystemUtil.setUserAgent(this.$el.getUserAgent());
 				userAgent = SystemUtil.getUserAgent();
 			}
 			this.$el.setUserAgent(userAgent);
+		});
+
+		this.$el.addEventListener('did-stop-loading', () => {
+			this.props.switchLoading(false, this.props.url);
 		});
 	}
 

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -32,6 +32,10 @@
                         <i class="material-icons md-48">refresh</i>
                         <span id="reload-tooltip" style="display:none">Reload</span>
                     </div>
+                    <div class="action-button" id="loading-action">
+                        <i class="refresh material-icons md-48">loop</i>
+                        <span id="loading-tooltip" style="display:none">Loading</span>
+                    </div>
                     <div class="action-button disable" id="back-action">
                         <i class="material-icons md-48">arrow_back</i>
                         <span id="back-tooltip" style="display:none">Go Back</span>


### PR DESCRIPTION
Browser-like loading indicator added to the sidebar for better UX.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Follows up on the discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Loading.20indicator/near/519181) to add a loading indicator to the sidebar. 

The icon I've used is a simple loop picked up from the Material Design library. We can certainly include the more conventional spinner too. 

Fixes #430. Relevant discussion there too. 

**Screenshots**

![image](https://user-images.githubusercontent.com/24617297/53744922-06329080-3ec4-11e9-8d2e-feaebe71a837.png)

(Please observe that the case I've shown here is the login issue we've been talking about, and that the reload icon has been replaced by the loop icon).

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
