### PR TITLE
Added option to select download locations.

### DIFF
--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -66,7 +66,17 @@ function handleExternalLink(this: any, event: any): void {
 			ipcRenderer.once('downloadFileFailed', () => {
 				// Automatic download failed, so show save dialog prompt and download
 				// through webview
-				this.$el.downloadURL(url);
+				// Only do this if it is the automatic download, otherwise show an error (so we aren't showing two save
+				// prompts right after each other)
+				if (ConfigUtil.getConfigItem("promptDownload", false)) {
+					// We need to create a "new Notification" to display it, but just `Notification(...)` on its own
+					// doesn't work
+					new Notification('Download Complete', { // eslint-disable-line no-new
+						body: 'Download failed'
+					});
+				} else {
+					this.$el.downloadURL(url);
+				}
 				ipcRenderer.removeAllListeners('downloadFileCompleted');
 			});
 			return;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -59,6 +59,7 @@ interface SettingsOptions {
 	downloadsPath: string;
 	showDownloadFolder: boolean;
 	quitOnClose: boolean;
+	promptDownload: boolean;
 	flashTaskbarOnMessage?: boolean;
 	dockBouncing?: boolean;
 	loading?: AnyObject;
@@ -208,7 +209,8 @@ class ServerManagerView {
 			},
 			downloadsPath: `${app.getPath('downloads')}`,
 			showDownloadFolder: false,
-			quitOnClose: false
+			quitOnClose: false,
+			promptDownload: false
 		};
 
 		// Platform specific settings

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -127,6 +127,10 @@ class GeneralSection extends BaseSection {
 							<div class="download-folder-path">${ConfigUtil.getConfigItem('downloadsPath', `${app.getPath('downloads')}`)}</div>
 						</div>
 					</div>
+					<div class="setting-row" id="prompt-download">
+						<div class="setting-description">${t.__('Ask where to save files before downloading')}</div>
+						<div class="setting-control"></div>
+					</div>
 
 				</div>
 				<div class="title">${t.__('Reset Application Data')}</div>
@@ -160,6 +164,7 @@ class GeneralSection extends BaseSection {
 		this.downloadFolder();
 		this.showDownloadFolder();
 		this.updateQuitOnCloseOption();
+		this.updatePromptDownloadOption();
 		this.enableErrorReporting();
 
 		// Platform specific settings
@@ -465,6 +470,18 @@ class GeneralSection extends BaseSection {
 				const newValue = !ConfigUtil.getConfigItem('showDownloadFolder');
 				ConfigUtil.setConfigItem('showDownloadFolder', newValue);
 				this.showDownloadFolder();
+			}
+		});
+	}
+
+	updatePromptDownloadOption(): void {
+		this.generateSettingOption({
+			$element: document.querySelector('#prompt-download .setting-control'),
+			value: ConfigUtil.getConfigItem('promptDownload', false),
+			clickHandler: () => {
+				const newValue = !ConfigUtil.getConfigItem('promptDownload');
+				ConfigUtil.setConfigItem('promptDownload', newValue);
+				this.updatePromptDownloadOption();
 			}
 		});
 	}

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -114,5 +114,6 @@
 	"Zulip Help": "Zulip Help",
 	"keyboard shortcuts": "keyboard shortcuts",
 	"script": "script",
-	"Quit when the window is closed": "Quit when the window is closed"
+	"Quit when the window is closed": "Quit when the window is closed",
+	"Ask where to save files before downloading": "Ask where to save files before downloading"
 }


### PR DESCRIPTION
Added an option that, when enabled, will mean any file downloads that
would normally go to ~/Downloads (or wherever), in fact prompt.

---

**What's this PR do?**

Adds an option, when enabled clicking a file that will be downloaded to ~/Downloads (or wherever), it instead displays a "Save" prompt, allowing the user to select where to save it.

**Any background context you want to provide?**

I find the default behaviour very annoying. :C

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
