### PR TITLE
macos: Enable notarization for macOS Catalina.

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test"
   ],
   "build": {
+    "afterSign": "scripts/notarize.js",
     "appId": "org.zulip.zulip-electron",
     "asar": true,
     "asarUnpack": [
@@ -57,7 +58,11 @@
     "mac": {
       "category": "public.app-category.productivity",
       "darkModeSupport": true,
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "gatekeeperAssess": false
     },
     "linux": {
       "category": "Chat;GNOME;GTK;Network;InstantMessaging",
@@ -148,9 +153,10 @@
     "cp-file": "5.0.0",
     "devtron": "1.4.0",
     "electron": "3.1.10",
-    "electron-builder": "20.40.2",
+    "electron-builder": "20.43.0",
     "electron-connect": "0.6.2",
     "electron-debug": "1.4.0",
+    "electron-notarize": "0.1.1",
     "eslint-config-xo-typescript": "0.14.0",
     "fs-extra": "8.1.0",
     "gulp": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test"
   ],
   "build": {
-    "afterSign": "scripts/notarize.js",
+    "afterSign": "./scripts/notarize.js",
     "appId": "org.zulip.zulip-electron",
     "asar": true,
     "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "electron-builder": "20.43.0",
     "electron-connect": "0.6.2",
     "electron-debug": "1.4.0",
-    "electron-notarize": "0.1.1",
+    "electron-notarize": "0.2.0",
     "eslint-config-xo-typescript": "0.14.0",
     "fs-extra": "8.1.0",
     "gulp": "4.0.0",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+const { notarize } = require('electron-notarize');
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;  
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  return await notarize({
+    appBundleId: process.env.APP_BUNDLE_ID,
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASS,
+  });
+};

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -10,7 +10,7 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productFilename;
 
   return await notarize({
-    appBundleId: process.env.APP_BUNDLE_ID,
+    appBundleId: 'org.zulip.zulip-electron',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_ID_PASS,

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,8 +1,12 @@
-require('dotenv').config();
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(__dirname, '/../.env') });
+
 const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
-  const { electronPlatformName, appOutDir } = context;  
+  const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') {
     return;
   }

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const dotenv = require('dotenv');
 
-dotenv.config({ path: path.resolve(__dirname, '/../.env') });
+dotenv.config({ path: path.join(__dirname, '/../.env') });
 
 const { notarize } = require('electron-notarize');
 


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

Fixes an issue Catalina users were facing with Zulip's lack of notarization.

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [ ] macOS
