### PR TITLE
Trim domain to first word in server URL

### DIFF
--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -104,6 +104,12 @@ class DomainUtil {
 		return false;
 	}
 
+	trimDomain(domain) {
+		let subDomain = domain.substring(domain.lastIndexOf('://') + 3);
+		subDomain = subDomain.substring(0, subDomain.indexOf('.'));
+		return subDomain;
+	}
+
 	// ignoreCerts parameter helps in fetching server icon and
 	// other server details when user chooses to ignore certificate warnings
 	checkDomain(domain, ignoreCerts = false, silent = false) {
@@ -142,7 +148,7 @@ class DomainUtil {
 		const serverConf = {
 			icon: defaultIconUrl,
 			url: domain,
-			alias: domain,
+			alias: this.trimDomain(domain),
 			ignoreCerts
 		};
 

--- a/app/renderer/js/utils/domain-util.js
+++ b/app/renderer/js/utils/domain-util.js
@@ -105,6 +105,11 @@ class DomainUtil {
 	}
 
 	trimDomain(domain) {
+		/*
+			sometimes, the app is unable to fetch realm_name
+			we then show the first letter character after the protocol scheme
+			instead of the first character of the realm_name
+		*/
 		let subDomain = domain.substring(domain.lastIndexOf('://') + 3);
 		subDomain = subDomain.substring(0, subDomain.indexOf('.'));
 		return subDomain;


### PR DESCRIPTION
If the app is unable to fetch the realm name, the server alias will now
default to first word after the protocol scheme in the server URL.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Changes `serverConf` object so that if the app is unable to save the correct realm name, the sidebar receives the first character of the URL after `://`. 

**Any background context you want to provide?**

Discussion at #675 

**Screenshots?**

![54884441-20dea080-4e97-11e9-9c7d-ccbf4e32d54f](https://user-images.githubusercontent.com/24617297/55289437-64c82d00-53e4-11e9-894e-0131bf4d541e.png)


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS