### PR TITLE
Add custom configurations for enterprise

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -453,6 +453,11 @@ i.open-tab-button {
     user-select: none;
 }
 
+.disallowed:hover {
+    background-color: rgba(241, 241, 241, 1.000);
+    cursor: not-allowed;
+}
+
 input.toggle-round + label {
     padding: 2px;
     width: 50px;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -228,7 +228,7 @@ class ServerManagerView {
 			const setting = i as keyof SettingsOptions;
 			// give preference to defaults defined in global_config.json
 			if (EnterpriseUtil.configItemExists(setting)) {
-				ConfigUtil.setConfigItem(setting, EnterpriseUtil.getConfigItem(setting));
+				ConfigUtil.setConfigItem(setting, EnterpriseUtil.getConfigItem(setting), true);
 			} else if (ConfigUtil.getConfigItem(setting) === null) {
 				ConfigUtil.setConfigItem(setting, settingOptions[setting]);
 			}

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -138,12 +138,12 @@ class ServerManagerView {
 
 	init(): void {
 		this.loadProxy().then(() => {
+			this.initDefaultSettings();
 			this.initSidebar();
 			this.initPresetOrgs();
 			this.initTabs();
 			this.initActions();
 			this.registerIpcs();
-			this.initDefaultSettings();
 		});
 	}
 
@@ -226,8 +226,11 @@ class ServerManagerView {
 
 		for (const i in settingOptions) {
 			const setting = i as keyof SettingsOptions;
-			if (ConfigUtil.getConfigItem(i) === null) {
-				ConfigUtil.setConfigItem(i, settingOptions[setting]);
+			// give preference to defaults defined in global_config.json
+			if (EnterpriseUtil.configItemExists(setting)) {
+				ConfigUtil.setConfigItem(setting, EnterpriseUtil.getConfigItem(setting));
+			} else if (ConfigUtil.getConfigItem(setting) === null) {
+				ConfigUtil.setConfigItem(setting, settingOptions[setting]);
 			}
 		}
 	}

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -140,7 +140,9 @@ class ServerManagerView {
 		this.loadProxy().then(() => {
 			this.initDefaultSettings();
 			this.initSidebar();
-			this.initPresetOrgs();
+			if (EnterpriseUtil.configFile) {
+				this.initPresetOrgs();
+			}
 			this.initTabs();
 			this.initActions();
 			this.registerIpcs();

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -21,6 +21,7 @@ import ReconnectUtil = require('./utils/reconnect-util');
 import Logger = require('./utils/logger-util');
 import CommonUtil = require('./utils/common-util');
 import EnterpriseUtil = require('./utils/enterprise-util');
+import Messages = require('./../../resources/messages');
 
 const logger = new Logger({
 	file: 'errors.log',
@@ -283,6 +284,10 @@ class ServerManagerView {
 			} else {
 				ipcRenderer.send('reload-full-app');
 			}
+		} else if (domainsAdded.length > 0) {
+			// no enterprise domains added
+			const { title, content } = Messages.enterpriseOrgError(domainsAdded.length);
+			dialog.showErrorBox(title, content);
 		}
 	}
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -20,6 +20,7 @@ import DNDUtil = require('./utils/dnd-util');
 import ReconnectUtil = require('./utils/reconnect-util');
 import Logger = require('./utils/logger-util');
 import CommonUtil = require('./utils/common-util');
+import EnterpriseUtil = require('./utils/enterprise-util');
 
 const logger = new Logger({
 	file: 'errors.log',
@@ -135,6 +136,7 @@ class ServerManagerView {
 	init(): void {
 		this.loadProxy().then(() => {
 			this.initSidebar();
+			this.initPresetOrgs();
 			this.initTabs();
 			this.initActions();
 			this.registerIpcs();
@@ -230,6 +232,40 @@ class ServerManagerView {
 	initSidebar(): void {
 		const showSidebar = ConfigUtil.getConfigItem('showSidebar', true);
 		this.toggleSidebar(showSidebar);
+	}
+
+	async queueDomain(domain: any): Promise<boolean> {
+		// allows us to start adding multiple domains to the app simultaneously
+		// promise of addition resolves in both cases, but we consider it rejected
+		// if the resolved value is false
+		try {
+			const serverConf = await DomainUtil.checkDomain(domain);
+			await DomainUtil.addDomain(serverConf);
+			return true;
+		} catch (err) {
+			logger.error(err);
+			logger.error('Could not add ' + domain + '. Please contact your system administrator.');
+			return false;
+		}
+	}
+
+	async initPresetOrgs(): Promise<void> {
+		// read preset organizations from global_config.json and queues them
+		// for addition to the app's domains
+		const presetOrgs = EnterpriseUtil.getConfigItem('presetOrganizations', []);
+		// set to true if at least one new domain is added
+		const domainPromises = [];
+		for (const url in presetOrgs) {
+			if (DomainUtil.duplicateDomain(presetOrgs[url])) {
+				continue;
+			}
+			domainPromises.push(this.queueDomain(presetOrgs[url]));
+		}
+		const domainsAdded = await Promise.all(domainPromises);
+		if (domainsAdded.includes(true)) {
+			// at least one domain was resolved
+			ipcRenderer.send('reload-full-app');
+		}
 	}
 
 	initTabs(): void {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -252,6 +252,7 @@ class ServerManagerView {
 	async initPresetOrgs(): Promise<void> {
 		// read preset organizations from global_config.json and queues them
 		// for addition to the app's domains
+		const preAddedDomains = DomainUtil.getDomains();
 		const presetOrgs = EnterpriseUtil.getConfigItem('presetOrganizations', []);
 		// set to true if at least one new domain is added
 		const domainPromises = [];
@@ -264,7 +265,22 @@ class ServerManagerView {
 		const domainsAdded = await Promise.all(domainPromises);
 		if (domainsAdded.includes(true)) {
 			// at least one domain was resolved
-			ipcRenderer.send('reload-full-app');
+			if (preAddedDomains.length > 0) {
+				// user already has servers added
+				// ask them before reloading the app
+				dialog.showMessageBox({
+					type: 'question',
+					buttons: ['Yes', 'Later'],
+					defaultId: 0,
+					message: 'New server' + (domainsAdded.length > 1 ? 's' : '') + ' added. Reload app now?'
+				}, response => {
+					if (response === 0) {
+						ipcRenderer.send('reload-full-app');
+					}
+				});
+			} else {
+				ipcRenderer.send('reload-full-app');
+			}
 		}
 	}
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -288,6 +288,10 @@ class ServerManagerView {
 			// no enterprise domains added
 			const { title, content } = Messages.enterpriseOrgError(domainsAdded.length);
 			dialog.showErrorBox(title, content);
+			if (DomainUtil.getDomains().length === 0) {
+				// no orgs present, stop showing loading gif
+				this.openSettings('AddServer');
+			}
 		}
 	}
 

--- a/app/renderer/js/pages/preference/base-section.ts
+++ b/app/renderer/js/pages/preference/base-section.ts
@@ -7,23 +7,26 @@ import BaseComponent = require('../../components/base');
 class BaseSection extends BaseComponent {
 	// TODO: TypeScript - Here props should be object type
 	generateSettingOption(props: any): void {
-		const {$element, value, clickHandler} = props;
+		const {$element, disabled, value, clickHandler} = props;
 
 		$element.innerHTML = '';
 
-		const $optionControl = this.generateNodeFromTemplate(this.generateOptionTemplate(value));
+		const $optionControl = this.generateNodeFromTemplate(this.generateOptionTemplate(value, disabled));
 		$element.append($optionControl);
 
-		$optionControl.addEventListener('click', clickHandler);
+		if (!disabled) {
+			$optionControl.addEventListener('click', clickHandler);
+		}
 	}
 
-	generateOptionTemplate(settingOption: boolean): string {
+	generateOptionTemplate(settingOption: boolean, disabled: boolean): string {
+		const label = disabled ? `<label class="disallowed" />` : `<label/>`;
 		if (settingOption) {
 			return `
 				<div class="action">
 					<div class="switch">
-					  <input class="toggle toggle-round" type="checkbox" checked>
-					  <label></label>
+					  <input class="toggle toggle-round" type="checkbox" checked disabled>
+					  ${label}
 					</div>
 				</div>
 			`;
@@ -32,7 +35,7 @@ class BaseSection extends BaseComponent {
 				<div class="action">
 					<div class="switch">
 					  <input class="toggle toggle-round" type="checkbox">
-					  <label></label>
+					  ${label}
 					</div>
 				</div>
 			`;

--- a/app/renderer/js/pages/preference/base-section.ts
+++ b/app/renderer/js/pages/preference/base-section.ts
@@ -20,7 +20,7 @@ class BaseSection extends BaseComponent {
 	}
 
 	generateOptionTemplate(settingOption: boolean, disabled: boolean): string {
-		const label = disabled ? `<label class="disallowed" />` : `<label/>`;
+		const label = disabled ? `<label class="disallowed" title="Setting locked by system administrator."/>` : `<label/>`;
 		if (settingOption) {
 			return `
 				<div class="action">

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -9,6 +9,7 @@ const currentBrowserWindow = remote.getCurrentWindow();
 
 import BaseSection = require('./base-section');
 import ConfigUtil = require('../../utils/config-util');
+import EnterpriseUtil = require('./../../utils/enterprise-util');
 
 class GeneralSection extends BaseSection {
 	// TODO: TypeScript - Here props should be object type
@@ -238,6 +239,7 @@ class GeneralSection extends BaseSection {
 	autoUpdateOption(): void {
 		this.generateSettingOption({
 			$element: document.querySelector('#autoupdate-option .setting-control'),
+			disabled: EnterpriseUtil.configItemExists('autoUpdate'),
 			value: ConfigUtil.getConfigItem('autoUpdate', true),
 			clickHandler: () => {
 				const newValue = !ConfigUtil.getConfigItem('autoUpdate');

--- a/app/renderer/js/pages/preference/server-info-form.ts
+++ b/app/renderer/js/pages/preference/server-info-form.ts
@@ -4,6 +4,7 @@ import { remote, ipcRenderer } from 'electron';
 
 import BaseComponent = require('../../components/base');
 import DomainUtil = require('../../utils/domain-util');
+import Messages = require('./../../../../resources/messages');
 
 const { dialog } = remote;
 
@@ -67,8 +68,12 @@ class ServerInfoForm extends BaseComponent {
 				message: 'Are you sure you want to disconnect this organization?'
 			}, response => {
 				if (response === 0) {
-					DomainUtil.removeDomain(this.props.index);
-					this.props.onChange(this.props.index);
+					if (DomainUtil.removeDomain(this.props.index)) {
+						ipcRenderer.send('reload-full-app');
+					} else {
+						const { title, content } = Messages.orgRemovalError(DomainUtil.getDomain(this.props.index).url);
+						dialog.showErrorBox(title, content);
+					}
 				}
 			});
 		});

--- a/app/renderer/js/utils/config-util.ts
+++ b/app/renderer/js/utils/config-util.ts
@@ -5,6 +5,7 @@ import fs = require('fs');
 import path = require('path');
 import electron = require('electron');
 import Logger = require('./logger-util');
+import EnterpriseUtil = require('./enterprise-util');
 
 const logger = new Logger({
 	file: 'config-util.log',
@@ -67,7 +68,11 @@ class ConfigUtil {
 		return (value !== undefined);
 	}
 
-	setConfigItem(key: string, value: any): void {
+	setConfigItem(key: string, value: any, override? : boolean): void {
+		if (EnterpriseUtil.configItemExists(key) && !override) {
+			// if item is in global config and we're not trying to override
+			return;
+		}
 		this.db.push(`/${key}`, value, true);
 		this.db.save();
 	}

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -9,6 +9,7 @@ import Logger = require('./logger-util');
 import electron = require('electron');
 
 import RequestUtil = require('./request-util');
+import EnterpriseUtil = require('./enterprise-util');
 import Messages = require('../../../resources/messages');
 
 const { app, dialog } = electron.remote;
@@ -87,9 +88,13 @@ class DomainUtil {
 		this.reloadDB();
 	}
 
-	removeDomain(index: number): void {
+	removeDomain(index: number): boolean {
+		if (EnterpriseUtil.isPresetOrg(this.getDomain(index).url)) {
+			return false;
+		}
 		this.db.delete(`/domains[${index}]`);
 		this.reloadDB();
+		return true;
 	}
 
 	// Check if domain is already added

--- a/app/renderer/js/utils/enterprise-util.ts
+++ b/app/renderer/js/utils/enterprise-util.ts
@@ -52,6 +52,19 @@ class EnterpriseUtil {
 		this.reloadDB();
 		return (this.enterpriseSettings[key] !== undefined);
 	}
+
+	isPresetOrg(url: string): boolean {
+		if (!this.configItemExists('presetOrganizations')) {
+			return false;
+		}
+		const presetOrgs = this.enterpriseSettings.presetOrganizations;
+		for (const org of presetOrgs) {
+			if (url.includes(org)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }
 
 export = new EnterpriseUtil();

--- a/app/renderer/js/utils/enterprise-util.ts
+++ b/app/renderer/js/utils/enterprise-util.ts
@@ -13,6 +13,7 @@ let instance: null | EnterpriseUtil = null;
 class EnterpriseUtil {
 	// todo: replace enterpriseSettings type with an interface once settings are final
 	enterpriseSettings: any;
+	configFile: boolean;
 	constructor() {
 		if (instance) {
 			return instance;
@@ -30,6 +31,7 @@ class EnterpriseUtil {
 
 		enterpriseFile = path.resolve(enterpriseFile);
 		if (fs.existsSync(enterpriseFile)) {
+			this.configFile = true;
 			try {
 				const file = fs.readFileSync(enterpriseFile, 'utf8');
 				this.enterpriseSettings = JSON.parse(file);
@@ -37,11 +39,16 @@ class EnterpriseUtil {
 				logger.log('Error while JSON parsing global_config.json: ');
 				logger.log(err);
 			}
+		} else {
+			this.configFile = false;
 		}
 	}
 
 	getConfigItem(key: string, defaultValue?: any): any {
 		this.reloadDB();
+		if (!this.configFile) {
+			return defaultValue;
+		}
 		if (defaultValue === undefined) {
 			defaultValue = null;
 		}
@@ -50,11 +57,14 @@ class EnterpriseUtil {
 
 	configItemExists(key: string): boolean {
 		this.reloadDB();
+		if (!this.configFile) {
+			return false;
+		}
 		return (this.enterpriseSettings[key] !== undefined);
 	}
 
 	isPresetOrg(url: string): boolean {
-		if (!this.configItemExists('presetOrganizations')) {
+		if (!this.configFile || !this.configItemExists('presetOrganizations')) {
 			return false;
 		}
 		const presetOrgs = this.enterpriseSettings.presetOrganizations;

--- a/app/renderer/js/utils/enterprise-util.ts
+++ b/app/renderer/js/utils/enterprise-util.ts
@@ -1,0 +1,57 @@
+import fs = require('fs');
+import path = require('path');
+
+import Logger = require('./logger-util');
+
+const logger = new Logger({
+	file: 'enterprise-util.log',
+	timestamp: true
+});
+
+let instance: null | EnterpriseUtil = null;
+
+class EnterpriseUtil {
+	// todo: replace enterpriseSettings type with an interface once settings are final
+	enterpriseSettings: any;
+	constructor() {
+		if (instance) {
+			return instance;
+		}
+		instance = this;
+
+		this.reloadDB();
+	}
+
+	reloadDB(): void {
+		let enterpriseFile = '/etc/zulip-desktop-config/global_config.json';
+		if (process.platform === 'win32') {
+			enterpriseFile = 'C:\\Program Files\\Zulip-Desktop-Config\\global_config.json';
+		}
+
+		enterpriseFile = path.resolve(enterpriseFile);
+		if (fs.existsSync(enterpriseFile)) {
+			try {
+				const file = fs.readFileSync(enterpriseFile, 'utf8');
+				this.enterpriseSettings = JSON.parse(file);
+			} catch (err) {
+				logger.log('Error while JSON parsing global_config.json: ');
+				logger.log(err);
+			}
+		}
+	}
+
+	getConfigItem(key: string, defaultValue?: any): any {
+		this.reloadDB();
+		if (defaultValue === undefined) {
+			defaultValue = null;
+		}
+		return this.configItemExists(key) ? this.enterpriseSettings[key] : defaultValue;
+	}
+
+	configItemExists(key: string): boolean {
+		this.reloadDB();
+		return (this.enterpriseSettings[key] !== undefined);
+	}
+}
+
+export = new EnterpriseUtil();

--- a/app/resources/messages.ts
+++ b/app/resources/messages.ts
@@ -22,6 +22,13 @@ class Messages {
 		\nUnless you have a good reason to believe otherwise, you should not proceed.
 		\nYou can click here if you'd like to proceed with the connection.`;
 	}
+
+	enterpriseOrgError(length: number): any {
+		return {
+			title: `Could not add ${length} ${length === 1 ? `organization` : `organizations`}`,
+			content: `Please contact your system administrator.`
+		};
+	}
 }
 
 export = new Messages();

--- a/app/resources/messages.ts
+++ b/app/resources/messages.ts
@@ -23,9 +23,20 @@ class Messages {
 		\nYou can click here if you'd like to proceed with the connection.`;
 	}
 
-	enterpriseOrgError(length: number): any {
+	enterpriseOrgError(length: number, domains: string[]): any {
+		let domainList = '';
+		for (const domain of domains) {
+			domainList += `• ${domain}\n`;
+		}
 		return {
-			title: `Could not add ${length} ${length === 1 ? `organization` : `organizations`}`,
+			title: `Could not add the following ${length === 1 ? `organization` : `organizations`}`,
+			content: `${domainList}\nPlease contact your system administrator.`
+		};
+	}
+
+	orgRemovalError(url: string): any {
+		return {
+			title: `Removing ${url} is a restricted operation.`,
 			content: `Please contact your system administrator.`
 		};
 	}

--- a/app/resources/messages.ts
+++ b/app/resources/messages.ts
@@ -1,3 +1,8 @@
+interface DialogBoxError {
+	title: string;
+	content: string;
+}
+
 class Messages {
 	invalidZulipServerError(domain: string): string {
 		return `${domain} does not appear to be a valid Zulip server. Make sure that
@@ -23,7 +28,7 @@ class Messages {
 		\nYou can click here if you'd like to proceed with the connection.`;
 	}
 
-	enterpriseOrgError(length: number, domains: string[]): any {
+	enterpriseOrgError(length: number, domains: string[]): DialogBoxError {
 		let domainList = '';
 		for (const domain of domains) {
 			domainList += `• ${domain}\n`;
@@ -34,7 +39,7 @@ class Messages {
 		};
 	}
 
-	orgRemovalError(url: string): any {
+	orgRemovalError(url: string): DialogBoxError {
 		return {
 			title: `Removing ${url} is a restricted operation.`,
 			content: `Please contact your system administrator.`

--- a/docs/Enterprise.md
+++ b/docs/Enterprise.md
@@ -1,0 +1,27 @@
+# Configuring Zulip Desktop for multiple users
+
+If you're a system admin and want to add certain organizations to the Zulip app for
+all users of your system, you can do so by creating an enterprise config file.
+The file should be placed at `/etc/zulip-desktop-config` for Linux and macOS computers
+and inside `C:\Program Files\Zulip-Desktop-Config` on Windows.
+It must be named `global_config.json` in both cases. 
+
+To specify the preset organization you want to add for other users, you will need to
+add the `json` shown below to the `global_config.json`. Replace `https://chat.zulip.org` with the
+organization you want to add. You can also specify multiple organizations. 
+
+```json
+{
+	"presetOrganizations": ["https://chat.zulip.org"],
+	"autoUpdate": true
+}
+```
+
+The above example adds [Zulip Community](https://chat.zulip.org) to Zulip every time the app is loaded. 
+Users can add new organizations at all times, but cannot remove any organizations listed under `presetOrganizations`.
+
+If you'd like to remove organizations and have admin access, you'll need to change the config file and remove the concerned URL from the `value` field.
+
+It also turns on automatic updates for every Zulip user on the same machine. 
+
+> Currently, we only support `presetOrganizations` and `autoUpdate` settings. We are working on other settings as well, and will update this page when we add support for more.


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Considers a new custom config file for managing user-level settings of the app. We expect that the admin deploying Zulip at enterprise will `echo` the filepath for this config file into `settings.json` and then we can read this as replacements for settings in the app. 

**Any background context you want to provide?**

A major request by enterprise users is that they should be able to regulate user-level settings by maintaining a `custom_settings.json` file at a system-level settings. Following the discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/high.20availability/near/701040), I have implemented a simple method to read enterprise settings using `fs`.
This assumes that the admin will `echo` the filepath of the custom config file as per their choice in the script they write and the app will just read that.

I also realised that some settings (say auto updates) should be disabled by admins but some settings (like showing the sidebar) should be accessible to the user. So I've added an `admin` field to every config item. By default, it is false, which means that admin access to change that field is not required. Handled that in ConfigUtil's `setConfigItem` directly.

**Slated improvements**

I've sent in this draft PR to make sure everyone invested in this functionality (quite a few people) can provide feedback as we go along. That being said, I plan to add the following features over the next couple of days:

- [x] 1. Extend the switches' permissions regulation to other settings fields and dialog boxes
- [x] 2. Extend similar permissions to preset organizations
- [x] 3. Investigate options we have in terms of granularity and add support for the relevant ones
- [x] 4. Document the new files made and the process of editing custom settings

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
