### PR TITLE
reconnect-util: Gracefully reload current webview.

### DIFF
--- a/app/renderer/js/utils/reconnect-util.js
+++ b/app/renderer/js/utils/reconnect-util.js
@@ -35,7 +35,7 @@ class ReconnectUtil {
 					.then(online => {
 						if (online) {
 							if (!this.alreadyReloaded) {
-								this.serverManagerView.reloadView();
+								this.serverManagerView.reloadCurrentView();
 							}
 							logger.log('You\'re back online.');
 							return resolve(true);


### PR DESCRIPTION
Before we were destroying, removing the webview elements, when we
need to reload webviews which cause unwanted side-effect for example
drafts not saving because no beforeunload event handler isn't ran.

Fixes: https://github.com/zulip/zulip-desktop/issues/767.

**You have tested this PR on:**
  - [X] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
