### PR TITLE
macOS: Replace deprecated isDarkMode() with shouldUseDarkColors.

### DIFF
--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -4,10 +4,10 @@ import { ipcRenderer, remote, WebviewTag, NativeImage } from 'electron';
 import path from 'path';
 import * as ConfigUtil from './utils/config-util';
 
-const { Tray, Menu, nativeImage, BrowserWindow, systemPreferences } = remote;
+const { Tray, Menu, nativeImage, BrowserWindow, nativeTheme } = remote;
 
 // get the theme on macOS
-const theme = systemPreferences.isDarkMode() ? 'dark' : 'light';
+const theme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
 
 const ICON_DIR = process.platform === 'darwin' ? `../../resources/tray/${theme}` : '../../resources/tray';
 


### PR DESCRIPTION
**What's this PR do?**
Fixes: #891

**You have tested this PR on:**
  - [✓] macOS Catalina 10.15.2
