### PR TITLE
settings: Add field to find accounts by email

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -259,6 +259,10 @@ img.server-info-icon {
     border: rgba(78, 191, 172, 1.000) 2px solid;
 }
 
+.invalid-input-value:focus {
+    border: rgba(239, 83, 80, 1) 2px solid;
+}
+
 .manual-proxy-block {
     width: 96%;
 }

--- a/app/renderer/js/pages/preference/connected-org-section.js
+++ b/app/renderer/js/pages/preference/connected-org-section.js
@@ -4,6 +4,7 @@ const BaseSection = require(__dirname + '/base-section.js');
 const DomainUtil = require(__dirname + '/../../utils/domain-util.js');
 const ServerInfoForm = require(__dirname + '/server-info-form.js');
 const AddCertificate = require(__dirname + '/add-certificate.js');
+const FindAccounts = require(__dirname + '/find-accounts.js');
 
 class ConnectedOrgSection extends BaseSection {
 	constructor(props) {
@@ -20,6 +21,8 @@ class ConnectedOrgSection extends BaseSection {
 				<div id="new-org-button"><button class="green sea w-250">Connect to another organization</button></div>
 				<div class="page-title">Add Custom Certificates</div>
 				<div id="add-certificate-container"></div>
+				<div class="page-title">Find accounts by email</div>
+				<div id="find-accounts-container"></div>
 			</div>
 		`;
 	}
@@ -38,6 +41,7 @@ class ConnectedOrgSection extends BaseSection {
 		this.$existingServers = document.getElementById('existing-servers');
 		this.$newOrgButton = document.getElementById('new-org-button');
 		this.$addCertificateContainer = document.getElementById('add-certificate-container');
+		this.$findAccountsContainer = document.getElementById('find-accounts-container');
 
 		const noServerText = 'All the connected orgnizations will appear here';
 		// Show noServerText if no servers are there otherwise hide it
@@ -59,6 +63,7 @@ class ConnectedOrgSection extends BaseSection {
 		});
 
 		this.initAddCertificate();
+		this.initFindAccounts();
 	}
 
 	initAddCertificate() {
@@ -67,6 +72,11 @@ class ConnectedOrgSection extends BaseSection {
 		}).init();
 	}
 
+	initFindAccounts() {
+		new FindAccounts({
+			$root: this.$findAccountsContainer
+		}).init();
+	}
 }
 
 module.exports = ConnectedOrgSection;

--- a/app/renderer/js/pages/preference/find-accounts.js
+++ b/app/renderer/js/pages/preference/find-accounts.js
@@ -1,0 +1,31 @@
+'use-strict';
+
+const BaseComponent = require(__dirname + '/../../components/base.js');
+
+class FindAccounts extends BaseComponent {
+	constructor(props) {
+		super();
+		this.props = props;
+	}
+
+	template() {
+		return `
+			<div class="settings-card certificate-card">
+				<div class="certificate-input">
+					<div>Organization URL</div>
+					<input class="setting-input-value" value="zulipchat.com"/>
+				</div>
+				<div class="certificate-input">
+					<button class="green w-150" id="find-accounts-button">Find accounts</button>
+				</div>
+			</div>
+		`;
+	}
+
+	init() {
+		this.$findAccounts = this.generateNodeFromTemplate(this.template());
+		this.props.$root.appendChild(this.$findAccounts);
+	}
+}
+
+module.exports = FindAccounts;

--- a/app/renderer/js/pages/preference/find-accounts.js
+++ b/app/renderer/js/pages/preference/find-accounts.js
@@ -1,5 +1,7 @@
 'use-strict';
 
+const { shell } = require('electron');
+
 const BaseComponent = require(__dirname + '/../../components/base.js');
 
 class FindAccounts extends BaseComponent {
@@ -25,6 +27,31 @@ class FindAccounts extends BaseComponent {
 	init() {
 		this.$findAccounts = this.generateNodeFromTemplate(this.template());
 		this.props.$root.appendChild(this.$findAccounts);
+		this.$findAccountsButton = this.$findAccounts.querySelector('#find-accounts-button');
+		this.$serverUrlField = this.$findAccounts.querySelectorAll('input.setting-input-value')[0];
+		this.initListeners();
+	}
+
+	findAccounts(url) {
+		if (!url) {
+			return;
+		}
+		if (!url.startsWith('http')) {
+			url = 'https://' + url;
+		}
+		shell.openExternal(url + '/accounts/find');
+	}
+
+	initListeners() {
+		this.$findAccountsButton.addEventListener('click', () => {
+			this.findAccounts(this.$serverUrlField.value);
+		});
+
+		this.$serverUrlField.addEventListener('keypress', event => {
+			if (event.keyCode === 13) {
+				this.findAccounts(this.$serverUrlField.value);
+			}
+		});
 	}
 }
 

--- a/app/renderer/js/pages/preference/find-accounts.js
+++ b/app/renderer/js/pages/preference/find-accounts.js
@@ -52,6 +52,14 @@ class FindAccounts extends BaseComponent {
 				this.findAccounts(this.$serverUrlField.value);
 			}
 		});
+
+		this.$serverUrlField.addEventListener('input', () => {
+			if (this.$serverUrlField.value) {
+				this.$serverUrlField.classList.remove('invalid-input-value');
+			} else {
+				this.$serverUrlField.classList.add('invalid-input-value');
+			}
+		});
 	}
 }
 

--- a/app/renderer/js/pages/preference/find-accounts.js
+++ b/app/renderer/js/pages/preference/find-accounts.js
@@ -47,6 +47,12 @@ class FindAccounts extends BaseComponent {
 			this.findAccounts(this.$serverUrlField.value);
 		});
 
+		this.$serverUrlField.addEventListener('click', () => {
+			if (this.$serverUrlField.value === 'zulipchat.com') {
+				this.$serverUrlField.setSelectionRange(0, 0);
+			}
+		});
+
 		this.$serverUrlField.addEventListener('keypress', event => {
 			if (event.keyCode === 13) {
 				this.findAccounts(this.$serverUrlField.value);


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Adds a URL field in Settings > Organizations for finding accounts associated with a particular email.

**Any background context you want to provide?**

Discussion at #600 and #638 (closed because it got too polluted). 

**Screenshots?**

![Peek 2019-05-21 01-11](https://user-images.githubusercontent.com/24617297/58047462-e5461700-7b65-11e9-8cce-b46a4c467db4.gif)

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
