### PR TITLE
menu: Remove minimize and close from File menu.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -325,10 +325,6 @@ class AppMenu {
 			}, {
 				type: 'separator'
 			}, {
-				role: 'minimize'
-			}, {
-				role: 'close'
-			}, {
 				role: 'quit'
 			}]
 		}, {
@@ -428,10 +424,6 @@ class AppMenu {
 				}
 			}, {
 				type: 'separator'
-			}, {
-				role: 'minimize'
-			}, {
-				role: 'close'
 			}, {
 				role: 'quit',
 				accelerator: 'Ctrl+Q'


### PR DESCRIPTION
Remove duplicate entries of minimize and close from
File menu as they are already present in Window menu.

Discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/twice.20-.20minimize.20and.20close).

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
