### PR TITLE
typescript: Migrate components dir to typescript.

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1123,9 +1123,9 @@
       "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8="
     },
     "node-json-db": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-0.9.1.tgz",
-      "integrity": "sha512-4BydUI7a10W8QBdHq/J3UBswU1i8WhCgTS4BZU0MjlUKrSU7cuUti71eojistgqe5hIrb4adj/wvAT5dw63NPg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-0.9.2.tgz",
+      "integrity": "sha512-vd8A6wznm3hi82IKlVKdomZvsEnASYWl0n4iwLkI7ukbIQkXTtFdJG8aZg0BNbEN+Vr/VktDFSqwWx/iSdf31Q==",
       "requires": {
         "mkdirp": "0.5.x"
       }

--- a/app/renderer/js/components/tab.ts
+++ b/app/renderer/js/components/tab.ts
@@ -1,6 +1,7 @@
 'use strict';
 
-import BaseComponent = require('./base');
+import WebView from './webview';
+import BaseComponent from './base';
 
 // TODO: TypeScript - Type annotate props
 interface TabProps {
@@ -9,7 +10,7 @@ interface TabProps {
 
 class Tab extends BaseComponent {
 	props: TabProps;
-	webview: any;
+	webview: WebView;
 	$el: Element;
 	constructor(props: TabProps) {
 		super();
@@ -25,7 +26,7 @@ class Tab extends BaseComponent {
 	}
 
 	isLoading(): boolean {
-		return this.webview.isLoading;
+		return this.webview.$el.isLoading();
 	}
 
 	activate(): void {


### PR DESCRIPTION
**What's this PR do?**
Migrate components dir to typescript.

Fixed all errors except one-
```
app/renderer/js/components/tab.ts:19:49 - error TS2339: Property 'template' does not exist on type 'Tab'.

19  	this.$el = this.generateNodeFromTemplate(this.template());
    	                                              ~~~~~~~~
```
There was no template function in Tab class.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
