### PR TITLE
lint: Implement CSS linting with stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,60 @@
+{
+    "rules": {
+      "function-comma-space-after": "always",
+      "function-comma-space-before": "never",
+      "function-max-empty-lines": 0,
+      "function-whitespace-after": "always",
+
+      "value-keyword-case": "lower",
+      "value-list-comma-newline-after": "always-multi-line",
+      "value-list-comma-space-after": "always-single-line",
+      "value-list-comma-space-before": "never",
+      "value-list-max-empty-lines": 0,
+
+      "unit-case": "lower",
+      "property-case": "lower",
+
+      "declaration-bang-space-before": "always",
+      "declaration-colon-newline-after": "always-multi-line",
+      "declaration-colon-space-after": "always-single-line",
+      "declaration-colon-space-before": "never",
+      "declaration-block-semicolon-newline-after": "always",
+      "declaration-block-semicolon-space-before": "never",
+      "declaration-block-trailing-semicolon": "always",
+
+      "block-closing-brace-empty-line-before": "never",
+      "block-closing-brace-newline-after": "always",
+      "block-closing-brace-newline-before": "always",
+      "block-opening-brace-newline-after": "always",
+      "block-opening-brace-space-before": "always",
+
+      "selector-attribute-brackets-space-inside": "never",
+      "selector-attribute-operator-space-after": "never",
+      "selector-attribute-operator-space-before": "never",
+      "selector-combinator-space-after": "always",
+      "selector-combinator-space-before": "always",
+      "selector-descendant-combinator-no-non-space": true,
+      "selector-pseudo-class-parentheses-space-inside": "never",
+      "selector-pseudo-element-case": "lower",
+      "selector-type-case": "lower",
+      "selector-list-comma-newline-after": "always",
+      "selector-list-comma-space-before": "never",
+
+      "media-feature-colon-space-after": "always",
+      "media-feature-colon-space-before": "never",
+      "media-feature-name-case": "lower",
+      "media-feature-parentheses-space-inside": "never",
+      "media-feature-range-operator-space-after": "always",
+      "media-feature-range-operator-space-before": "always",
+      "media-query-list-comma-newline-after": "always",
+      "media-query-list-comma-space-before": "never",
+
+      "at-rule-name-case": "lower",
+      "at-rule-name-space-after": "always",
+      "at-rule-semicolon-newline-after": "always",
+      "at-rule-semicolon-space-before": "never",
+
+      "comment-whitespace-inside": "always",
+      "indentation": 4
+    }
+}

--- a/app/renderer/css/about.css
+++ b/app/renderer/css/about.css
@@ -1,66 +1,66 @@
 body {
-	background: #fafafa;
-	font-family: menu, "Helvetica Neue", sans-serif;
-	-webkit-font-smoothing: subpixel-antialiased;
+    background: #fafafa;
+    font-family: menu, "Helvetica Neue", sans-serif;
+    -webkit-font-smoothing: subpixel-antialiased;
 }
 
 .logo {
-	display: block;
-	margin: -40px auto;
+    display: block;
+    margin: -40px auto;
 }
 
 #version {
-	color: #444343;
-	font-size: 1.3em;
-	padding-top: 40px;
+    color: #444343;
+    font-size: 1.3em;
+    padding-top: 40px;
 }
 
 .about {
-	margin: 25vh auto;
-	height: 25vh;
-	text-align: center;
+    margin: 25vh auto;
+    height: 25vh;
+    text-align: center;
 }
 
 .about p {
-	font-size: 20px;
-	color: rgba(0, 0, 0, 0.62);
+    font-size: 20px;
+    color: rgba(0, 0, 0, 0.62);
 }
 
 .about img {
-	width: 150px;
+    width: 150px;
 }
 
 .detail {
-	text-align: center;
+    text-align: center;
 }
 
 .detail.maintainer {
-	font-size: 1.2em;
-	font-weight: 500;
+    font-size: 1.2em;
+    font-weight: 500;
 }
 
 .detail.license {
-	font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .maintenance-info {
-	cursor: pointer;
-	position: absolute;
-	width: 100%;
-	left: 0px;
-	color: #444;
+    cursor: pointer;
+    position: absolute;
+    width: 100%;
+    left: 0px;
+    color: #444;
 }
 
 .maintenance-info p {
-	margin: 0;
-	font-size: 1em;
-	width: 100%;
+    margin: 0;
+    font-size: 1em;
+    width: 100%;
 }
 
 p.detail a {
-	color: #355f4c;
+    color: #355f4c;
 }
 
 p.detail a:hover {
-	text-decoration: underline;
+    text-decoration: underline;
 }

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -43,25 +43,25 @@ body {
 }
 
 #view-controls-container {
-	height: calc(100% - 208px);
-	overflow-y: hidden;
+    height: calc(100% - 208px);
+    overflow-y: hidden;
 }
 
 #view-controls-container:hover {
-	overflow-y: overlay;
+    overflow-y: overlay;
 }
 
 #view-controls-container::-webkit-scrollbar {
-	width: 4px;
+    width: 4px;
 }
 
 #view-controls-container::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 }
 
 #view-controls-container::-webkit-scrollbar-thumb {
-  background-color: darkgrey;
-  outline: 1px solid slategrey;
+    background-color: darkgrey;
+    outline: 1px solid slategrey;
 }
 
 @font-face {
@@ -278,7 +278,7 @@ body {
     width: 100%;
 }
 
-/*Pseudo element for loading indicator*/
+/* Pseudo element for loading indicator */
 #webviews-container::before {
     content: "";
     position: absolute;
@@ -290,7 +290,7 @@ body {
     height: 100%;
 }
 
-/*When the active webview is loaded*/
+/* When the active webview is loaded */
 #webviews-container.loaded::before {
     opacity: 0;
     z-index: -1;
@@ -453,24 +453,24 @@ webview.focus {
 }
 
 send-feedback {
-  width: 60%;
-  height: 85%;
+    width: 60%;
+    height: 85%;
 }
 
 #feedback-modal {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(68, 67, 67, 0.81);
-  align-items: center;
-  justify-content: center;
-  z-index: 2;
-  transition: all 1s ease-out;
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(68, 67, 67, 0.81);
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+    transition: all 1s ease-out;
 }
 
 #feedback-modal.show {
-  display: flex;
+    display: flex;
 }

--- a/app/renderer/css/network.css
+++ b/app/renderer/css/network.css
@@ -1,10 +1,11 @@
-html, body {
+html,
+body {
     margin: 0;
     cursor: default;
     font-size: 14px;
     color: #333;
     background: #fff;
-    user-select:none;
+    user-select: none;
 }
 
 #content {

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -287,7 +287,7 @@ img.server-info-icon {
 
 .settings-pane {
     flex-grow: 1;
-	min-width: 550px;
+    min-width: 550px;
 }
 
 .action:hover {
@@ -441,7 +441,7 @@ i.open-tab-button {
     visibility: hidden;
 }
 
-.toggle+label {
+.toggle + label {
     display: block;
     position: relative;
     cursor: pointer;
@@ -449,7 +449,7 @@ i.open-tab-button {
     user-select: none;
 }
 
-input.toggle-round+label {
+input.toggle-round + label {
     padding: 2px;
     width: 50px;
     height: 25px;
@@ -457,8 +457,8 @@ input.toggle-round+label {
     border-radius: 25px;
 }
 
-input.toggle-round+label:before,
-input.toggle-round+label:after {
+input.toggle-round + label:before,
+input.toggle-round + label:after {
     display: block;
     position: absolute;
     top: 2px;
@@ -467,7 +467,7 @@ input.toggle-round+label:after {
     content: "";
 }
 
-input.toggle-round+label:before {
+input.toggle-round + label:before {
     background-color: #f1f1f1;
     border-radius: 25px;
     top: 0;
@@ -476,14 +476,14 @@ input.toggle-round+label:before {
     bottom: 0px;
 }
 
-input.toggle-round+label:after {
+input.toggle-round + label:after {
     width: 25px;
     height: 25px;
     background-color: #fff;
     border-radius: 100%;
 }
 
-input.toggle-round:checked+label:before {
+input.toggle-round:checked + label:before {
     background-color: #4EBFAC;
     top: 0;
     right: 0px;
@@ -491,7 +491,7 @@ input.toggle-round:checked+label:before {
     bottom: 0px;
 }
 
-input.toggle-round:checked+label:after {
+input.toggle-round:checked + label:after {
     margin-left: 25px;
 }
 
@@ -582,7 +582,7 @@ input.toggle-round:checked+label:after {
 }
 
 .certificates-card {
-    width: 80%
+    width: 80%;
 }
 
 .certificate-input {
@@ -609,8 +609,8 @@ input.toggle-round:checked+label:after {
     padding: 0;
 }
 
-.tip:hover{
-   box-shadow: none;
+.tip:hover {
+    box-shadow: none;
 }
 
 .md-14 {

--- a/app/renderer/css/preload.css
+++ b/app/renderer/css/preload.css
@@ -1,9 +1,9 @@
 /* Override css rules */
 
-.portico-wrap>.header {
+.portico-wrap > .header {
     display: none;
 }
 
-.portico-container>.footer {
+.portico-container > .footer {
     display: none;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "electron app --disable-http-cache --no-electron-connect",
     "reinstall": "node ./tools/reinstall-node-modules.js",
     "postinstall": "electron-builder install-app-deps",
-    "test": "xo",
+    "test": "stylelint app/renderer/css/*.css && xo",
     "test-e2e": "gulp test-e2e",
     "dev": "gulp dev & nodemon --watch app/main --watch app/renderer --exec 'npm test' -e html,css,js",
     "pack": "electron-builder --dir",
@@ -132,6 +132,7 @@
     "nodemon": "^1.14.11",
     "pre-commit": "1.2.2",
     "spectron": "^5.0.0",
+    "stylelint": "^9.10.1",
     "tap-colorize": "^1.2.0",
     "tape": "^4.8.0",
     "xo": "0.18.2"
@@ -179,5 +180,65 @@
       "browser",
       "mocha"
     ]
+  },
+  "stylelint": {
+    "rules": {
+      "function-comma-space-after": "always",
+      "function-comma-space-before": "never",
+      "function-max-empty-lines": 0,
+      "function-whitespace-after": "always",
+
+      "value-keyword-case": "lower",
+      "value-list-comma-newline-after": "always-multi-line",
+      "value-list-comma-space-after": "always-single-line",
+      "value-list-comma-space-before": "never",
+      "value-list-max-empty-lines": 0,
+
+      "unit-case": "lower",
+      "property-case": "lower",
+
+      "declaration-bang-space-before": "always",
+      "declaration-colon-newline-after": "always-multi-line",
+      "declaration-colon-space-after": "always-single-line",
+      "declaration-colon-space-before": "never",
+      "declaration-block-semicolon-newline-after": "always",
+      "declaration-block-semicolon-space-before": "never",
+      "declaration-block-trailing-semicolon": "always",
+
+      "block-closing-brace-empty-line-before": "never",
+      "block-closing-brace-newline-after": "always",
+      "block-closing-brace-newline-before": "always",
+      "block-opening-brace-newline-after": "always",
+      "block-opening-brace-space-before": "always",
+
+      "selector-attribute-brackets-space-inside": "never",
+      "selector-attribute-operator-space-after": "never",
+      "selector-attribute-operator-space-before": "never",
+      "selector-combinator-space-after": "always",
+      "selector-combinator-space-before": "always",
+      "selector-descendant-combinator-no-non-space": true,
+      "selector-pseudo-class-parentheses-space-inside": "never",
+      "selector-pseudo-element-case": "lower",
+      "selector-type-case": "lower",
+      "selector-list-comma-newline-after": "always",
+      "selector-list-comma-space-before": "never",
+
+      "media-feature-colon-space-after": "always",
+      "media-feature-colon-space-before": "never",
+      "media-feature-name-case": "lower",
+      "media-feature-parentheses-space-inside": "never",
+      "media-feature-range-operator-space-after": "always",
+      "media-feature-range-operator-space-before": "always",
+      "media-query-list-comma-newline-after": "always",
+      "media-query-list-comma-space-before": "never",
+
+      "at-rule-name-case": "lower",
+      "at-rule-name-space-after": "always",
+      "at-rule-semicolon-newline-after": "always",
+      "at-rule-semicolon-space-before": "never",
+
+      "comment-whitespace-inside": "always",
+      "indentation": 4
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "start": "electron app --disable-http-cache --no-electron-connect",
     "reinstall": "node ./tools/reinstall-node-modules.js",
     "postinstall": "electron-builder install-app-deps",
-    "test": "stylelint app/renderer/css/*.css && xo",
+    "lint-css": "stylelint app/renderer/css/*.css",
+    "lint-js": "xo",
+    "test": "npm run lint-css && npm run lint-js",
     "test-e2e": "gulp test-e2e",
     "dev": "gulp dev & nodemon --watch app/main --watch app/renderer --exec 'npm test' -e html,css,js",
     "pack": "electron-builder --dir",
@@ -180,65 +182,5 @@
       "browser",
       "mocha"
     ]
-  },
-  "stylelint": {
-    "rules": {
-      "function-comma-space-after": "always",
-      "function-comma-space-before": "never",
-      "function-max-empty-lines": 0,
-      "function-whitespace-after": "always",
-
-      "value-keyword-case": "lower",
-      "value-list-comma-newline-after": "always-multi-line",
-      "value-list-comma-space-after": "always-single-line",
-      "value-list-comma-space-before": "never",
-      "value-list-max-empty-lines": 0,
-
-      "unit-case": "lower",
-      "property-case": "lower",
-
-      "declaration-bang-space-before": "always",
-      "declaration-colon-newline-after": "always-multi-line",
-      "declaration-colon-space-after": "always-single-line",
-      "declaration-colon-space-before": "never",
-      "declaration-block-semicolon-newline-after": "always",
-      "declaration-block-semicolon-space-before": "never",
-      "declaration-block-trailing-semicolon": "always",
-
-      "block-closing-brace-empty-line-before": "never",
-      "block-closing-brace-newline-after": "always",
-      "block-closing-brace-newline-before": "always",
-      "block-opening-brace-newline-after": "always",
-      "block-opening-brace-space-before": "always",
-
-      "selector-attribute-brackets-space-inside": "never",
-      "selector-attribute-operator-space-after": "never",
-      "selector-attribute-operator-space-before": "never",
-      "selector-combinator-space-after": "always",
-      "selector-combinator-space-before": "always",
-      "selector-descendant-combinator-no-non-space": true,
-      "selector-pseudo-class-parentheses-space-inside": "never",
-      "selector-pseudo-element-case": "lower",
-      "selector-type-case": "lower",
-      "selector-list-comma-newline-after": "always",
-      "selector-list-comma-space-before": "never",
-
-      "media-feature-colon-space-after": "always",
-      "media-feature-colon-space-before": "never",
-      "media-feature-name-case": "lower",
-      "media-feature-parentheses-space-inside": "never",
-      "media-feature-range-operator-space-after": "always",
-      "media-feature-range-operator-space-before": "always",
-      "media-query-list-comma-newline-after": "always",
-      "media-query-list-comma-space-before": "never",
-
-      "at-rule-name-case": "lower",
-      "at-rule-name-space-after": "always",
-      "at-rule-semicolon-newline-after": "always",
-      "at-rule-semicolon-space-before": "never",
-
-      "comment-whitespace-inside": "always",
-      "indentation": 4
-    }
   }
 }


### PR DESCRIPTION
Adds linting to CSS files using stylelint.
Closes the CSS part of #676.

**What's this PR do?**
Implements CSS linting using [stylelint](https://github.com/stylelint/stylelint).
Format CSS file according to zulip webapp's [lint config](https://github.com/zulip/zulip/blob/master/.stylelintrc).

Some options have been excluded from lint config which are-
1. "color-hex-case": "lower"
2. "selector-pseudo-element-colon-notation": "double"
3. "color-no-hex": true
4. "color-named": "never"

These rules required changing more than just spaces and tabs, so i excluded them. I intend to add them separately later after this PR is merged.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
