### PR TITLE
focus: Fix focus after clicking back button.

### DIFF
--- a/app/renderer/js/components/webview.js
+++ b/app/renderer/js/components/webview.js
@@ -225,6 +225,7 @@ class WebView extends BaseComponent {
 	back() {
 		if (this.$el.canGoBack()) {
 			this.$el.goBack();
+			this.focus();
 		}
 	}
 


### PR DESCRIPTION
Addresses the issue of the webview not being in focus
after the Back button is clicked. Now, the webview is focused
explicitly by calling focus() on click.

More discussion about this [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Back.20arrow.20.2F.20Down.20arrow)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
