### PR TITLE
Modify reset app data button

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -322,16 +322,24 @@ img.server-info-icon {
 }
 
 .red {
-    color: #ef5350;
-    padding: 8px;
-    border: rgba(239, 83, 80, 0.5) solid 1px;
+    color: white;
+    background: #ee8787;
     border-radius: 4px;
-    border-color: #fff;
+    display: inline-block;
+    border: 2px solid rgba(243, 94, 92, 0.5);
+    padding: 10px;
+    width: 100px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: bold;
+    transition: background-color 0.2s ease;
+    text-decoration: none;
+    text-align: center;
 }
 
 .red:hover {
-    background-color: rgba(230, 52, 49, 0.5);
-    color: #fff;
+    background-color: #f05252;
+    color: white;
 }
 
 .green {

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -322,11 +322,11 @@ img.server-info-icon {
 }
 
 .red {
-    color: white;
-    background: #ee8787;
+    color: rgb(240, 148, 148);
+    background: white;
     border-radius: 4px;
     display: inline-block;
-    border: 2px solid rgba(243, 94, 92, 0.5);
+    border: 2px solid rgb(240, 148, 148);
     padding: 10px;
     width: 100px;
     cursor: pointer;
@@ -338,7 +338,7 @@ img.server-info-icon {
 }
 
 .red:hover {
-    background-color: #f05252;
+    background-color: rgb(240, 148, 148);
     color: white;
 }
 

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -120,7 +120,7 @@ class GeneralSection extends BaseSection {
 					<div class="setting-row" id="resetdata-option">
 						<div class="setting-description">This will delete all application data including all added accounts and preferences
 						</div>
-						<button class="reset-data-button green w-150">Reset App Data</button>
+						<button class="reset-data-button red w-150">Reset App Data</button>
 					</div>
 				</div>
             </div>


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
This PR improves the look of Reset App Data button in Setting->general section

**Any background context you want to provide?**
discussed [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/reset.20app.20data.20button/near/722883) 

**Screenshots?**
![dangerbutton](https://user-images.githubusercontent.com/36422396/54849450-53a75e00-4d0a-11e9-9ea9-57205b7a7f9d.gif)


**You have tested this PR on:**
  - [x] Linux/Ubuntu
  - [ ] Windows
  - [ ] macOS
