### PR TITLE
startup: Use inbuilt electron API for autostartup.

### DIFF
--- a/app/main/startup.ts
+++ b/app/main/startup.ts
@@ -11,21 +11,23 @@ export const setAutoLaunch = (AutoLaunchValue: boolean): void => {
 		return;
 	}
 
-	// On Mac, work around a bug in auto-launch where it opens a Terminal window
-	// See https://github.com/Teamwork/node-auto-launch/issues/28#issuecomment-222194437
-
-	const appPath = process.platform === 'darwin' ? app.getPath('exe').replace(/\.app\/Content.*/, '.app') : undefined; // Use the default
-
-	const ZulipAutoLauncher = new AutoLaunch({
-		name: 'Zulip',
-		path: appPath,
-		isHidden: false
-	});
 	const autoLaunchOption = ConfigUtil.getConfigItem('startAtLogin', AutoLaunchValue);
 
-	if (autoLaunchOption) {
-		ZulipAutoLauncher.enable();
+	// setLoginItemSettings doesn't support linux
+	if (process.platform === 'linux') {
+		const ZulipAutoLauncher = new AutoLaunch({
+			name: 'Zulip',
+			isHidden: false
+		});
+		if (autoLaunchOption) {
+			ZulipAutoLauncher.enable();
+		} else {
+			ZulipAutoLauncher.disable();
+		}
 	} else {
-		ZulipAutoLauncher.disable();
+		app.setLoginItemSettings({
+			openAtLogin: autoLaunchOption,
+			openAsHidden: false
+		});
 	}
 };


### PR DESCRIPTION
**What's this PR do?**
Switch from using external auto-launch module to
inbuilt setLoginItemSettings for windows and macos,
as some users reported issues on windows.
Fixes #851.

@akashnimare @kanishk98  Need to test this on windows and macos. Can you do it ?

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
