### PR TITLE
Reactivate network.js script.

### DIFF
--- a/app/renderer/network.html
+++ b/app/renderer/network.html
@@ -17,6 +17,7 @@
             <div id="reconnect">Try now</div>
         </div>
     </body>
+    <script>var exports = {};</script>
     <script src="js/pages/network.js"></script>
     <script>require('./js/shared/preventdrag.js')</script>
 </html>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Fixes issue introduced during TS migration that rendered network.ts
ineffective because exports were not defined.

**Any background context you want to provide?**

@akashnimare @priyank-p this addresses the problem I'd texted you guys about on czo. Please have a look at it whenever you have time.
An easy way to test this is to confirm that the `Try now` button fails to reconnect the app on `master` but works as expected on this branch.

**Screenshots?**

Error this PR fixes:

![image](https://user-images.githubusercontent.com/24617297/64079099-de9c7380-cd00-11e9-8963-240b4029827e.png)


**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
