### PR TITLE
[WIP] Upgrade Electron version to 5.0.6

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -77,7 +77,8 @@ function createMainWindow() {
 		webPreferences: {
 			plugins: true,
 			nodeIntegration: true,
-			partition: 'persist:webviewsession'
+			partition: 'persist:webviewsession',
+			webviewTag: true
 		},
 		show: false
 	});

--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -88,7 +88,8 @@ window.addEventListener('beforeunload', () => {
 
 // electron's globalShortcut can cause unexpected results
 // so adding the reload shortcut in the old-school way
-// Zoom from numpad keys is not supported by electron, so adding it through listeners.
+// electron does not support adding multiple accelerators for a menu item
+// so adding numpad shortcuts here
 document.addEventListener('keydown', event => {
 	if (event.code === 'F5') {
 		ipcRenderer.send('forward-message', 'hard-reload');

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "assert": "1.4.1",
     "cp-file": "5.0.0",
     "devtron": "1.4.0",
-    "electron": "3.1.10",
+    "electron": "5.0.6",
     "electron-builder": "20.40.2",
     "electron-connect": "0.6.2",
     "electron-debug": "1.4.0",


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Makes a couple Electron version leaps to 5.0.6.

**Any background context you want to provide?**

Needed to enable `webviewTag` when creating a `BrowserWindow` in the main process.
Still have to assure ourselves that things haven't broken in the upgrade. 

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
