### PR TITLE
components: Remove unused isLoading function from Tab.

### DIFF
--- a/app/renderer/js/components/tab.js
+++ b/app/renderer/js/components/tab.js
@@ -25,10 +25,6 @@ class Tab extends BaseComponent {
 		this.$el.addEventListener('mouseout', this.props.onHoverOut);
 	}
 
-	isLoading() {
-		return this.webview.isLoading;
-	}
-
 	activate() {
 		this.$el.classList.add('active');
 		this.webview.load();


### PR DESCRIPTION
Before we were returning this.webview.isLoading, which is always undefined
since we don't define any isLoading property on class WebView. This was
caught during migration to typescript.
