### PR TITLE
Added option to quit on closing the window.

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -94,6 +94,9 @@ function createMainWindow(): Electron.BrowserWindow {
 
 	// Keep the app running in background on close event
 	win.on('close', e => {
+		if (ConfigUtil.getConfigItem("quitOnClose")) {
+			app.quit();
+		}
 		if (!isQuitting) {
 			e.preventDefault();
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -58,6 +58,7 @@ interface SettingsOptions {
 	};
 	downloadsPath: string;
 	showDownloadFolder: boolean;
+	quitOnClose: boolean;
 	flashTaskbarOnMessage?: boolean;
 	dockBouncing?: boolean;
 	loading?: AnyObject;
@@ -206,7 +207,8 @@ class ServerManagerView {
 				silent: false
 			},
 			downloadsPath: `${app.getPath('downloads')}`,
-			showDownloadFolder: false
+			showDownloadFolder: false,
+			quitOnClose: false
 		};
 
 		// Platform specific settings

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -82,6 +82,10 @@ class GeneralSection extends BaseSection {
 						<div class="setting-description">${t.__('Always start minimized')}</div>
 						<div class="setting-control"></div>
 					</div>
+					<div class="setting-row" id="quitOnClose-option">
+						<div class="setting-description">${t.__('Quit when the window is closed')}</div>
+						<div class="setting-control"></div>
+					</div>
 					<div class="setting-row" id="enable-spellchecker-option">
 						<div class="setting-description">${t.__('Enable spellchecker (requires restart)')}</div>
 						<div class="setting-control"></div>
@@ -155,6 +159,7 @@ class GeneralSection extends BaseSection {
 		this.removeCustomCSS();
 		this.downloadFolder();
 		this.showDownloadFolder();
+		this.updateQuitOnCloseOption();
 		this.enableErrorReporting();
 
 		// Platform specific settings
@@ -317,6 +322,18 @@ class GeneralSection extends BaseSection {
 				ConfigUtil.setConfigItem('startAtLogin', newValue);
 				ipcRenderer.send('toggleAutoLauncher', newValue);
 				this.updateStartAtLoginOption();
+			}
+		});
+	}
+
+	updateQuitOnCloseOption(): void {
+		this.generateSettingOption({
+			$element: document.querySelector('#quitOnClose-option .setting-control'),
+			value: ConfigUtil.getConfigItem('quitOnClose', false),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('quitOnClose');
+				ConfigUtil.setConfigItem('quitOnClose', newValue);
+				this.updateQuitOnCloseOption();
 			}
 		});
 	}

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -113,5 +113,6 @@
 	"Zoom Out": "Zoom Out",
 	"Zulip Help": "Zulip Help",
 	"keyboard shortcuts": "keyboard shortcuts",
-	"script": "script"
+	"script": "script",
+	"Quit when the window is closed": "Quit when the window is closed"
 }


### PR DESCRIPTION
This adds an configuration option to quit the app (rather than going to
the tray) when the "close" button is clicked.

---

**What's this PR do?**
Normally, when you click the close button, the app minimises to a tray icon. This behaviour may be undesirable, so this patch adds an option in the settings to cause the close button to actually close the app.

**Any background context you want to provide?**

Many apps don't minimise to tray, and IMO it should be the default.

**Screenshots?**

![Screenshot](https://user-images.githubusercontent.com/662364/66252779-5eca5480-e757-11e9-9803-799b2586d40a.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
