### PR TITLE
Fixed-CSS-Button

### DIFF
--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -104,14 +104,10 @@ class GeneralSection extends BaseSection {
 				<button class="custom-css-button green">${t.__('Upload')}</button>
 			</div>
 			<div class="setting-row" id="remove-custom-css">
-		"S
 				<div class="setting-description">
 					<div class="selected-css-path" id="custom-css-path">${ConfigUtil.getConfigItem('customCSS')}</div>
 				</div>
-				<div class="action red" id="css-delete-action">
-					<i class="material-icons">indeterminate_check_box</i>
-					<span>${t.__('Delete')}</span>
-				</div>
+				<button class="red" id="css-delete-action">${t.__('Delete')}</button>
 			</div>
 					<div class="setting-row" id="download-folder">
 						<div class="setting-description">


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes the size and appearance of the "Delete CSS from external file button". Converted the div tag into a button tag and removed the action class so that the button looks identical to the Upload and Change buttons.

**Any background context you want to provide?**
Issue: #801 

**Screenshots?**
![zulipchangeddelbuton](https://user-images.githubusercontent.com/40121248/62396015-8eaa7f80-b58f-11e9-95af-cf9b47545a43.PNG)

**You have tested this PR on:**
  - [ ] Windows
  - [X ] Linux/Ubuntu
  - [ ] macOS
