### PR TITLE
spellchecker: Improve auto detection of spellchecker language.

### DIFF
--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -3,7 +3,6 @@
 const { ipcRenderer, shell } = require('electron');
 const SetupSpellChecker = require('./spellchecker');
 
-const ConfigUtil = require(__dirname + '/utils/config-util.js');
 const LinkUtil = require(__dirname + '/utils/link-util.js');
 const params = require(__dirname + '/utils/params-util.js');
 
@@ -47,10 +46,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	// Get the default language of the server
 		const serverLanguage = page_params.default_language; // eslint-disable-line no-undef, camelcase
 		if (serverLanguage) {
-			// Set spellcheker language
-			ConfigUtil.setConfigItem('spellcheckerLanguage', serverLanguage);
 			// Init spellchecker
-			SetupSpellChecker.init();
+			SetupSpellChecker.init(serverLanguage);
 		}
 		// redirect users to network troubleshooting page
 		const getRestartButton = document.querySelector('.restart_get_events_button');

--- a/app/renderer/js/spellchecker.js
+++ b/app/renderer/js/spellchecker.js
@@ -11,11 +11,11 @@ const logger = new Logger({
 });
 
 class SetupSpellChecker {
-	init() {
+	init(serverLanguage) {
 		if (ConfigUtil.getConfigItem('enableSpellchecker')) {
 			this.enableSpellChecker();
 		}
-		this.enableContextMenu();
+		this.enableContextMenu(serverLanguage);
 	}
 
 	enableSpellChecker() {
@@ -26,13 +26,13 @@ class SetupSpellChecker {
 		}
 	}
 
-	enableContextMenu() {
+	enableContextMenu(serverLanguage) {
 		if (this.SpellCheckHandler) {
 			this.SpellCheckHandler.attachToInput();
-
-			const userLanguage = ConfigUtil.getConfigItem('spellcheckerLanguage');
-
-			this.SpellCheckHandler.switchLanguage(userLanguage);
+			this.SpellCheckHandler.switchLanguage(serverLanguage);
+			this.SpellCheckHandler.currentSpellcheckerChanged.subscribe(() => {
+				this.SpellCheckHandler.switchLanguage(this.SpellCheckHandler.currentSpellcheckerLanguage);
+			});
 		}
 
 		const contextMenuBuilder = new ContextMenuBuilder(this.SpellCheckHandler);


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Adds options for configuring the spellchecker in Settings > General. 

There are 3 levels for settings:
1. Auto-detect and correct (default)
2. Set `spellcheckerLanguage` to the realm language (org-level)
3. Allow user to override (1) and (2) with custom language (app-level). 

**Screenshots?**

Fixed setting, overriding both input text and server language:

![Override](https://user-images.githubusercontent.com/24617297/58668685-497f8c80-8357-11e9-89e5-004548969b44.png)

Organization-specific setting:

![Switch](https://user-images.githubusercontent.com/24617297/58807481-c8b1e080-8635-11e9-86ed-bdf8d5f6c023.gif)

Auto-detect works as expected. 

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
