### PR TITLE
Unify case across menus and settings

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -230,7 +230,7 @@ class AppMenu {
 				type: 'separator'
 			});
 			initialSubmenu.push({
-				label: 'Switch to next organization',
+				label: 'Switch to Next Organization',
 				accelerator: `Ctrl+Tab`,
 				enabled: tabs[activeTabIndex].props.role === 'server',
 				click(item, focusedWindow) {
@@ -239,7 +239,7 @@ class AppMenu {
 					}
 				}
 			}, {
-				label: 'Switch to previous organization',
+				label: 'Switch to Previous Organization',
 				accelerator: `Ctrl+Shift+Tab`,
 				enabled: tabs[activeTabIndex].props.role === 'server',
 				click(item, focusedWindow) {

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -24,7 +24,7 @@ class GeneralSection extends BaseSection {
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="menubar-option" style= "display:${process.platform === 'darwin' ? 'none' : ''}">
-						<div class="setting-description">Auto hide Menubar (Press Alt key to display)</div>
+						<div class="setting-description">Auto hide menu bar (Press Alt key to display)</div>
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="sidebar-option">
@@ -47,7 +47,7 @@ class GeneralSection extends BaseSection {
 				<div class="title">Desktop Notifications</div>
 				<div class="settings-card">
 					<div class="setting-row" id="show-notification-option">
-						<div class="setting-description">Show Desktop Notifications</div>
+						<div class="setting-description">Show desktop notifications</div>
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="silent-option">

--- a/app/renderer/js/pages/preference/shortcuts-section.js
+++ b/app/renderer/js/pages/preference/shortcuts-section.js
@@ -132,11 +132,11 @@ class ShortcutsSection extends BaseSection {
                   </tr>
                   <tr>
                     <td><kbd>Ctrl</kbd> + <kbd>Tab</kbd></td>
-                    <td>Switch to next organization</td>
+                    <td>Switch to Next Organization</td>
                   </tr>
                   <tr>
                     <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
-                    <td>Switch to previous organization</td>
+                    <td>Switch to Previous Organization</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>
@@ -280,11 +280,11 @@ class ShortcutsSection extends BaseSection {
                   </tr>
                   <tr>
                     <td><kbd>${userOSKey}</kbd> + <kbd>Tab</kbd></td>
-                    <td>Switch to next organization</td>
+                    <td>Switch to Next Organization</td>
                   </tr>
                   <tr>
                     <td><kbd>${userOSKey}</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd></td>
-                    <td>Switch to previous organization</td>
+                    <td>Switch to Previous Organization</td>
                   </tr>
                 </table>
                 <div class="setting-control"></div>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Follows up on the discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Zulip.20URL/near/733303) and converts:
1. Menu items to title case
2. In-app settings listings to sentence case

Addresses #246.

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
