### PR TITLE
sidebar: Improve UX for notification settings.

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -731,6 +731,11 @@ class ServerManagerView {
 		this.$dndButton.querySelector('i').textContent = alert ? 'notifications_off' : 'notifications';
 	}
 
+	isLoggedIn(tabIndex: number): boolean {
+		const url = this.tabs[tabIndex].webview.$el.src;
+		return !(url.endsWith('/login/') || this.tabs[tabIndex].webview.loading);
+	}
+
 	addContextMenu($serverImg: HTMLImageElement, index: number): void {
 		$serverImg.addEventListener('contextmenu', e => {
 			e.preventDefault();
@@ -757,6 +762,7 @@ class ServerManagerView {
 				},
 				{
 					label: 'Notification settings',
+					enabled: this.isLoggedIn(index),
 					click: () => {
 						this.tabs[this.activeTabIndex].webview.showNotificationSettings();
 					}

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -764,7 +764,9 @@ class ServerManagerView {
 					label: 'Notification settings',
 					enabled: this.isLoggedIn(index),
 					click: () => {
-						this.tabs[this.activeTabIndex].webview.showNotificationSettings();
+						// switch to tab whose icon was right-clicked
+						this.activateTab(index);
+						this.tabs[index].webview.showNotificationSettings();
 					}
 				},
 				{


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

1. Disables the option for notification settings in the context menu for a server icon if the user is not logged in to that server.
2. If an inactive server's context menu is opened up and its notification settings are requested, we simply switch to that tab first and then show the settings. 

**Any background context you want to provide?**

Discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/disable.20notification.20settings.20option/near/788363).

**Screenshots?**

Disabled context menu item shown below (on the login page).

![image](https://user-images.githubusercontent.com/24617297/65579373-3f803a00-df95-11e9-8243-dee079a03f7c.png)

**You have tested this PR on:**
  - [x] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
