### PR TITLE
TS TODOs : makes reconnect-util generic, provides type annotations

### DIFF
--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -3,13 +3,13 @@ import { ipcRenderer, remote } from 'electron';
 import LinkUtil = require('../utils/link-util');
 import DomainUtil = require('../utils/domain-util');
 import ConfigUtil = require('../utils/config-util');
+import type WebView from './webview';
 
 const { shell, app } = remote;
 
 const dingSound = new Audio('../resources/sounds/ding.ogg');
 
-// TODO: TypeScript - Figure out a way to pass correct type here.
-function handleExternalLink(this: any, event: any): void {
+function handleExternalLink(this: WebView, event: Electron.NewWindowEvent): void {
 	const { url } = event;
 	const domainPrefix = DomainUtil.getDomain(this.props.index).url;
 	const downloadPath = ConfigUtil.getConfigItem('downloadsPath', `${app.getPath('downloads')}`);

--- a/app/renderer/js/notification/helpers.ts
+++ b/app/renderer/js/notification/helpers.ts
@@ -80,9 +80,7 @@ const webContentsId = webContents.id;
 // this function will focus the server that sent
 // the notification. Main function implemented in main.js
 export function focusCurrentServer(): void {
-	// TODO: TypeScript: currentWindow of type BrowserWindow doesn't
-	// have a .send() property per typescript.
-	(currentWindow as any).send('focus-webview-with-id', webContentsId);
+	currentWindow.webContents.send('focus-webview-with-id', webContentsId);
 }
 // this function parses the reply from to notification
 // making it easier to reply from notification eg

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -290,9 +290,7 @@ class GeneralSection extends BaseSection {
 				const newValue = !ConfigUtil.getConfigItem('silent', true);
 				ConfigUtil.setConfigItem('silent', newValue);
 				this.updateSilentOption();
-				// TODO: TypeScript: currentWindow of type BrowserWindow doesn't
-				// have a .send() property per typescript.
-				(currentBrowserWindow as any).send('toggle-silent', newValue);
+				currentBrowserWindow.webContents.send('toggle-silent', newValue);
 			}
 		});
 	}

--- a/app/renderer/js/utils/proxy-util.ts
+++ b/app/renderer/js/utils/proxy-util.ts
@@ -4,7 +4,7 @@ import url = require('url');
 
 import ConfigUtil = require('./config-util');
 
-interface ProxyRule {
+export interface ProxyRule {
 	hostname?: string;
 	port?: number;
 }

--- a/app/renderer/js/utils/request-util.ts
+++ b/app/renderer/js/utils/request-util.ts
@@ -15,11 +15,9 @@ const logger = new Logger({
 	timestamp: true
 });
 
-// TODO: TypeScript - Use ProxyRule for the proxy property
-// we can do this now since we use export = ProxyUtil syntax
 interface RequestUtilResponse {
 	ca: string;
-	proxy: string | void | object;
+	proxy: string | void | ProxyUtil.ProxyRule;
 	ecdhCurve: 'auto';
 	headers: { 'User-Agent': string };
 	rejectUnauthorized: boolean;


### PR DESCRIPTION
**What's this PR do?**
What does this PR do:
    Worked on TypeScript TODOs
	Can pass class into reconnect-util from main.ts (generic class)
	CurrentWindow now has a .send() property
	We now use ProxyRule for the proxy property
	Type annotated some variables

**You have tested this PR on:**
  - [✓ ] macOS (Catalina 10.15.2)

Zulip App v 4.0.3