### PR TITLE
Add feature to enable Time based DND Mode

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -82,6 +82,70 @@ body {
     flex-direction: column;
 }
 
+
+/* DND Menu */
+
+@keyframes fading {
+    0% {
+        opacity: 0;
+    }
+    20% {
+        opacity: 1;
+    }
+    80% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
+.toast {
+    font-family: Verdana;
+    border-radius: 10px;
+    font-size: 13.5px;
+    left: 45%;
+    top: 10px;
+    position: fixed;
+    background-color: rgba(200, 200, 200, 1.000);
+    padding: 15px 30px  15px 30px;
+    color: rgb(0, 0, 0);
+    animation: fading 4s;
+}
+
+.dnd-menu {
+    font-family: Verdana;
+    font-size: 13px;
+    left: 60px;
+    bottom: 10px;
+    position: fixed;
+    background-color: transparent;
+    padding: 10px;
+    width: 150px;
+    min-height: 150px;
+    color: rgb(255, 255, 255);
+    list-style-type: none;
+}
+
+.dnd-time-btn {
+    background-color: rgba(34, 44, 49, 1.000);
+    border-style: solid;
+    border-color: rgba(255, 255, 255, 1.000);
+    border-width: 1.5px;
+    border-radius: 20px;
+    padding: 10px;
+    text-align: center;
+    margin: 2px 0;
+    transition: .1s;
+}
+
+.dnd-time-btn:hover {
+    background-color: rgba(59, 76, 85, 1.000);
+    transition: .2s;
+    cursor: pointer;
+}
+
+
 .material-icons {
     font-family: 'Material Icons';
     font-weight: normal;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -404,12 +404,20 @@ class ServerManagerView {
 	initLeftSidebarEvents(): void {
 		this.$dndButton.addEventListener('click', () => {
 			const dnd = ConfigUtil.getConfigItem('dnd', false);
+
+			// Case: DND is turned on and user clicks DND button -> switch it off
 			if (dnd) {
 				const dndUtil = DNDUtil.toggle();
 				ipcRenderer.send('forward-message', 'toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
-			} else if (document.querySelector('.dnd-menu') === null) {
-				DNDUtil.makeMenu();
-			} else {
+			} // eslint-disable-line @typescript-eslint/brace-style
+
+			// Case: DND is turned off, there is no DND menu and user clicks DND button -> create menu and schedule
+			else if (document.querySelector('.dnd-menu') === null) {
+				DNDUtil.scheduleDND();
+			} // eslint-disable-line @typescript-eslint/brace-style
+
+			// Case: DND is turned off, DND menu is already created and user clicks DND button -> remove the menu
+			else {
 				document.querySelector('.dnd-menu').remove();
 			}
 		});

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -403,8 +403,15 @@ class ServerManagerView {
 
 	initLeftSidebarEvents(): void {
 		this.$dndButton.addEventListener('click', () => {
-			const dndUtil = DNDUtil.toggle();
-			ipcRenderer.send('forward-message', 'toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
+			const dnd = ConfigUtil.getConfigItem('dnd', false);
+			if (dnd) {
+				const dndUtil = DNDUtil.toggle();
+				ipcRenderer.send('forward-message', 'toggle-dnd', dndUtil.dnd, dndUtil.newSettings);
+			} else if (document.querySelector('.dnd-menu') === null) {
+				DNDUtil.makeMenu();
+			} else {
+				document.querySelector('.dnd-menu').remove();
+			}
 		});
 		this.$reloadButton.addEventListener('click', () => {
 			this.tabs[this.activeTabIndex].webview.reload();
@@ -428,6 +435,7 @@ class ServerManagerView {
 	}
 
 	initDNDButton(): void {
+		DNDUtil.setDNDTimer();
 		const dnd = ConfigUtil.getConfigItem('dnd', false);
 		this.toggleDNDButton(dnd);
 	}

--- a/app/renderer/js/utils/dnd-util.ts
+++ b/app/renderer/js/utils/dnd-util.ts
@@ -1,5 +1,6 @@
 import * as ConfigUtil from './config-util';
-
+import {ipcRenderer} from 'electron';
+import schedule from 'node-schedule';
 type SettingName = 'showNotification' | 'silent' | 'flashTaskbarOnMessage';
 
 export interface DNDSettings {
@@ -12,6 +13,10 @@ interface Toggle {
 	dnd: boolean;
 	newSettings: DNDSettings;
 }
+
+/*	Node-schedule job instance accepts time parameter and schedules to turn off DND
+	and pops a toast that DND has ended. Cancel a pre-existing job before scheduling a new one. */
+let job: schedule.Job = null;
 
 export function toggle(): Toggle {
 	const dnd = !ConfigUtil.getConfigItem('dnd', false);
@@ -37,6 +42,10 @@ export function toggle(): Toggle {
 		ConfigUtil.setConfigItem('dndPreviousSettings', oldSettings);
 	} else {
 		newSettings = ConfigUtil.getConfigItem('dndPreviousSettings');
+		ConfigUtil.setConfigItem('dndSwitchOff', null);
+		if (job !== null) {
+			job.cancel();
+		}
 	}
 
 	for (const settingName of dndSettingList) {
@@ -46,3 +55,125 @@ export function toggle(): Toggle {
 	ConfigUtil.setConfigItem('dnd', dnd);
 	return {dnd, newSettings};
 }
+
+/*	Create the DND menu and closed it when focussed out. */
+export const makeMenu = (): void => {
+	const actionsContainer = document.querySelector('#actions-container');
+	const dndExist = document.querySelectorAll('.dnd-menu');
+	if (dndExist.length === 0) {
+		const dndMenu = document.createElement('ul');
+		dndMenu.className = 'dnd-menu';
+		const dndOptions: {[key: string]: string} = {
+			'30 Minutes': 'thirty_min',
+			'1 Hour': 'one_hr',
+			'6 Hours': 'six_hr',
+			'12 Hours': 'twelve_hr',
+			'Until I Resume': 'custom'
+		};
+
+		Object.keys(dndOptions).forEach(key => {
+			const opt = document.createElement('li');
+			opt.className = 'dnd-time-btn';
+			opt.innerHTML = key;
+			opt.id = dndOptions[key];
+			opt.addEventListener('click', () => {
+				configureDND(opt, dndMenu);
+			}, false);
+			dndMenu.append(opt);
+		});
+		actionsContainer.append(dndMenu);
+
+		const dndMenuFocusOut = (event: Event) => {
+			console.log(event);
+			if ((event.target as HTMLLIElement).innerHTML !== 'notifications') {
+				dndMenu.remove();
+				document.removeEventListener('click', dndMenuFocusOut);
+			}
+		};
+
+		document.addEventListener('keydown', event => {
+			if (event.key === 'Escape') {
+				dndMenu.remove();
+				document.removeEventListener('click', dndMenuFocusOut);
+			}
+		});
+		document.addEventListener('click', dndMenuFocusOut);
+	}
+};
+
+/*	Configure DND as per user's selected option and pops a toast showing dnd switch off time. */
+const configureDND = (opt: HTMLLIElement, dndMenu: HTMLUListElement): void => {
+	let dndOffTime;
+	dndOffTime = new Date();
+	const optionElement = document.querySelector('#' + opt.id);
+	dndMenu.style.height = '75px';
+	optionElement.className = 'dnd-options-btn';
+	switch (opt.id) {
+		case 'thirty_min':
+			dndOffTime.setMinutes(dndOffTime.getMinutes() + 30);
+			break;
+		case 'one_hr':
+			dndOffTime.setMinutes(dndOffTime.getMinutes() + 60);
+			break;
+		case 'six_hr':
+			dndOffTime.setMinutes(dndOffTime.getMinutes() + 360);
+			break;
+		case 'twelve_hr':
+			dndOffTime.setMinutes(dndOffTime.getMinutes() + 720);
+			break;
+		default:
+			dndOffTime = null;
+			break;
+	}
+
+	ConfigUtil.setConfigItem('dndSwitchOff', dndOffTime);
+
+	dndMenu.remove();
+	showDNDTimeLeft();
+	setDNDTimer();
+	const state = toggle();
+	ipcRenderer.send('forward-message', 'toggle-dnd', state.dnd, state.newSettings);
+};
+
+/*	Fetch DND switch off time and toggle DND off if the time has elapsed. */
+export const setDNDTimer = (): void => {
+	const dbTime = ConfigUtil.getConfigItem('dndSwitchOff');
+	if (dbTime !== null) {
+		const time = new Date(dbTime);
+		// Handle the case when user closes the app before switch off time and stars it after the time has elapsed.
+		if (time < new Date()) {
+			toggle();
+			return;
+		}
+
+		if (job !== null) {
+			job.cancel();
+		}
+
+		job = schedule.scheduleJob(time, () => {
+			ConfigUtil.setConfigItem('dndSwitchOff', null);
+			const state = toggle();
+			ipcRenderer.send('forward-message', 'toggle-dnd', state.dnd, state.newSettings);
+			showToast('DND has ended');
+		});
+	}
+};
+
+/*	Show a toast with the clock time when DND will go off. */
+export const showDNDTimeLeft = (): void => {
+	const check = ConfigUtil.getConfigItem('dndSwitchOff');
+	if (check !== null) {
+		const dbTime = new Date(check);
+		const timeLeft = `DND goes off at ${dbTime.getHours()} : ${(dbTime.getMinutes() < 10 ? (`0${dbTime.getMinutes()}`) : dbTime.getMinutes())}`;
+		showToast(timeLeft);
+	}
+};
+
+export const showToast = (t: string): void => {
+	const actionsContainer = document.querySelector('#actions-container');
+	const toast = document.createElement('p');
+	toast.className = 'toast';
+	toast.innerHTML = t;
+	actionsContainer.append(toast);
+	setTimeout(() => toast.remove(), 4000);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -735,6 +735,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
       "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
     },
+    "@types/node-schedule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node-schedule/-/node-schedule-1.3.0.tgz",
+      "integrity": "sha512-gjKmC9wFxn8laKYKwVP2iZvxeiA1DWUb6CXAYXtoYBcDbiyMqxLn2sQq+8aaNc7Xr0p93Hf0O0VizdaEPUO0vA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2674,6 +2682,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cron-parser": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.15.0.tgz",
+      "integrity": "sha512-rMFkrQw8+oG5OuwjiXesup4KeIlEG/IU82YtG4xyAHbO5jhKmYaHPp/ZNhq9+7TjSJ65E3zV3kQPUbmXSff2/g==",
+      "requires": {
+        "is-nan": "^1.3.0",
+        "moment-timezone": "^0.5.31"
       }
     },
     "cross-spawn": {
@@ -7383,6 +7400,14 @@
       "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
       "dev": true
     },
+    "is-nan": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
+      "integrity": "sha512-z7bbREymOqt2CCaZVly8aC4ML3Xhfi0ekuOnjO2L8vKdl+CttdVoGZQhd4adMFAsxQ5VeRVwORs4tU8RH+HFtQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -8198,6 +8223,11 @@
         }
       }
     },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
+    },
     "longest-streak": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -8592,6 +8622,19 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+    },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8757,6 +8800,16 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
       "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
       "dev": true
+    },
+    "node-schedule": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.3.2.tgz",
+      "integrity": "sha512-GIND2pHMHiReSZSvS6dpZcDH7pGPGFfWBIEud6S00Q8zEIzAs9ommdyRK1ZbQt8y1LyZsJYZgPnyi7gpU2lcdw==",
+      "requires": {
+        "cron-parser": "^2.7.3",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.0.0"
+      }
     },
     "nodemon": {
       "version": "2.0.3",
@@ -11264,6 +11317,11 @@
           }
         }
       }
+    },
+    "sorted-array-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
+      "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
   "dependencies": {
     "@electron-elements/send-feedback": "^2.0.3",
     "@sentry/electron": "^1.3.0",
+    "@types/node-schedule": "^1.3.0",
     "adm-zip": "^0.4.14",
     "auto-launch": "^5.0.5",
     "backoff": "^2.5.0",
@@ -160,6 +161,7 @@
     "fs-extra": "^9.0.0",
     "i18n": "^0.9.1",
     "node-json-db": "^1.1.0",
+    "node-schedule": "^1.3.2",
     "request": "^2.88.2",
     "rxjs": "^5.5.12",
     "semver": "^7.3.2"


### PR DESCRIPTION
**What's this PR do?**
Fixes: #561
User can now select time for which DND will be enabled.
Toast notification (4 sec) will be shown for clock time when DND would go off and also when it actually goes off.

**Screenshots?**
![Screenshot 2020-03-11 at 12 59 19 AM](https://user-images.githubusercontent.com/31139861/76351500-90150500-6333-11ea-94d1-88597429472b.png)
![Screenshot 2020-03-11 at 12 58 29 AM](https://user-images.githubusercontent.com/31139861/76351507-91dec880-6333-11ea-9169-336ac39d8e30.png)

**You have tested this PR on:**
[✓ ] macOS Catalina 10.15.4
