### PR TITLE
network: Tackle network issues independently.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
     "@sentry/electron": "0.14.0",
     "adm-zip": "0.4.11",
     "auto-launch": "5.0.5",
+    "backoff": "2.5.0",
     "dotenv": "8.0.0",
     "electron-is-dev": "0.3.0",
     "electron-log": "2.2.14",

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,6 @@
     "electron-window-state": "5.0.3",
     "escape-html": "1.0.3",
     "i18n": "0.8.3",
-    "is-online": "7.0.0",
     "node-json-db": "0.9.2",
     "request": "2.85.0",
     "semver": "5.4.1",

--- a/app/renderer/css/network.css
+++ b/app/renderer/css/network.css
@@ -17,27 +17,43 @@ body {
 }
 
 #title {
+    text-align: left;
     font-size: 24px;
     font-weight: bold;
     margin: 20px 0;
 }
 
+#subtitle {
+    font-size: 20px;
+    text-align: left;
+    margin: 12px 0;
+}
+
 #description {
+    text-align: left;
     font-size: 16px;
+    list-style-position: inside;
 }
 
 #reconnect {
+    float: left;
+}
+
+#settings {
+    margin-left: 116px;
+}
+
+.button {
     font-size: 16px;
     background: rgba(0, 150, 136, 1.000);
     color: rgba(255, 255, 255, 1.000);
-    width: 84px;
+    width: 96px;
     height: 32px;
     border-radius: 5px;
     line-height: 32px;
-    margin: 20px auto 0;
     cursor: pointer;
 }
 
-#reconnect:hover {
+.button:hover {
     opacity: 0.8;
 }

--- a/app/renderer/js/components/tab.ts
+++ b/app/renderer/js/components/tab.ts
@@ -25,6 +25,10 @@ class Tab extends BaseComponent {
 		this.$el.addEventListener('mouseout', this.props.onHoverOut);
 	}
 
+	showNetworkError(): void {
+		this.webview.forceLoad();
+	}
+
 	activate(): void {
 		this.$el.classList.add('active');
 		this.webview.load();

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -125,7 +125,9 @@ class WebView extends BaseComponent {
 			const hasConnectivityErr = SystemUtil.connectivityERR.includes(errorDescription);
 			if (hasConnectivityErr) {
 				console.error('error', errorDescription);
-				this.props.onNetworkError(this.props.index);
+				if (!this.props.url.includes('network.html')) {
+					this.props.onNetworkError(this.props.index);
+				}
 			}
 		});
 

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -125,7 +125,7 @@ class WebView extends BaseComponent {
 			const hasConnectivityErr = SystemUtil.connectivityERR.includes(errorDescription);
 			if (hasConnectivityErr) {
 				console.error('error', errorDescription);
-				this.props.onNetworkError();
+				this.props.onNetworkError(this.props.index);
 			}
 		});
 
@@ -281,6 +281,10 @@ class WebView extends BaseComponent {
 		this.loading = true;
 		this.props.switchLoading(true, this.props.url);
 		this.$el.reload();
+	}
+
+	forceLoad(): void {
+		this.init();
 	}
 
 	send(channel: string, ...param: any[]): void {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -23,11 +23,6 @@ import CommonUtil = require('./utils/common-util');
 import EnterpriseUtil = require('./utils/enterprise-util');
 import Messages = require('./../../resources/messages');
 
-const logger = new Logger({
-	file: 'errors.log',
-	timestamp: true
-});
-
 interface FunctionalTabProps {
 	name: string;
 	materialIcon: string;
@@ -67,6 +62,11 @@ interface SettingsOptions {
 	dockBouncing?: boolean;
 	loading?: AnyObject;
 }
+
+const logger = new Logger({
+	file: 'errors.log',
+	timestamp: true
+});
 
 const rendererDirectory = path.resolve(__dirname, '..');
 type ServerOrFunctionalTab = ServerTab | FunctionalTab;
@@ -569,6 +569,8 @@ class ServerManagerView {
 	}
 
 	openNetworkTroubleshooting(index: number): void {
+		const reconnectUtil = new ReconnectUtil(this.tabs[index].webview);
+		reconnectUtil.pollInternetAndReload();
 		this.tabs[index].webview.props.url = `file://${rendererDirectory}/network.html`;
 		this.tabs[index].showNetworkError();
 	}
@@ -996,17 +998,7 @@ class ServerManagerView {
 
 window.addEventListener('load', () => {
 	const serverManagerView = new ServerManagerView();
-	const reconnectUtil = new ReconnectUtil(serverManagerView);
 	serverManagerView.init();
-	window.addEventListener('online', () => {
-		reconnectUtil.pollInternetAndReload();
-	});
-
-	window.addEventListener('offline', () => {
-		reconnectUtil.clearState();
-		logger.log('No internet connection, you are offline.');
-	});
-
 	// only start electron-connect (auto reload on change) when its ran
 	// from `npm run dev` or `gulp dev` and not from `npm start` when
 	// app is started `npm start` main process's proces.argv will have

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -370,7 +370,7 @@ class ServerManagerView {
 					}
 					this.showLoading(this.loading[this.tabs[this.activeTabIndex].webview.props.url]);
 				},
-				onNetworkError: this.openNetworkTroubleshooting.bind(this),
+				onNetworkError: (index: number) => this.openNetworkTroubleshooting(index),
 				onTitleChange: this.updateBadge.bind(this),
 				nodeIntegration: false,
 				preload: true
@@ -536,7 +536,7 @@ class ServerManagerView {
 					}
 					this.showLoading(this.loading[this.tabs[this.activeTabIndex].webview.props.url]);
 				},
-				onNetworkError: this.openNetworkTroubleshooting.bind(this),
+				onNetworkError: (index: number) => this.openNetworkTroubleshooting(index),
 				onTitleChange: this.updateBadge.bind(this),
 				nodeIntegration: true,
 				preload: false
@@ -568,12 +568,9 @@ class ServerManagerView {
 		});
 	}
 
-	openNetworkTroubleshooting(): void {
-		this.openFunctionalTab({
-			name: 'Network Troubleshooting',
-			materialIcon: 'network_check',
-			url: `file://${rendererDirectory}/network.html`
-		});
+	openNetworkTroubleshooting(index: number): void {
+		this.tabs[index].webview.props.url = `file://${rendererDirectory}/network.html`;
+		this.tabs[index].showNetworkError();
 	}
 
 	activateLastTab(index: number): void {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -796,6 +796,10 @@ class ServerManagerView {
 			});
 		}
 
+		ipcRenderer.on('show-network-error', (event: Event, index: number) => {
+			this.openNetworkTroubleshooting(index);
+		});
+
 		ipcRenderer.on('open-settings', (event: Event, settingNav: string) => {
 			this.openSettings(settingNav);
 		});

--- a/app/renderer/js/pages/network.ts
+++ b/app/renderer/js/pages/network.ts
@@ -3,24 +3,14 @@
 import { ipcRenderer } from 'electron';
 
 class NetworkTroubleshootingView {
-	$reconnectButton: Element;
-	$settingsButton: Element;
-	constructor() {
-		this.$reconnectButton = document.querySelector('#reconnect');
-		this.$settingsButton = document.querySelector('#settings');
-	}
-
-	init(): void {
-		this.$reconnectButton.addEventListener('click', () => {
+	init($reconnectButton: Element, $settingsButton: Element): void {
+		$reconnectButton.addEventListener('click', () => {
 			ipcRenderer.send('forward-message', 'reload-viewer');
 		});
-		this.$settingsButton.addEventListener('click', () => {
+		$settingsButton.addEventListener('click', () => {
 			ipcRenderer.send('forward-message', 'open-settings');
 		});
 	}
 }
 
-window.addEventListener('load', () => {
-	const networkTroubleshootingView = new NetworkTroubleshootingView();
-	networkTroubleshootingView.init();
-});
+export = new NetworkTroubleshootingView();

--- a/app/renderer/js/pages/network.ts
+++ b/app/renderer/js/pages/network.ts
@@ -4,13 +4,18 @@ import { ipcRenderer } from 'electron';
 
 class NetworkTroubleshootingView {
 	$reconnectButton: Element;
+	$settingsButton: Element;
 	constructor() {
 		this.$reconnectButton = document.querySelector('#reconnect');
+		this.$settingsButton = document.querySelector('#settings');
 	}
 
 	init(): void {
 		this.$reconnectButton.addEventListener('click', () => {
 			ipcRenderer.send('forward-message', 'reload-viewer');
+		});
+		this.$settingsButton.addEventListener('click', () => {
+			ipcRenderer.send('forward-message', 'open-settings');
 		});
 	}
 }

--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -12,6 +12,8 @@ import isDev = require('electron-is-dev');
 import LinkUtil = require('./utils/link-util');
 import params = require('./utils/params-util');
 
+import NetworkError = require('./pages/network');
+
 interface PatchedGlobal extends NodeJS.Global {
 	logout: () => void;
 	shortcut: () => void;
@@ -118,6 +120,15 @@ document.addEventListener('DOMContentLoaded', (): void => {
 // otherwise, you may experience errors
 window.addEventListener('beforeunload', (): void => {
 	SetupSpellChecker.unsubscribeSpellChecker();
+});
+
+window.addEventListener('load', (event: any): void => {
+	if (!event.target.URL.includes('app/renderer/network.html')) {
+		return;
+	}
+	const $reconnectButton = document.querySelector('#reconnect');
+	const $settingsButton = document.querySelector('#settings');
+	NetworkError.init($reconnectButton, $settingsButton);
 });
 
 // electron's globalShortcut can cause unexpected results

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -59,6 +59,16 @@ class DomainUtil {
 		return this.db.getData(`/domains[${index}]`);
 	}
 
+	shouldIgnoreCerts(url: string): boolean {
+		const domains = this.getDomains();
+		for (const domain of domains) {
+			if (domain.url === url) {
+				return domain.ignoreCerts;
+			}
+		}
+		return null;
+	}
+
 	updateDomain(index: number, server: object): void {
 		this.reloadDB();
 		this.db.push(`/domains[${index}]`, server, true);

--- a/app/renderer/js/utils/reconnect-util.ts
+++ b/app/renderer/js/utils/reconnect-util.ts
@@ -1,5 +1,9 @@
-import isOnline = require('is-online');
+import { ipcRenderer } from 'electron';
+
+import request = require('request');
 import Logger = require('./logger-util');
+import RequestUtil = require('./request-util');
+import DomainUtil = require('./domain-util');
 
 const logger = new Logger({
 	file: `domain-util.log`,
@@ -7,19 +11,45 @@ const logger = new Logger({
 });
 
 class ReconnectUtil {
-	// TODO: TypeScript - Figure out how to annotate serverManagerView
-	// it should be ServerManagerView; maybe make it a generic so we can
-	// pass the class from main.js
-	serverManagerView: any;
+	// TODO: TypeScript - Figure out how to annotate webview
+	// it should be WebView; maybe make it a generic so we can
+	// pass the class from main.ts
+	webview: any;
+	url: string;
 	alreadyReloaded: boolean;
 
-	constructor(serverManagerView: any) {
-		this.serverManagerView = serverManagerView;
+	constructor(webview: any) {
+		this.webview = webview;
+		this.url = webview.props.url;
 		this.alreadyReloaded = false;
 	}
 
 	clearState(): void {
 		this.alreadyReloaded = false;
+	}
+
+	isOnline(): Promise<boolean> {
+		return new Promise(resolve => {
+			try {
+				const ignoreCerts = DomainUtil.shouldIgnoreCerts(this.url);
+				if (ignoreCerts === null) {
+					return;
+				}
+				request(
+					{
+						url: `${this.url}/static/favicon.ico`,
+						...RequestUtil.requestOptions(this.url, ignoreCerts)
+					},
+					(error: Error, response: any) => {
+						const isValidResponse =
+							!error && response.statusCode >= 200 && response.statusCode < 400;
+						resolve(isValidResponse);
+					}
+				);
+			} catch (err) {
+				logger.log(err);
+			}
+		});
 	}
 
 	pollInternetAndReload(): void {
@@ -38,11 +68,11 @@ class ReconnectUtil {
 	_checkAndReload(): Promise<boolean> {
 		return new Promise(resolve => {
 			if (!this.alreadyReloaded) { // eslint-disable-line no-negated-condition
-				isOnline()
+				this.isOnline()
 					.then((online: boolean) => {
 						if (online) {
 							if (!this.alreadyReloaded) {
-								this.serverManagerView.reloadCurrentView();
+								ipcRenderer.send('forward-message', 'reload-viewer');
 							}
 							logger.log('You\'re back online.');
 							return resolve(true);

--- a/app/renderer/network.html
+++ b/app/renderer/network.html
@@ -24,6 +24,6 @@
         </div>
     </body>
     <script>var exports = {};</script>
-    <script src="js/pages/network.js"></script>
+    <script src="js/preload.js"></script>
     <script>require('./js/shared/preventdrag.js')</script>
 </html>

--- a/app/renderer/network.html
+++ b/app/renderer/network.html
@@ -9,12 +9,18 @@
     <body>
         <div id="content">
             <div id="picture"><img src="img/zulip_network.png"></div>
-            <div id="title">Zulip can't connect</div>
-            <div id="description">
-                <div>Your computer seems to be offline.</div>
-                <div>We will keep trying to reconnect, or you can try now.</div>
+            <div id="title">We can't connect to this organization</div>
+            <div id="subtitle">This could be because</div>
+            <ul id="description">
+                <li>You're not online or your proxy is misconfigured.</li>
+                <li>There is no Zulip organization hosted at this URL.</li>
+                <li>This Zulip organization is temporarily unavailable.</li>
+                <li>This Zulip organization has been moved or deleted.</li>
+            </ul>
+            <div id="buttons">
+                <div id="reconnect" class="button">Reconnect</div>
+                <div id="settings" class="button">Settings</div>
             </div>
-            <div id="reconnect">Try now</div>
         </div>
     </body>
     <script>var exports = {};</script>

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,6 +12,7 @@ declare module 'escape-html';
 declare module 'fs-extra';
 declare module 'wurl';
 declare module 'i18n';
+declare module 'backoff';
 
 interface PageParamsObject {
     realm_uri: string;


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

1. Splits network concerns of each server into its own tab and then implements retry logic with exponential backoff for each of them independently. 
2. Removes `is-online` package and instead uses DOM listeners to decide if connection has failed. 
3. Keeps retrying to reach a server's favicon by using `request-util.js`. By default, there is no limit.
4. Removes need to open a new `FunctionalTab` to show network error. Instead loads error-indicating `network.html` in the webview of the server that failed to connect. 

**Any background context you want to provide?**

Please follow the discussions at #591 and #694.
In the former, it was decided that we should try to reach the `domain/static/favicon.ico`, but I'm unsure if that's the best idea (can someone move it from there?). Please let me know what to do there. 

**Screenshots?**

![image](https://user-images.githubusercontent.com/24617297/56039540-1c98fb00-5d52-11e9-9695-50af61d9c16f.png)

(this only shows the UI side of things, my computer's freezing up when I try to record a gif today). Please check that out and let me know if something goes wrong.

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
