### PR TITLE
system-presence: Add ability to detect system presence.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -344,6 +344,18 @@ app.on('ready', () => {
 	ipcMain.on('realm-icon-changed', (event, serverURL, iconURL) => {
 		page.send('update-realm-icon', serverURL, iconURL);
 	});
+
+	// Update user idle status for each realm
+	// Set user idle if no activity for 60s
+	ipcMain.on('detect-presence', event => {
+		electron.powerMonitor.querySystemIdleState(60, idleState => {
+			if (idleState === 'active') {
+				event.sender.send('set-active');
+			} else {
+				event.sender.send('set-idle');
+			}
+		});
+	});
 });
 
 app.on('before-quit', () => {


### PR DESCRIPTION
**What's this PR do?**
Created two electron-bridge variables.
idle_on_system tells whether the user is idle or not.
last_active_on_system gives the time the user was last
active. Both variables will be used by the webapp to set
user status.

Fixes #352.

Corresponding webapp PR [here](https://github.com/zulip/zulip/pull/12003).

**How to test?**
You can test by console logging the two variables at line 97 of preload.js. They will update based on user activity.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
