### PR TITLE
dev: Use .env file for Sentry DSN.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "@sentry/electron": "0.14.0",
     "adm-zip": "0.4.11",
     "auto-launch": "5.0.5",
+    "dotenv": "8.0.0",
     "electron-is-dev": "0.3.0",
     "electron-log": "2.2.14",
     "electron-spellchecker": "1.1.2",

--- a/app/renderer/js/utils/sentry-util.ts
+++ b/app/renderer/js/utils/sentry-util.ts
@@ -1,11 +1,14 @@
 import { init } from '@sentry/electron';
 
 import isDev = require('electron-is-dev');
+import path = require('path');
+import dotenv = require('dotenv');
+dotenv.config({ path: path.resolve(__dirname, '/../../../../.env') });
 
 export const sentryInit = (): void => {
 	if (!isDev) {
 		init({
-			dsn: 'SENTRY_DSN',
+			dsn: process.env.SENTRY_DSN,
 			// We should ignore this error since it's harmless and we know the reason behind this
 			// This error mainly comes from the console logs.
 			// This is a temp solution until Sentry supports disabling the console logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,6 +263,15 @@
         "@types/node": "*"
       }
     },
+    "@types/dotenv": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
+      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   ],
   "devDependencies": {
     "@types/adm-zip": "^0.4.32",
+    "@types/dotenv": "6.1.1",
     "@typescript-eslint/eslint-plugin": "1.10.2",
     "@typescript-eslint/parser": "1.10.2",
     "assert": "1.4.1",


### PR DESCRIPTION
* Reads .env file in root folder of repo to get Sentry DSN for builds.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Developers working on the Zulip desktop app often have to build packaged versions of the app, and I personally often forget to replace the `SENTRY_DSN` placeholder string with the actual DSN. This PR reads a `.env` file that'll be ignored by `git` and therefore can be used across branches for development.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
