### PR TITLE
Decode server name in Window menu.

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -347,7 +347,7 @@ class ServerManagerView {
 		this.tabs.push(new ServerTab({
 			role: 'server',
 			icon: server.icon,
-			name: server.alias,
+			name: CommonUtil.decodeString(server.alias),
 			$root: this.$tabsContainer,
 			onClick: this.activateLastTab.bind(this, index),
 			index,


### PR DESCRIPTION

**What's this PR do?**
We are decoding the name in the webview but are currently not doing so in the Window menu. I hope this is what we want @akashnimare . 

**Screenshots?**
Earlier
![Screenshot from 2020-01-08 00-19-33](https://user-images.githubusercontent.com/21038781/71920725-6ca3d180-31ad-11ea-8856-05191a32b5b0.png)

Now
![Screenshot from 2020-01-08 00-21-05](https://user-images.githubusercontent.com/21038781/71920727-6d3c6800-31ad-11ea-9982-24dddd296be0.png)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
