### PR TITLE
Remove trailing brackets from settings page.

### DIFF
--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -42,7 +42,7 @@ class GeneralSection extends BaseSection {
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="dock-bounce-option" style= "display:${process.platform === 'darwin' ? '' : 'none'}">
-						<div class="setting-description">${t.__('Bounce dock on new private message')})}</div>
+						<div class="setting-description">${t.__('Bounce dock on new private message')}</div>
 						<div class="setting-control"></div>
 					</div>
 					<div class="setting-row" id="flash-taskbar-option" style= "display:${process.platform === 'win32' ? '' : 'none'}">


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Removes extra `)}` from a settings item on the General settings page of Zulip for Mac. 

**Any background context you want to provide?**
 
Bug report [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/trailing.20parens.2Bbracket/near/780303). 
We should probably release a v4.0.2 with this change.

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
