### PR TITLE
sidebar: Remove superfluous padding on sidebar.

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -18,7 +18,7 @@ body {
 .toggle-sidebar {
     background: rgba(34, 44, 49, 1.000);
     width: 54px;
-    padding: 27px 0 20px 0;
+    padding: 0 0 20px 0;
     justify-content: space-between;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
**What's this PR do?**
There is extra top padding of 27px which isn't needed. I don't know if we should add `2px` padding instead of none but whatever we had before was way too much?

**Screenshots?**
Before:
![image](https://user-images.githubusercontent.com/23620441/60391119-80ab9f80-9ab5-11e9-8016-ac0da4c635a3.png)
![image](https://user-images.githubusercontent.com/23620441/60391127-96b96000-9ab5-11e9-9afa-3e0c1de88d03.png)

After:
![image](https://user-images.githubusercontent.com/23620441/60391136-b6e91f00-9ab5-11e9-89d5-83df926cb36d.png)