### PR TITLE
menu: Open help page of current active server.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -195,8 +195,10 @@ class AppMenu {
 			},
 			{
 				label: `Help Center`,
-				click() {
-					shell.openExternal('https://zulipchat.com/help/');
+				click(focusedWindow) {
+					if (focusedWindow) {
+						AppMenu.sendAction('open-help');
+					}
 				}
 			}, {
 				label: 'Report an Issue',

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -269,6 +269,10 @@ class ServerManagerView {
 		return currentIndex;
 	}
 
+	getCurrentActiveServer() {
+		return this.tabs[this.activeTabIndex].webview.props.url;
+	}
+
 	displayInitialCharLogo($img, index) {
 		/*
 			index parameter needed because webview[data-tab-id] can increment
@@ -625,7 +629,8 @@ class ServerManagerView {
 
 		ipcRenderer.on('open-help', () => {
 			// Open help page of current active server
-			shell.openExternal(DomainUtil.getDomain(this.activeTabIndex).url + '/help');
+			const helpPage = this.getCurrentActiveServer() + '/help';
+			shell.openExternal(helpPage);
 		});
 
 		ipcRenderer.on('reload-viewer', this.reloadView.bind(this, this.tabs[this.activeTabIndex].props.index));
@@ -791,7 +796,7 @@ class ServerManagerView {
 		});
 
 		ipcRenderer.on('copy-zulip-url', () => {
-			clipboard.writeText(DomainUtil.getDomain(this.activeTabIndex).url);
+			clipboard.writeText(this.getCurrentActiveServer());
 		});
 
 		ipcRenderer.on('new-server', () => {

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ipcRenderer, remote, clipboard } = require('electron');
+const { ipcRenderer, remote, clipboard, shell } = require('electron');
 const isDev = require('electron-is-dev');
 
 const { session, app, Menu, dialog } = remote;
@@ -622,6 +622,11 @@ class ServerManagerView {
 		});
 
 		ipcRenderer.on('open-about', this.openAbout.bind(this));
+
+		ipcRenderer.on('open-help', () => {
+			// Open help page of current active server
+			shell.openExternal(DomainUtil.getDomain(this.activeTabIndex).url + '/help');
+		});
 
 		ipcRenderer.on('reload-viewer', this.reloadView.bind(this, this.tabs[this.activeTabIndex].props.index));
 


### PR DESCRIPTION
Before we used to open `https://zulipchat.com/help` page when a user clicks on `Help Center` menu item. Now we open the help page of the current active server. 

Fixes: #758.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

<img src="https://cl.ly/64ca2c37b8cd/download/Screen%20Recording%202019-06-19%20at%2003.28%20AM.gif"/>

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS

