### PR TITLE
webview: fix focus after soft reload

### DIFF
--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -95,6 +95,11 @@ class WebView extends BaseComponent {
 			}
 			this.loading = false;
 			this.show();
+
+			// Refocus text boxes after reload
+			// Remove when upstream issue https://github.com/electron/electron/issues/14474 is fixed
+			this.$el.blur();
+			this.$el.focus();
 		});
 
 		this.$el.addEventListener('did-fail-load', event => {


### PR DESCRIPTION
Fixes #697.

**What's this PR do?**
Refocuses webview after each reload. 

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
