### PR TITLE
[WIP] Add zulip:// URI scheme for navigating within app

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -27,7 +27,6 @@ if (isDev) {
 let mainWindow;
 let badgeCount;
 let deepLinkingUrl;
-let execPath;
 
 let isQuitting = false;
 
@@ -41,7 +40,7 @@ if (singleInstanceLock) {
 		if (process.platform === 'win32') {
 			deepLinkingUrl = argv.slice(1);
 			if (mainWindow) {
-				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl);
+				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[isDev ? 1 : 0]);
 			}
 		}
 
@@ -139,10 +138,11 @@ function createMainWindow() {
 // Decrease load on GPU (experimental)
 app.disableHardwareAcceleration();
 
-if (process.platform === 'win32') {
-	execPath = 'C:\\Program Files\\Zulip\\Zulip.exe';
+if (process.platform === 'win32' && isDev) {
+	app.setAsDefaultProtocolClient('zulip', process.execPath, [path.resolve(process.argv[1])]);
+} else {
+	app.setAsDefaultProtocolClient('zulip');
 }
-app.setAsDefaultProtocolClient('zulip', execPath);
 
 // uri scheme handler for macOS
 app.on('open-url', (event, url) => {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -39,10 +39,7 @@ if (singleInstanceLock) {
 		// uri scheme handler for windows and linux
 		if (process.platform !== 'darwin') {
 			deepLinkingUrl = argv.slice(1);
-			if (mainWindow) {
-				mainWindow.webContents.focus();
-				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
-			}
+			handleDeepLink(deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
 		}
 
 		if (mainWindow) {
@@ -62,6 +59,13 @@ const APP_ICON = path.join(__dirname, '../resources', 'Icon');
 const iconPath = () => {
 	return APP_ICON + (process.platform === 'win32' ? '.ico' : '.png');
 };
+
+function handleDeepLink(deepLinkingUrl) {
+	if (mainWindow) {
+		mainWindow.webContents.focus();
+		mainWindow.webContents.send('deep-linking-url', deepLinkingUrl);
+	}
+}
 
 function createMainWindow() {
 	// Load the previous state with fallback to defaults
@@ -211,10 +215,7 @@ app.on('ready', () => {
 
 	if (process.platform !== 'darwin') {
 		deepLinkingUrl = process.argv.slice(1);
-		if (mainWindow) {
-			mainWindow.webContents.focus();
-			mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
-		}
+		handleDeepLink(deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
 	}
 
 	// Temporarily remove this event

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -36,11 +36,12 @@ const mainURL = 'file://' + path.join(__dirname, '../renderer', 'main.html');
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (singleInstanceLock) {
 	app.on('second-instance', (event, argv) => {
-		// uri scheme handler for windows
-		if (process.platform === 'win32') {
+		// uri scheme handler for windows and linux
+		if (process.platform !== 'darwin') {
 			deepLinkingUrl = argv.slice(1);
 			if (mainWindow) {
-				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[isDev ? 1 : 0]);
+				mainWindow.webContents.focus();
+				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
 			}
 		}
 

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -36,10 +36,13 @@ const mainURL = 'file://' + path.join(__dirname, '../renderer', 'main.html');
 
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (singleInstanceLock) {
-	app.on('second-instance', (event, argv, cwd) => {
+	app.on('second-instance', (event, argv) => {
 		// uri scheme handler for windows
 		if (process.platform === 'win32') {
 			deepLinkingUrl = argv.slice(1);
+			if (mainWindow) {
+				mainWindow.webContents.send('deep-linking-url', deepLinkingUrl);
+			}
 		}
 
 		if (mainWindow) {
@@ -145,6 +148,9 @@ app.setAsDefaultProtocolClient('zulip', execPath);
 app.on('open-url', (event, url) => {
 	event.preventDefault();
 	deepLinkingUrl = url;
+	if (mainWindow) {
+		mainWindow.webContents.send('deep-linking-url', deepLinkingUrl);
+	}
 });
 
 // Temporary fix for Electron render colors differently

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -209,6 +209,14 @@ app.on('ready', () => {
 		}
 	});
 
+	if (process.platform !== 'darwin') {
+		deepLinkingUrl = process.argv.slice(1);
+		if (mainWindow) {
+			mainWindow.webContents.focus();
+			mainWindow.webContents.send('deep-linking-url', deepLinkingUrl[(isDev && process.platform === 'win32') ? 1 : 0]);
+		}
+	}
+
 	// Temporarily remove this event
 	// electron.powerMonitor.on('resume', () => {
 	// 	mainWindow.reload();

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -20,6 +20,7 @@ class WebView extends BaseComponent {
 		this.zoomFactor = 1.0;
 		this.loading = true;
 		this.badgeCount = 0;
+		this.redirected = false;
 		this.customCSS = ConfigUtil.getConfigItem('customCSS');
 		this.$webviewsContainer = document.querySelector('#webviews-container').classList;
 	}
@@ -128,10 +129,10 @@ class WebView extends BaseComponent {
 
 	show() {
 		// Do not show WebView if another tab was selected and this tab should be in background.
-		if (!this.props.isActive()) {
+		if (!this.props.isActive() && !this.redirected) {
 			return;
 		}
-
+		this.redirected = false;
 		// To show or hide the loading indicator in the the active tab
 		if (this.loading) {
 			this.$webviewsContainer.remove('loaded');
@@ -250,6 +251,12 @@ class WebView extends BaseComponent {
 		this.$webviewsContainer.remove('loaded');
 		this.loading = true;
 		this.$el.reload();
+	}
+
+	redirect(url) {
+		this.loading = true;
+		this.$el.src = url;
+		this.redirected = true;
 	}
 
 	send(...param) {

--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -254,6 +254,8 @@ class WebView extends BaseComponent {
 	}
 
 	redirect(url) {
+		this.hide();
+		this.$webviewsContainer.remove('loaded');
 		this.loading = true;
 		this.$el.src = url;
 		this.redirected = true;

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -644,7 +644,7 @@ class ServerManagerView {
 		});
 
 		ipcRenderer.on('deep-linking-url', (event, deepLinkingUrl) => {
-			let url = 'https' + deepLinkingUrl[0].substring(5);
+			let url = 'https' + deepLinkingUrl.substring(5);
 			if (url.charAt(url.length - 1) === '/') {
 				// invoked when url is directly entered in browser
 				// remove / character at the end of the url

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -16,6 +16,7 @@ const DNDUtil = require(__dirname + '/js/utils/dnd-util.js');
 const ReconnectUtil = require(__dirname + '/js/utils/reconnect-util.js');
 const Logger = require(__dirname + '/js/utils/logger-util.js');
 const CommonUtil = require(__dirname + '/js/utils/common-util.js');
+const LinkUtil = require(__dirname + '/js/utils/link-util.js');
 
 const { feedbackHolder } = require(__dirname + '/js/feedback.js');
 
@@ -550,16 +551,6 @@ class ServerManagerView {
 		});
 	}
 
-	isURLNarrow(url) {
-		const domains = DomainUtil.getDomains();
-		for (const domain in domains) {
-			if (url.startsWith(domains[domain].url)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	registerIpcs() {
 		const webviewListeners = {
 			'webview-reload': 'reload',
@@ -659,10 +650,11 @@ class ServerManagerView {
 				// remove / character at the end of the url
 				url = url.slice(0, -1);
 			}
-			if (this.isURLNarrow(url)) {
+			if (LinkUtil.isURLNarrow(url)) {
 				for (const tab in this.tabs) {
 					if (url.startsWith(this.tabs[tab].webview.props.url)) {
 						this.activateTab(tab);
+						this.tabs[tab].webview.redirect(url);
 					}
 				}
 			}

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -550,6 +550,16 @@ class ServerManagerView {
 		});
 	}
 
+	isURLNarrow(url) {
+		const domains = DomainUtil.getDomains();
+		for (const domain in domains) {
+			if (url.startsWith(domains[domain].url)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	registerIpcs() {
 		const webviewListeners = {
 			'webview-reload': 'reload',
@@ -640,6 +650,22 @@ class ServerManagerView {
 			const webview = document.querySelector(selector);
 			const webContents = webview.getWebContents();
 			webContents.send('toggle-dnd', state, newSettings);
+		});
+
+		ipcRenderer.on('deep-linking-url', (event, deepLinkingUrl) => {
+			let url = 'https' + deepLinkingUrl[0].substring(5);
+			if (url.charAt(url.length - 1) === '/') {
+				// invoked when url is directly entered in browser
+				// remove / character at the end of the url
+				url = url.slice(0, -1);
+			}
+			if (this.isURLNarrow(url)) {
+				for (const tab in this.tabs) {
+					if (url.startsWith(this.tabs[tab].webview.props.url)) {
+						this.activateTab(tab);
+					}
+				}
+			}
 		});
 
 		ipcRenderer.on('update-realm-name', (event, serverURL, realmName) => {

--- a/app/renderer/js/utils/link-util.js
+++ b/app/renderer/js/utils/link-util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const wurl = require('wurl');
+const DomainUtil = require('./domain-util.js');
 
 let instance = null;
 
@@ -13,6 +14,16 @@ class LinkUtil {
 		}
 
 		return instance;
+	}
+
+	isURLNarrow(url) {
+		const domains = DomainUtil.getDomains();
+		for (const domain in domains) {
+			if (url.startsWith(domains[domain].url)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	isInternal(currentUrl, newUrl) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,12 @@
       "!docs${/*}",
       "!node_modules/@paulcbetts/cld/deps/cld${/*}"
     ],
+    "protocols": [
+      {
+        "name": "Zulip",
+        "schemes": ["zulip"]
+      }
+    ],
     "copyright": "©2019 Kandra Labs, Inc.",
     "mac": {
       "category": "public.app-category.productivity",


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Registers links starting with zulip:// to open with the Zulip app. Redirects users with installed app to the correct narrow and server (only if the domain is already saved) in the desktop app.

**Any background context you want to provide?**

Discussion at #470.

**Screenshots?**

![deeplinking](https://user-images.githubusercontent.com/24617297/55737352-a723e680-5a42-11e9-9551-17ce14d71db4.gif)


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
