### PR TITLE
shortcut: Allow zoom options from numpad.

### DIFF
--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -91,8 +91,15 @@ window.addEventListener('beforeunload', () => {
 
 // electron's globalShortcut can cause unexpected results
 // so adding the reload shortcut in the old-school way
+// Zoom from numpad keys is not supported by electron, so adding it through listeners.
 document.addEventListener('keydown', event => {
 	if (event.code === 'F5') {
 		ipcRenderer.send('forward-message', 'hard-reload');
+	} else if (event.ctrlKey && event.code === 'NumpadAdd') {
+		ipcRenderer.send('forward-message', 'zoomIn');
+	} else if (event.ctrlKey && event.code === 'NumpadSubtract') {
+		ipcRenderer.send('forward-message', 'zoomOut');
+	} else if (event.ctrlKey && event.code === 'Numpad0') {
+		ipcRenderer.send('forward-message', 'zoomActualSize');
 	}
 });


### PR DESCRIPTION
Numpad keys by default aren't supported by electron
for using in menu accelarators. Uses a workaround to
make zoom options work with Numpad keys.

Fixes #344.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
