### PR TITLE
nsis: Allow install without admin previliges.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
       "publisherName": "Kandra Labs, Inc."
     },
     "nsis": {
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "oneClick": false,
+      "perMachine": false
     }
   },
   "keywords": [


### PR DESCRIPTION
Allow the nsis installer to install the app to
AppData for a single user so that administrator
previliges are not required while installing.

Fixes #720.

Refer to electron nsis config page [here](https://www.electron.build/configuration/nsis) for more info.
> If oneClick is false and perMachine is false (default): install mode installer page.

**Screenshots?**
![Screenshot (203)](https://user-images.githubusercontent.com/21038781/55960265-045da900-5c8a-11e9-8946-9b533deeef9e.png)
![Screenshot (202)](https://user-images.githubusercontent.com/21038781/55960293-12abc500-5c8a-11e9-9ee8-a7a13004da7e.png)


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
