### PR TITLE
Bounce dock only once on receiving a private message

### DIFF
--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -91,21 +91,6 @@ class WebView extends BaseComponent {
 			this.canGoBackButton();
 		});
 
-		this.$el.addEventListener('page-favicon-updated', event => {
-			const { favicons } = event;
-
-			// This returns a string of favicons URL. If there is a PM counts in unread messages then the URL would be like
-			// https://chat.zulip.org/static/images/favicon/favicon-pms.png
-			if (favicons[0].indexOf('favicon-pms') > 0 && process.platform === 'darwin') {
-				// This api is only supported on macOS
-				app.dock.setBadge('●');
-				// bounce the dock
-				if (ConfigUtil.getConfigItem('dockBouncing')) {
-					app.dock.bounce();
-				}
-			}
-		});
-
 		this.$el.addEventListener('dom-ready', () => {
 			if (this.props.role === 'server') {
 				this.$el.classList.add('onload');
@@ -194,6 +179,16 @@ class WebView extends BaseComponent {
 			}
 
 			this.$el.insertCSS(fs.readFileSync(path.resolve(__dirname, this.customCSS), 'utf8'));
+		}
+	}
+
+	updatePMCount(count: number): void {
+		if (process.platform === 'darwin') {
+			app.dock.setBadge(count.toString());
+			if (ConfigUtil.getConfigItem('dockBouncing') && ConfigUtil.getConfigItem('showNotification')) {
+				app.dock.bounce();
+			}
+			this.props.unreadPmCount = count;
 		}
 	}
 

--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -38,6 +38,12 @@ electron_bridge.on('total_unread_count', (...args) => {
 	ipcRenderer.send('unread-count', ...args);
 });
 
+electron_bridge.on('unread_pm_count', unreadPMs => {
+	const unreadPMCount = unreadPMs.unread_pm_count;
+	const realmUri = unreadPMs.realm_uri;
+	ipcRenderer.send('forward-message', 'unread-pm-count', unreadPMCount, realmUri);
+});
+
 electron_bridge.on('realm_name', realmName => {
 	const serverURL = location.origin;
 	ipcRenderer.send('realm-name-changed', serverURL, realmName);

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -373,7 +373,8 @@ class ServerManagerView {
 				onNetworkError: this.openNetworkTroubleshooting.bind(this),
 				onTitleChange: this.updateBadge.bind(this),
 				nodeIntegration: false,
-				preload: true
+				preload: true,
+				unreadPMCount: 0
 			})
 		}));
 		this.loading[server.url] = true;
@@ -993,6 +994,13 @@ class ServerManagerView {
 			webviews.forEach(webview => {
 				webview.send('set-idle');
 			});
+		});
+
+		ipcRenderer.on('unread-pm-count', (event: Event, unreadPMCount: number, realmUri: string) => {
+			const tabIndex = DomainUtil.getIndex(realmUri);
+			if (tabIndex < 0) {
+				this.tabs[tabIndex].webview.updatePMCount(unreadPMCount);
+			}
 		});
 	}
 }

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -59,6 +59,18 @@ class DomainUtil {
 		return this.db.getData(`/domains[${index}]`);
 	}
 
+	getIndex(url: string): number {
+		const domains = this.getDomains();
+		for (let i = 0; i < domains.length; i++) {
+			const domain = domains[i];
+			if (domain.url === url) {
+				return i;
+			}
+		}
+		// invalid index, use check in calling function
+		return -1;
+	}
+
 	updateDomain(index: number, server: object): void {
 		this.reloadDB();
 		this.db.push(`/domains[${index}]`, server, true);


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

1. Changes dock badge on macOS from a dot to the unread PM count of the server that last received a PM. 
2. Makes dock bounce only once (as opposed to every time the favicon of the web app is updated)

**Any background context you want to provide?**

Check out the discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/macOS.20Bouncing.20Dock.20Icon/near/733520).
Server repo PR [here](https://github.com/zulip/zulip/pull/12222).

**Screenshots?**

![Zulip dock](https://user-images.githubusercontent.com/24617297/56856975-60ac1280-6984-11e9-9776-cf7848c7d9db.gif)

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
