### PR TITLE
system-util: Set User-Agent from main process.

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import fs = require('fs');
 import isDev = require('electron-is-dev');
 import electron = require('electron');
-const { app, ipcMain } = electron;
+const { app, ipcMain, session } = electron;
 
 import AppMenu = require('./menu');
 import BadgeSettings = require('../renderer/js/pages/preference/badge-settings');
@@ -181,6 +181,10 @@ app.on('ready', () => {
 			mainWindow.hide();
 		} else {
 			mainWindow.show();
+		}
+		if (!ConfigUtil.isConfigItemExists('userAgent')) {
+			const userAgent = session.fromPartition('webview:persistsession').getUserAgent();
+			ConfigUtil.setConfigItem('userAgent', userAgent);
 		}
 	});
 

--- a/app/renderer/js/utils/system-util.ts
+++ b/app/renderer/js/utils/system-util.ts
@@ -2,6 +2,7 @@
 import { remote } from 'electron';
 
 import os = require('os');
+import ConfigUtil = require('./config-util');
 
 const { app } = remote;
 let instance: null | SystemUtil = null;
@@ -53,6 +54,9 @@ class SystemUtil {
 	}
 
 	getUserAgent(): string | null {
+		if (!this.userAgent) {
+			this.setUserAgent(ConfigUtil.getConfigItem('userAgent', null));
+		}
 		return this.userAgent;
 	}
 }


### PR DESCRIPTION
**What's this PR do?**

* Sets user-agent config item when the app's DOM is ready.
* App sends the right User-Agent to the server-settings API.
* Fixes #817.

**Any background context you want to provide?**

Please have a look at #817.

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
