### PR TITLE
Spellchecker: Enable spellcheck lang in server lang for all platform.

### DIFF
--- a/app/renderer/js/spellchecker.js
+++ b/app/renderer/js/spellchecker.js
@@ -32,14 +32,7 @@ class SetupSpellChecker {
 
 			const userLanguage = ConfigUtil.getConfigItem('spellcheckerLanguage');
 
-			// eslint-disable-next-line no-unused-expressions
-			process.platform === 'darwin' ?
-				// On macOS, spellchecker fails to auto-detect the lanugage user is typing in
-				// that's why we need to mention it explicitly
-				this.SpellCheckHandler.switchLanguage(userLanguage) :
-				// On Linux and Windows, spellchecker can automatically detects the language the user is typing in
-				// and silently switches on the fly; thus we can start off as US English
-				this.SpellCheckHandler.switchLanguage('en-US');
+			this.SpellCheckHandler.switchLanguage(userLanguage);
 		}
 
 		const contextMenuBuilder = new ContextMenuBuilder(this.SpellCheckHandler);


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
This PR enable spellchecker language in server language for all platform


**Screenshots?**
spellchecker automatically enable for English when server lang. is english
![Screenshot from 2019-05-04 20-51-58](https://user-images.githubusercontent.com/36422396/57181823-40191680-6eb6-11e9-8361-1385f7ac6d3a.png)
spellchecker automatically enable for Hindi when server lang. is Hindi
![Screenshot from 2019-05-04 20-50-39](https://user-images.githubusercontent.com/36422396/57181824-40b1ad00-6eb6-11e9-86e0-e830357ea675.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
