### PR TITLE
asar: Unpack node binding files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "build": {
     "appId": "org.zulip.zulip-electron",
     "asar": true,
+    "asarUnpack": [
+      "**/*.node"
+    ],
     "files": [
       "**/*",
       "!docs${/*}",


### PR DESCRIPTION
We have noticed that on Windows, Zulip app is creating a temp file at %appdata%/Local/Temp
as <guid>.tmp.node on each run. Adding *.node files to asarUnpack fixes this issue.
More info - https://github.com/brave/browser-laptop/issues/12534

Fixes: #789.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
