### PR TITLE
Add missing transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "electron-builder": "20.40.2",
     "electron-connect": "0.6.2",
     "electron-debug": "1.4.0",
+    "fs-extra": "8.1.0",
     "google-translate-api": "2.3.0",
     "gulp": "4.0.0",
     "gulp-tape": "0.0.9",


### PR DESCRIPTION
**What's this PR do?**

zulip was using a dependency on fs-extra that was resolving transitively
through electron. This adds the dependency explicitly. This is safer and
allows tools like pnpm to function.

**Any background context you want to provide?**

https://medium.com/pnpm/pnpms-strictness-helps-to-avoid-silly-bugs-9a15fb306308

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
