### PR TITLE
Fix broken inline reply on macOS

### DIFF
--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -9,6 +9,7 @@ type ListenerType = ((...args: any[]) => void);
 // for the whole file.
 /* eslint-disable @typescript-eslint/camelcase */
 class ElectronBridge extends events {
+	send_notification_reply_message_supported = false;
 	send_event(eventName: string | symbol, ...args: any[]): void {
 		this.emit(eventName, ...args);
 	}

--- a/app/renderer/js/notification/darwin-notifications.ts
+++ b/app/renderer/js/notification/darwin-notifications.ts
@@ -13,6 +13,7 @@ type ClickHandler = () => void;
 let replyHandler: ReplyHandler;
 let clickHandler: ClickHandler;
 
+declare const window: ZulipWebWindow;
 interface NotificationHandlerArgs {
 	response: string;
 }
@@ -89,8 +90,12 @@ class DarwinNotification {
 	notificationHandler({ response }: NotificationHandlerArgs): void {
 		response = parseReply(response);
 		focusCurrentServer();
-		setupReply(this.tag);
+		if (window.electron_bridge.send_notification_reply_message_supported) {
+			window.electron_bridge.send_event('send_notification_reply_message', this.tag, response);
+			return;
+		}
 
+		setupReply(this.tag);
 		if (replyHandler) {
 			replyHandler(response);
 			return;


### PR DESCRIPTION
The relevent webapp PR: #12829.

**Testing**:
 - To this this I applied the patch below and from a browser tab send messages that will trigger a notification (Group PM, PM, and Stream message mention). The patch below is only required because I am not on macOS:
```diff
diff --git a/app/renderer/js/notification/darwin-notifications.ts b/app/renderer/js/notification/darwin-notifications.ts
index acb29ca..05082e0 100644
--- a/app/renderer/js/notification/darwin-notifications.ts
+++ b/app/renderer/js/notification/darwin-notifications.ts
@@ -5,7 +5,7 @@ import {
 } from './helpers';
 
 import url = require('url');
-import MacNotifier = require('node-mac-notifier');
+// import MacNotifier = require('node-mac-notifier');
 import ConfigUtil = require('../utils/config-util');
 
 type ReplyHandler = (response: string) => void;
@@ -18,6 +18,7 @@ interface NotificationHandlerArgs {
 	response: string;
 }
 
+const MacNotifier = Notification;
 class DarwinNotification {
 	tag: string;
 
@@ -46,7 +47,8 @@ class DarwinNotification {
 			ipcRenderer.send('focus-app');
 		});
 
-		notification.addEventListener('reply', this.notificationHandler);
+		this.notificationHandler({ response: "*Reply for testing **send_notification_message***" });
+		// notification.addEventListener('reply', this.notificationHandler);
 	}
 
 	static requestPermission(): void {
diff --git a/app/renderer/js/notification/index.ts b/app/renderer/js/notification/index.ts
index 90b6f26..f00b69a 100644
--- a/app/renderer/js/notification/index.ts
+++ b/app/renderer/js/notification/index.ts
@@ -11,7 +11,7 @@ const { app } = remote;
 // On windows 8 we have to explicitly set the appUserModelId otherwise notification won't work.
 app.setAppUserModelId(appId);
 
-window.Notification = DefaultNotification;
+window.Notification = require('./darwin-notifications');
 
 if (process.platform === 'darwin') {
 	window.Notification = require('./darwin-notifications');

```

@akashnimare you will need to test this on macOS.