### PR TITLE
sidebar: Sync loading indicator with loading GIF.

### DIFF
--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -275,6 +275,7 @@ class WebView extends BaseComponent {
 		// Shows the loading indicator till the webview is reloaded
 		this.$webviewsContainer.remove('loaded');
 		this.loading = true;
+		this.props.switchLoading(true, this.props.url);
 		this.$el.reload();
 	}
 

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -32,7 +32,7 @@
                         <i class="material-icons md-48">refresh</i>
                         <span id="reload-tooltip" style="display:none">Reload</span>
                     </div>
-                    <div class="action-button" id="loading-action">
+                    <div class="action-button disable" id="loading-action">
                         <i class="refresh material-icons md-48">loop</i>
                         <span id="loading-tooltip" style="display:none">Loading</span>
                     </div>


### PR DESCRIPTION
* Disable loading indicator (same as going back in settings)
* Show loading indicator on reload

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Fixes concerns raised by @abhigyank in #674. 

**Screenshots?**

![reload](https://user-images.githubusercontent.com/24617297/59624637-e9f5ef00-9154-11e9-9f2c-09090867f9d7.gif)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
