### PR TITLE
Default to starting app on login

### DIFF
--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -105,7 +105,7 @@ class ServerManagerView {
 			useSystemProxy: false,
 			showSidebar: true,
 			badgeOption: true,
-			startAtLogin: false,
+			startAtLogin: true,
 			startMinimized: false,
 			enableSpellchecker: true,
 			showNotification: true,


### PR DESCRIPTION
**What's this PR do?**

Acts on an observation that it is easier to turn off auto-start on login
than it is to turn on.

---

**Any background context you want to provide?**

Please follow [the discussion here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Start.20app.20at.20PC.20login/near/715054).

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
