### PR TITLE
menu: Reorder file menu and add option to Add Organization.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -259,6 +259,21 @@ class AppMenu {
 		return [{
 			label: `${app.getName()}`,
 			submenu: [{
+				label: 'Add Organization',
+				accelerator: 'Cmd+Shift+N',
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('new-server');
+					}
+				}
+			}, {
+				label: 'Toggle Do Not Disturb',
+				accelerator: 'Cmd+Shift+M',
+				click() {
+					const dndUtil = DNDUtil.toggle();
+					AppMenu.sendAction('toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
+				}
+			}, {
 				label: 'Desktop Settings',
 				accelerator: 'Cmd+,',
 				click(item, focusedWindow) {
@@ -278,13 +293,6 @@ class AppMenu {
 			}, {
 				type: 'separator'
 			}, {
-				label: 'Toggle Do Not Disturb',
-				accelerator: 'Command+Shift+M',
-				click() {
-					const dndUtil = DNDUtil.toggle();
-					AppMenu.sendAction('toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
-				}
-			}, {
 				label: 'Copy Zulip URL',
 				accelerator: 'Cmd+Shift+C',
 				click(item, focusedWindow) {
@@ -293,7 +301,7 @@ class AppMenu {
 					}
 				}
 			}, {
-				label: 'Log Out',
+				label: 'Log Out of Organization',
 				accelerator: 'Cmd+L',
 				enabled: enableMenu,
 				click(item, focusedWindow) {
@@ -316,6 +324,10 @@ class AppMenu {
 				role: 'unhide'
 			}, {
 				type: 'separator'
+			}, {
+				role: 'minimize'
+			}, {
+				role: 'close'
 			}, {
 				role: 'quit'
 			}]
@@ -362,22 +374,11 @@ class AppMenu {
 		return [{
 			label: '&File',
 			submenu: [{
-				label: 'Desktop Settings',
-				accelerator: 'Ctrl+,',
+				label: 'Add Organization',
+				accelerator: 'Ctrl+Shift+N',
 				click(item, focusedWindow) {
 					if (focusedWindow) {
-						AppMenu.sendAction('open-settings');
-					}
-				}
-			}, {
-				type: 'separator'
-			}, {
-				label: 'Keyboard Shortcuts',
-				accelerator: 'Ctrl+Shift+K',
-				enabled: enableMenu,
-				click(item, focusedWindow) {
-					if (focusedWindow) {
-						AppMenu.sendAction('shortcut');
+						AppMenu.sendAction('new-server');
 					}
 				}
 			}, {
@@ -390,6 +391,25 @@ class AppMenu {
 					AppMenu.sendAction('toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
 				}
 			}, {
+				label: 'Desktop Settings',
+				accelerator: 'Ctrl+,',
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('open-settings');
+					}
+				}
+			}, {
+				label: 'Keyboard Shortcuts',
+				accelerator: 'Ctrl+Shift+K',
+				enabled: enableMenu,
+				click(item, focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('shortcut');
+					}
+				}
+			}, {
+				type: 'separator'
+			}, {
 				label: 'Copy Zulip URL',
 				accelerator: 'Ctrl+Shift+C',
 				click(item, focusedWindow) {
@@ -398,7 +418,7 @@ class AppMenu {
 					}
 				}
 			}, {
-				label: 'Log Out',
+				label: 'Log Out of Organization',
 				accelerator: 'Ctrl+L',
 				enabled: enableMenu,
 				click(item, focusedWindow) {
@@ -408,6 +428,10 @@ class AppMenu {
 				}
 			}, {
 				type: 'separator'
+			}, {
+				role: 'minimize'
+			}, {
+				role: 'close'
 			}, {
 				role: 'quit',
 				accelerator: 'Ctrl+Q'

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -734,6 +734,10 @@ class ServerManagerView {
 		ipcRenderer.on('copy-zulip-url', () => {
 			clipboard.writeText(DomainUtil.getDomain(this.activeTabIndex).url);
 		});
+
+		ipcRenderer.on('new-server', () => {
+			this.openSettings('AddServer');
+		});
 	}
 }
 


### PR DESCRIPTION
**What's this PR do?**
Reorder the File Menu. Also, adds a new option to
add a new organization to the file menu.

Changes made according to the discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Zulip.20URL).

Someone needs to test this on macOS.

**Screenshots?**
![Screenshot from 2019-04-07 21-30-07](https://user-images.githubusercontent.com/21038781/55686254-75e0e300-597c-11e9-8ab8-a96b6307634c.png)

Separators aren't visible on my system because of issue [here](https://github.com/zulip/zulip-electron/issues/689).

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
