### PR TITLE
macOS: Fix undo redo not working on macOS.

### DIFF
--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -372,10 +372,20 @@ function getDarwinTpl(props: any): Electron.MenuItemConstructorOptions[] {
 		label: t.__('Edit'),
 		submenu: [{
 			label: t.__('Undo'),
-			role: 'undo'
+			accelerator: 'Cmd+Z',
+			click(_item: any, focusedWindow: any) {
+				if (focusedWindow) {
+					sendAction('undo');
+				}
+			}
 		}, {
 			label: t.__('Redo'),
-			role: 'redo'
+			accelerator: 'Cmd+Shift+Z',
+			click(_item: any, focusedWindow: any) {
+				if (focusedWindow) {
+					sendAction('redo');
+				}
+			}
 		}, {
 			type: 'separator'
 		}, {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -737,7 +737,7 @@ class ServerManagerView {
 		return !(url.endsWith('/login/') || this.tabs[tabIndex].webview.loading);
 	}
 
-	getActiveWebview(): any {
+	getActiveWebview(): Electron.WebviewTag {
 		const selector = 'webview:not(.disabled)';
 		const webview: Electron.WebviewTag = document.querySelector(selector);
 		return webview;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -739,6 +739,14 @@ class ServerManagerView {
 		return !(url.endsWith('/login/') || this.tabs[tabIndex].webview.loading);
 	}
 
+	getActiveWebview(): any {
+		const selector = 'webview:not([class*=disabled])';
+		const webview = document.querySelector(selector);
+		if (webview) {
+			return webview;
+		}
+	}
+
 	addContextMenu($serverImg: HTMLImageElement, index: number): void {
 		$serverImg.addEventListener('contextmenu', e => {
 			e.preventDefault();
@@ -1015,6 +1023,15 @@ class ServerManagerView {
 
 		ipcRenderer.on('new-server', () => {
 			this.openSettings('AddServer');
+		});
+
+		// Redo and undo functionality since the default API doesn't work on macOS
+		ipcRenderer.on('undo', () => {
+			return this.getActiveWebview().undo();
+		});
+
+		ipcRenderer.on('redo', () => {
+			return this.getActiveWebview().redo();
 		});
 
 		ipcRenderer.on('set-active', () => {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -712,10 +712,8 @@ class ServerManagerView {
 	}
 
 	updateGeneralSettings(setting: string, value: any): void {
-		const selector = 'webview:not([class*=disabled])';
-		const webview: Electron.WebviewTag = document.querySelector(selector);
-		if (webview) {
-			const webContents = webview.getWebContents();
+		if (this.getActiveWebview()) {
+			const webContents = this.getActiveWebview().getWebContents();
 			webContents.send(setting, value);
 		}
 	}
@@ -740,11 +738,9 @@ class ServerManagerView {
 	}
 
 	getActiveWebview(): any {
-		const selector = 'webview:not([class*=disabled])';
-		const webview = document.querySelector(selector);
-		if (webview) {
-			return webview;
-		}
+		const selector = 'webview:not(.disabled)';
+		const webview: Electron.WebviewTag = document.querySelector(selector);
+		return webview;
 	}
 
 	addContextMenu($serverImg: HTMLImageElement, index: number): void {
@@ -918,9 +914,7 @@ class ServerManagerView {
 		ipcRenderer.on('toggle-dnd', (event: Event, state: boolean, newSettings: SettingsOptions) => {
 			this.toggleDNDButton(state);
 			ipcRenderer.send('forward-message', 'toggle-silent', newSettings.silent);
-			const selector = 'webview:not([class*=disabled])';
-			const webview: Electron.WebviewTag = document.querySelector(selector);
-			const webContents = webview.getWebContents();
+			const webContents = this.getActiveWebview().getWebContents();
 			webContents.send('toggle-dnd', state, newSettings);
 		});
 


### PR DESCRIPTION
The default API provided by Electron doesn't work
as expected. More info here -
https://github.com/electron/electron/issues/15728

Fixes: #866.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
