### PR TITLE
system-presence: Add ability to detect system presence.

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -362,6 +362,22 @@ app.on('ready', () => {
 	ipcMain.on('save-last-tab', (_event: Electron.IpcMessageEvent, index: number) => {
 		ConfigUtil.setConfigItem('lastActiveTab', index);
 	});
+
+	// Update user idle status for each realm after every 15s
+	// Set user idle if no activity for idleThreshold time in seconds
+	// Do a check every idleCheckInterval ms.
+	const idleCheckInterval = 15000;
+	setInterval(() => {
+		const idleThreshold = 60;
+		// Remove typecast to any when querySystemIdleState gets added to electron typings
+		(electron.powerMonitor as any).querySystemIdleState(idleThreshold, (idleState: string) => {
+			if (idleState === 'active') {
+				page.send('set-active');
+			} else {
+				page.send('set-idle');
+			}
+		});
+	}, idleCheckInterval);
 });
 
 app.on('before-quit', () => {

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -364,13 +364,17 @@ app.on('ready', () => {
 	});
 
 	// Update user idle status for each realm after every 15s
-	// Set user idle if no activity for idleThreshold time in seconds
-	// Do a check every idleCheckInterval ms.
-	const idleCheckInterval = 15000;
+	const idleCheckInterval = 15 * 1000; // 15 seconds
 	setInterval(() => {
-		const idleThreshold = 60;
-		// Remove typecast to any when querySystemIdleState gets added to electron typings
-		(electron.powerMonitor as any).querySystemIdleState(idleThreshold, (idleState: string) => {
+		// Set user idle if no activity in 1 second (idleThresholdSeconds)
+		const idleThresholdSeconds = 1; // 1 second
+
+		// TODO: Remove typecast to any when types get added
+		// TODO: use powerMonitor.getSystemIdleState when upgrading electron
+		// powerMonitor.querySystemIdleState is deprecated in current electron
+		// version at the time of writing.
+		const powerMonitor = electron.powerMonitor as any;
+		powerMonitor.querySystemIdleState(idleThresholdSeconds, (idleState: string) => {
 			if (idleState === 'active') {
 				page.send('set-active');
 			} else {

--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -9,7 +9,20 @@ type ListenerType = ((...args: any[]) => void);
 // for the whole file.
 /* eslint-disable @typescript-eslint/camelcase */
 class ElectronBridge extends events {
-	send_notification_reply_message_supported = false;
+	send_notification_reply_message_supported: boolean;
+	idle_on_system: boolean;
+	last_active_on_system: number;
+
+	constructor() {
+		super();
+		this.send_notification_reply_message_supported = false;
+		// Indicates if the user is idle or not
+		this.idle_on_system = false;
+
+		// Indicates the time at which user was last active
+		this.last_active_on_system = Date.now();
+	}
+
 	send_event(eventName: string | symbol, ...args: any[]): void {
 		this.emit(eventName, ...args);
 	}

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -961,6 +961,20 @@ class ServerManagerView {
 		ipcRenderer.on('new-server', () => {
 			this.openSettings('AddServer');
 		});
+
+		ipcRenderer.on('set-active', () => {
+			const webviews: NodeListOf<Electron.WebviewTag> = document.querySelectorAll('webview');
+			webviews.forEach(webview => {
+				webview.send('set-active');
+			});
+		});
+
+		ipcRenderer.on('set-idle', () => {
+			const webviews: NodeListOf<Electron.WebviewTag> = document.querySelectorAll('webview');
+			webviews.forEach(webview => {
+				webview.send('set-idle');
+			});
+		});
 	}
 }
 

--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -1,8 +1,14 @@
+// we have and will have some non camelcase stuff
+// while working with zulip and electron bridge
+// so turning the rule off for the whole file.
+/* eslint-disable @typescript-eslint/camelcase */
+
 'use strict';
 
 import { ipcRenderer, shell } from 'electron';
 import SetupSpellChecker from './spellchecker';
 
+import isDev = require('electron-is-dev');
 import LinkUtil = require('./utils/link-util');
 import params = require('./utils/params-util');
 
@@ -21,7 +27,6 @@ require(__dirname + '/shared/preventdrag.js');
 
 declare let window: ZulipWebWindow;
 
-// eslint-disable-next-line @typescript-eslint/camelcase
 window.electron_bridge = require('./electron-bridge');
 
 const logout = (): void => {
@@ -55,7 +60,7 @@ process.once('loaded', (): void => {
 document.addEventListener('DOMContentLoaded', (): void => {
 	if (params.isPageParams()) {
 	// Get the default language of the server
-		const serverLanguage = page_params.default_language; // eslint-disable-line no-undef, @typescript-eslint/camelcase
+		const serverLanguage = page_params.default_language; // eslint-disable-line no-undef
 		if (serverLanguage) {
 			// Init spellchecker
 			SetupSpellChecker.init(serverLanguage);
@@ -111,4 +116,21 @@ document.addEventListener('keydown', event => {
 	} else if (cmdOrCtrl && event.code === 'Numpad0') {
 		ipcRenderer.send('forward-message', 'zoomActualSize');
 	}
+});
+
+// Set user as active and update the time of last activity
+ipcRenderer.on('set-active', () => {
+	if (isDev) {
+		console.log('active');
+	}
+	window.electron_bridge.idle_on_system = false;
+	window.electron_bridge.last_active_on_system = Date.now();
+});
+
+// Set user as idle and time of last activity is left unchanged
+ipcRenderer.on('set-idle', () => {
+	if (isDev) {
+		console.log('idle');
+	}
+	window.electron_bridge.idle_on_system = true;
 });


### PR DESCRIPTION
**What's this PR do?**
Created two electron-bridge variables.
idle_on_system tells whether the user is idle or not.
last_active_on_system gives the time the user was last
active. Both variables will be used by the webapp to set
user status.

Fixes #352.

Corresponding webapp PR [here](https://github.com/zulip/zulip/pull/12003).

**How to test?**
You can test by console logging the two variables in the setInterval near line 97 of preload.js. They will update based on user activity.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
