### PR TITLE
sidebar: Fixes to org cycling

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -231,7 +231,7 @@ class AppMenu {
 			});
 			initialSubmenu.push({
 				label: 'Switch to next organization',
-				accelerator: `Ctrl + Tab`,
+				accelerator: `Ctrl+Tab`,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('switch-server-tab', (activeTabIndex + 1) % tabs.length);
@@ -239,10 +239,10 @@ class AppMenu {
 				}
 			}, {
 				label: 'Switch to previous organization',
-				accelerator: `Ctrl + Shift + Tab`,
+				accelerator: `Ctrl+Shift+Tab`,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
-						AppMenu.sendAction('switch-server-tab', (activeTabIndex - 1) % tabs.length);
+						AppMenu.sendAction('switch-server-tab', (activeTabIndex - 1 + tabs.length) % tabs.length);
 					}
 				}
 			});

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -232,17 +232,19 @@ class AppMenu {
 			initialSubmenu.push({
 				label: 'Switch to next organization',
 				accelerator: `Ctrl+Tab`,
+				enabled: tabs[activeTabIndex].props.role === 'server',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
-						AppMenu.sendAction('switch-server-tab', (activeTabIndex + 1) % tabs.length);
+						AppMenu.sendAction('switch-server-tab', AppMenu.getNextServer(tabs, activeTabIndex));
 					}
 				}
 			}, {
 				label: 'Switch to previous organization',
 				accelerator: `Ctrl+Shift+Tab`,
+				enabled: tabs[activeTabIndex].props.role === 'server',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
-						AppMenu.sendAction('switch-server-tab', (activeTabIndex - 1 + tabs.length) % tabs.length);
+						AppMenu.sendAction('switch-server-tab', AppMenu.getPreviousServer(tabs, activeTabIndex));
 					}
 				}
 			});
@@ -447,6 +449,23 @@ class AppMenu {
 	static checkForUpdate() {
 		appUpdater(true);
 	}
+
+	static getNextServer(tabs, activeTabIndex) {
+		do {
+			activeTabIndex = (activeTabIndex + 1) % tabs.length;
+		}
+		while (tabs[activeTabIndex].props.role !== 'server');
+		return activeTabIndex;
+	}
+
+	static getPreviousServer(tabs, activeTabIndex) {
+		do {
+			activeTabIndex = (activeTabIndex - 1 + tabs.length) % tabs.length;
+		}
+		while (tabs[activeTabIndex].props.role !== 'server');
+		return activeTabIndex;
+	}
+
 	static resetAppSettings() {
 		const resetAppSettingsMessage = 'By proceeding you will be removing all connected organizations and preferences from Zulip.';
 


### PR DESCRIPTION
**What's this PR do?**
Fixes #691.

Two changes made-
1. Ctrl+Shift+Tab wasn't working for first org. It should change the active realm to last realm.
2. Disabled org cycling with ctrl+tab on non-server pages.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
