### PR TITLE
[WIP] Session ID-based login for OAuth providers

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,7 @@
     "escape-html": "1.0.3",
     "i18n": "0.8.3",
     "node-json-db": "0.9.2",
+    "otp-generator": "1.1.0",
     "request": "2.85.0",
     "semver": "5.4.1",
     "wurl": "2.5.0"

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -21,6 +21,7 @@ import ReconnectUtil = require('./utils/reconnect-util');
 import Logger = require('./utils/logger-util');
 import CommonUtil = require('./utils/common-util');
 import EnterpriseUtil = require('./utils/enterprise-util');
+import AuthUtil = require('./utils/auth-util');
 import Messages = require('./../../resources/messages');
 
 interface FunctionalTabProps {
@@ -805,6 +806,15 @@ class ServerManagerView {
 				}
 			});
 		}
+
+		ipcRenderer.on('deep-linking-url', (event: Event, url: string) => {
+			if (!ConfigUtil.getConfigItem('desktopOtp')) {
+				return;
+			}
+			let apiKey = url.substring(url.indexOf('otp_encrypted_api_key') + 22, url.indexOf('&email='));
+			apiKey = AuthUtil.xorStrings(apiKey, ConfigUtil.getConfigItem('desktopOtp'));
+			ConfigUtil.setConfigItem('desktopOtp', null);
+		});
 
 		ipcRenderer.on('show-network-error', (event: Event, index: number) => {
 			this.openNetworkTroubleshooting(index);

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -764,6 +764,14 @@ class ServerManagerView {
 					}
 				},
 				{
+					label: 'Login with OAuth',
+					enabled: !this.isLoggedIn(index),
+					click: () => {
+						this.activateTab(index);
+						AuthUtil.startAuth(DomainUtil.getDomain(index).url);
+					}
+				},
+				{
 					label: 'Notification settings',
 					enabled: this.isLoggedIn(index),
 					click: () => {

--- a/app/renderer/js/utils/auth-util.ts
+++ b/app/renderer/js/utils/auth-util.ts
@@ -1,6 +1,7 @@
 import { remote } from 'electron';
 
 import otpGenerator = require('otp-generator');
+import ConfigUtil = require('./config-util');
 
 const { shell } = remote;
 
@@ -10,7 +11,18 @@ class AuthUtil {
 		if (!domain.endsWith('/')) {
 			domain += '/';
 		}
+		ConfigUtil.setConfigItem('desktopOtp', otp);
 		shell.openExternal(`${domain}accounts/login/?desktop_flow_otp=${otp}`);
+	};
+
+	xorStrings = (a: string, b: string): string => {
+		let res = '';
+		let i = a.length;
+		let j = b.length;
+		while (i-- > 0 && j-- > 0) {
+			res = (parseInt(a.charAt(i), 16) ^ parseInt(b.charAt(j), 16)).toString(16) + res;
+		}
+		return res;
 	};
 }
 

--- a/app/renderer/js/utils/auth-util.ts
+++ b/app/renderer/js/utils/auth-util.ts
@@ -1,0 +1,17 @@
+import { remote } from 'electron';
+
+import otpGenerator = require('otp-generator');
+
+const { shell } = remote;
+
+class AuthUtil {
+	startAuth = (domain: string) => {
+		const otp = otpGenerator.generate(64, { upperCase: false, specialChars: false });
+		if (!domain.endsWith('/')) {
+			domain += '/';
+		}
+		shell.openExternal(`${domain}accounts/login/?desktop_flow_otp=${otp}`);
+	};
+}
+
+export = new AuthUtil();

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -169,7 +169,8 @@ class DomainUtil {
 			icon: defaultIconUrl,
 			url: domain,
 			alias: domain,
-			ignoreCerts
+			ignoreCerts,
+			loggedIn: false
 		};
 
 		try {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false
     },
+    "protocols": [{
+      "name": "zulip",
+      "role": "Viewer",
+      "schemes": ["zulip"]
+    }],
     "linux": {
       "category": "Chat;GNOME;GTK;Network;InstantMessaging",
       "icon": "build/icon.icns",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -13,6 +13,7 @@ declare module 'fs-extra';
 declare module 'wurl';
 declare module 'i18n';
 declare module 'backoff';
+declare module 'otp-generator';
 
 interface PageParamsObject {
     realm_uri: string;


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Generates an OTP, similar to the mobile app flow, and then XORs the same with the encrypted API key returned by the server. Picks up this URL using the `zulip://` scheme. 

I'm working on writing an API endpoint for generating the session ID for a logged in user (will get back to czo about this tomorrow morning). 

@akashnimare @vsvipul please have a look at this whenever you find time. The patched version of the server you'll need to test this app against can be found [here](https://github.com/kanishk98/zulip/tree/desktop-oauth). 

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
