### PR TITLE
settings: Add option to toggle Error Reporting.

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -159,7 +159,10 @@ app.on('ready', () => {
 	}
 
 	// Initialize sentry for main process
-	sentryInit();
+	const errorReporting = ConfigUtil.getConfigItem('errorReporting');
+	if (errorReporting) {
+		sentryInit();
+	}
 
 	const isSystemProxy = ConfigUtil.getConfigItem('useSystemProxy');
 
@@ -343,6 +346,12 @@ app.on('ready', () => {
 
 	ipcMain.on('realm-icon-changed', (event, serverURL, iconURL) => {
 		page.send('update-realm-icon', serverURL, iconURL);
+	});
+
+	// Using event.sender.send instead of page.send here to
+	// make sure the value of errorReporting is sent only once on load.
+	ipcMain.on('error-reporting', event => {
+		event.sender.send('error-reporting-val', errorReporting);
 	});
 });
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -111,6 +111,7 @@ class ServerManagerView {
 			showNotification: true,
 			autoUpdate: true,
 			betaUpdate: false,
+			errorReporting: true,
 			customCSS: false,
 			silent: false,
 			lastActiveTab: 0,

--- a/app/renderer/js/pages/preference/general-section.js
+++ b/app/renderer/js/pages/preference/general-section.js
@@ -83,6 +83,10 @@ class GeneralSection extends BaseSection {
 				</div>
 				<div class="title">Advanced</div>
 				<div class="settings-card">
+				<div class="setting-row" id="enable-error-reporting">
+					<div class="setting-description">Enable error reporting (requires restart)</div>
+					<div class="setting-control"></div>
+				</div>
 				<div class="setting-row" id="show-download-folder">
 					<div class="setting-description">Show downloaded files in file manager</div>
 					<div class="setting-control"></div>
@@ -145,6 +149,7 @@ class GeneralSection extends BaseSection {
 		this.removeCustomCSS();
 		this.downloadFolder();
 		this.showDownloadFolder();
+		this.enableErrorReporting();
 
 		// Platform specific settings
 
@@ -315,6 +320,18 @@ class GeneralSection extends BaseSection {
 				const newValue = !ConfigUtil.getConfigItem('enableSpellchecker');
 				ConfigUtil.setConfigItem('enableSpellchecker', newValue);
 				this.enableSpellchecker();
+			}
+		});
+	}
+
+	enableErrorReporting() {
+		this.generateSettingOption({
+			$element: document.querySelector('#enable-error-reporting .setting-control'),
+			value: ConfigUtil.getConfigItem('errorReporting', true),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('errorReporting');
+				ConfigUtil.setConfigItem('errorReporting', newValue);
+				this.enableErrorReporting();
 			}
 		});
 	}

--- a/app/renderer/js/utils/logger-util.js
+++ b/app/renderer/js/utils/logger-util.js
@@ -5,10 +5,23 @@ const { initSetUp } = require('./default-util');
 const { sentryInit, captureException } = require('./sentry-util');
 
 initSetUp();
-sentryInit();
+
 let app = null;
+let reportErrors = true;
 if (process.type === 'renderer') {
 	app = require('electron').remote.app;
+
+	// Report Errors to Sentry only if it is enabled in settings
+	// Gets the value of reportErrors from config-util for renderer process
+	// For main process, sentryInit() is handled in index.js
+	const { ipcRenderer } = require('electron');
+	ipcRenderer.send('error-reporting');
+	ipcRenderer.on('error-reporting-val', (event, errorReporting) => {
+		reportErrors = errorReporting;
+		if (reportErrors) {
+			sentryInit();
+		}
+	});
 } else {
 	app = require('electron').app;
 }
@@ -86,7 +99,9 @@ class Logger {
 	}
 
 	reportSentry(err) {
-		captureException(err);
+		if (reportErrors) {
+			captureException(err);
+		}
 	}
 }
 

--- a/app/renderer/js/utils/proxy-util.js
+++ b/app/renderer/js/utils/proxy-util.js
@@ -52,7 +52,7 @@ class ProxyUtil {
 	resolveSystemProxy(mainWindow) {
 		const page = mainWindow.webContents;
 		const ses = page.session;
-		const resolveProxyUrl = 'www.google.com';
+		const resolveProxyUrl = 'www.example.com';
 
 		// Check HTTP Proxy
 		const httpProxy = new Promise(resolve => {


### PR DESCRIPTION
**What's this PR do?**
Adds an option to enable or disable sentry error
reporting under Advanced section in General
Settings. Handles both main and renderer
processes.

Also, changes the domain used to resolve proxy
in proxy-util from google.com to example.com.

Fixes #702.

**Screenshots?**
![Screenshot from 2019-04-23 02-13-49](https://user-images.githubusercontent.com/21038781/56528935-9a88ad80-656d-11e9-9634-ea3072fad680.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
