### PR TITLE
Revert to fallback icon only when needed

### DIFF
--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -247,12 +247,15 @@ class DomainUtil {
 
 	updateSavedServer(url: string, index: number): void {
 		// Does not promise successful update
+		const oldIcon = this.getDomain(index).icon;
 		const { ignoreCerts } = this.getDomain(index);
 		this.checkDomain(url, ignoreCerts, true).then(newServerConf => {
 			this.saveServerIcon(newServerConf, ignoreCerts).then(localIconUrl => {
-				newServerConf.icon = localIconUrl;
-				this.updateDomain(index, newServerConf);
-				this.reloadDB();
+				if (!oldIcon || localIconUrl !== '../renderer/img/icon.png') {
+					newServerConf.icon = localIconUrl;
+					this.updateDomain(index, newServerConf);
+					this.reloadDB();
+				}
 			});
 		});
 	}


### PR DESCRIPTION
We currently check if the server icon has updated everytime the app
loads. If a network error happens and the app can't fetch this icon,
then the character icon is loaded next time even though the original
server icon was saved in user's app data. This commit forces the app to
consider the original icon in such cases.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**Any background context you want to provide?**

Discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/realm.20icon.20in.20dock/near/716234) and [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/realm-icon). 

**Screenshots?**

![image](https://user-images.githubusercontent.com/24617297/55684017-124abb80-5964-11e9-8a6c-eb6cf4f66d73.png)


**Testing procedure**

Load the app once. Make sure the icons render properly in the sidebar. Then go to `domain-util` and change the `saveServerIcon()` method to something similar:

```javascript
saveServerIcon(server, ignoreCerts = false) {
	const url = 'https://fsjfbsk.com';
	const domain = server.url;
```

Reload the app a couple of times. The server icon should stay the same even though the URL is incorrect.


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
