### PR TITLE
domains: Prompt user on old server invalidation.

### DIFF
--- a/app/renderer/invalid-server.html
+++ b/app/renderer/invalid-server.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" class="responsive desktop">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Zulip - Invalid Server</title>
+        <link rel="stylesheet" href="css/network.css" type="text/css" media="screen">
+    </head>
+    <body>
+        <div id="content">
+            <div id="picture"><img src="img/zulip_network.png"></div>
+            <div id="title">Zulip can't connect</div>
+            <div id="description">
+                <div>Looks like this organization isn't a Zulip server.</div>
+                <div>We suggest you remove this organization, contact your server administrator, and re-add the organization with the correct URL.</div>
+            </div>
+        </div>
+    </body>
+    <script>require('./js/shared/preventdrag.js')</script>
+</html>

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -147,6 +147,10 @@ class WebView extends BaseComponent {
 		});
 	}
 
+	showInvalidServer(): void {
+		this.$el.src = `file://${this.props.rendererDirectory}/invalid-server.html`;
+	}
+
 	getBadgeCount(title: string): number {
 		const messageCountInTitle = (/\((\d+)\)/).exec(title);
 		return messageCountInTitle ? Number(messageCountInTitle[1]) : 0;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -373,7 +373,8 @@ class ServerManagerView {
 				onNetworkError: this.openNetworkTroubleshooting.bind(this),
 				onTitleChange: this.updateBadge.bind(this),
 				nodeIntegration: false,
-				preload: true
+				preload: true,
+				rendererDirectory
 			})
 		}));
 		this.loading[server.url] = true;
@@ -539,7 +540,8 @@ class ServerManagerView {
 				onNetworkError: this.openNetworkTroubleshooting.bind(this),
 				onTitleChange: this.updateBadge.bind(this),
 				nodeIntegration: true,
-				preload: false
+				preload: false,
+				rendererDirectory
 			})
 		}));
 
@@ -790,6 +792,10 @@ class ServerManagerView {
 				}
 			});
 		}
+
+		ipcRenderer.on('postvalidation-server-error', (event: Event, index: number) => {
+			this.tabs[index].webview.showInvalidServer();
+		});
 
 		ipcRenderer.on('open-settings', (event: Event, settingNav: string) => {
 			this.openSettings(settingNav);

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -264,6 +264,7 @@ class DomainUtil {
 				this.reloadDB();
 			}
 		} catch (err) {
+			ipcRenderer.send('forward-message', 'postvalidation-server-error', index);
 			dialog.showMessageBox({
 				type: 'warning',
 				buttons: ['YES', 'NO'],

--- a/app/resources/messages.ts
+++ b/app/resources/messages.ts
@@ -12,6 +12,13 @@ class Messages {
 			\n • The server has a valid certificate. (You can add custom certificates in Settings > Organizations).`;
 	}
 
+	postValidationServerError(domain: string): string {
+		return `Looks like ${domain} is no longer a Zulip server. We suggest you
+		\n • Contact your server administrator to confirm the server URL.\
+		\n • Click Yes below to remove this faulty organization and re-add it later.\
+		`;
+	}
+
 	noOrgsError(domain: string): string {
 		return `${domain} does not have any organizations added.\
 		\nPlease contact your server administrator.`;


### PR DESCRIPTION
Fixes #813.

On app load, we call `checkDomain()` every time we check for updates to the server icon and can detect if the new URL (possibly caused by corruption of `domain.json` or the server admin moving the address of the Zulip server) is not a legal Zulip org. This PR prompts the user to remove such an organisation and re-add the same after checking the URL. 

We also add an `override` parameter for this, so if there's an enterprise user facing this issue, they can also remove that organisation. This does allow them to remove an organisation using a hack - they could go to `domain.json` (which they can access since it's in their user folder), change the URL to say `google.com`, then have the app prompt them to remove the server. I'm not sure what we should do here, and implemented the override anyway. Let me know what you think. :)

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**Screenshots?**

![image](https://user-images.githubusercontent.com/24617297/63847653-dadcba00-c9ab-11e9-91e2-2d8993d95b12.png)

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
