### PR TITLE
menu: Disable menu items on non-server pages.

### DIFF
--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -19,10 +19,11 @@ const logger = new Logger({
 });
 
 class AppMenu {
-	getHistorySubmenu() {
+	getHistorySubmenu(enableMenu) {
 		return [{
 			label: 'Back',
 			accelerator: process.platform === 'darwin' ? 'Command+Left' : 'Alt+Left',
+			enabled: enableMenu,
 			click(item, focusedWindow) {
 				if (focusedWindow) {
 					AppMenu.sendAction('back');
@@ -31,6 +32,7 @@ class AppMenu {
 		}, {
 			label: 'Forward',
 			accelerator: process.platform === 'darwin' ? 'Command+Right' : 'Alt+Right',
+			enabled: enableMenu,
 			click(item, focusedWindow) {
 				if (focusedWindow) {
 					AppMenu.sendAction('forward');
@@ -196,7 +198,7 @@ class AppMenu {
 			}];
 	}
 
-	getWindowSubmenu(tabs, activeTabIndex) {
+	getWindowSubmenu(tabs, activeTabIndex, enableMenu) {
 		const initialSubmenu = [{
 			role: 'minimize'
 		}, {
@@ -232,7 +234,7 @@ class AppMenu {
 			initialSubmenu.push({
 				label: 'Switch to Next Organization',
 				accelerator: `Ctrl+Tab`,
-				enabled: tabs[activeTabIndex].props.role === 'server',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('switch-server-tab', AppMenu.getNextServer(tabs, activeTabIndex));
@@ -241,7 +243,7 @@ class AppMenu {
 			}, {
 				label: 'Switch to Previous Organization',
 				accelerator: `Ctrl+Shift+Tab`,
-				enabled: tabs[activeTabIndex].props.role === 'server',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('switch-server-tab', AppMenu.getPreviousServer(tabs, activeTabIndex));
@@ -295,6 +297,7 @@ class AppMenu {
 			}, {
 				label: 'Copy Zulip URL',
 				accelerator: 'Cmd+Shift+C',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('copy-zulip-url');
@@ -351,10 +354,10 @@ class AppMenu {
 			submenu: this.getViewSubmenu()
 		}, {
 			label: 'History',
-			submenu: this.getHistorySubmenu()
+			submenu: this.getHistorySubmenu(enableMenu)
 		}, {
 			label: 'Window',
-			submenu: this.getWindowSubmenu(tabs, activeTabIndex)
+			submenu: this.getWindowSubmenu(tabs, activeTabIndex, enableMenu)
 		}, {
 			label: 'Tools',
 			submenu: this.getToolsSubmenu()
@@ -408,6 +411,7 @@ class AppMenu {
 			}, {
 				label: 'Copy Zulip URL',
 				accelerator: 'Ctrl+Shift+C',
+				enabled: enableMenu,
 				click(item, focusedWindow) {
 					if (focusedWindow) {
 						AppMenu.sendAction('copy-zulip-url');
@@ -454,10 +458,10 @@ class AppMenu {
 			submenu: this.getViewSubmenu()
 		}, {
 			label: '&History',
-			submenu: this.getHistorySubmenu()
+			submenu: this.getHistorySubmenu(enableMenu)
 		}, {
 			label: '&Window',
-			submenu: this.getWindowSubmenu(tabs, activeTabIndex)
+			submenu: this.getWindowSubmenu(tabs, activeTabIndex, enableMenu)
 		}, {
 			label: '&Tools',
 			submenu: this.getToolsSubmenu()


### PR DESCRIPTION
Disables 'Copy Zulip URL' and 'Back' and 'Forward'
when user is on non-server pages, like Settings page.
Also, simplifies the logic for setting enable state
for 'Switch to Next Organization' and 'Switch to
Previous Organization'.

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
