### PR TITLE
Fix tip's place from bottom to top for Windows and Linux

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -605,8 +605,6 @@ input.toggle-round:checked+label:after {
 }
 
 .tip {
-    display: flex;
-    justify-content: center;
     background: none;
     padding: 0;
 }

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -605,6 +605,8 @@ input.toggle-round:checked+label:after {
 }
 
 .tip {
+    display: flex;
+    justify-content: center;
     background: none;
     padding: 0;
 }

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -178,6 +178,7 @@ class ShortcutsSection extends BaseSection {
 
 		return `
             <div class="settings-pane">
+            <div class="settings-card tip"><p><b><i class="material-icons md-14">settings</i>Tip:  </b>These desktop app shortcuts extend the Zulip webapp's <span id="open-hotkeys-link"> keyboard shortcuts</span>.</p></div>
               <div class="title">Application Shortcuts</div>
               <div class="settings-card">
                 <table>
@@ -316,7 +317,6 @@ class ShortcutsSection extends BaseSection {
                 </table>
                 <div class="setting-control"></div>
               </div>
-              <div class="tip"><b><i class="material-icons md-14">lightbulb_outline</i>Tip: </b>These desktop app shortcuts extend the Zulip webapp's <span id="open-hotkeys-link">keyboard shortcuts</span>.</div>
             </div>
 		`;
 	}


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
This PR fix tip's place from bottom to top for Windows and Linux and align the tip's text in the center.

**Any background context you want to provide?**
Settings QA:  #566, Rishi Gupta suggested a change for `TIP` in `Settings: Shortcuts`, the changes are only made for MacOs, though the work for Windows and Linux is remaining.

**Screenshots?**
![Screenshot from 2019-04-11 19-11-27](https://user-images.githubusercontent.com/36422396/55964396-425ecb00-5c92-11e9-848c-9724df47edb0.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
