### PR TITLE
[WIP] Fix #650 Broken back button 

### DIFF
--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -25,6 +25,7 @@ export default class WebView extends BaseComponent {
 	$webviewsContainer: DOMTokenList;
 	$el: Electron.WebviewTag;
 	domReady?: Promise<void>;
+	prevTabIndex: number;
 
 	// This is required because in main.js we access WebView.method as
 	// webview[method].
@@ -260,16 +261,18 @@ export default class WebView extends BaseComponent {
 		this.$el.loadURL(url);
 	}
 
-	back(): void {
+	back(): boolean {
 		if (this.$el.canGoBack()) {
 			this.$el.goBack();
 			this.focus();
+			return true;
 		}
+		return false;
 	}
 
 	canGoBackButton(): void {
 		const $backButton = document.querySelector('#actions-container #back-action');
-		if (this.$el.canGoBack()) {
+		if (this.$el.canGoBack() || this.prevTabIndex >= 0) {
 			$backButton.classList.remove('disable');
 		} else {
 			$backButton.classList.add('disable');


### PR DESCRIPTION
**What's this PR do?**
Solve the issue of the broken back button #650 . When someone goes to a setting option, then want to return back to the previous tab of the organization, then the user can do using the back button.

**Any background context you want to provide?**
This is being solved by adding a new variable that will keep track of the last tab(organization window) before going to the setting and when the user click on the back button then he will move to tab whose value is being stored in the variable.

**GIF**


![Working](https://user-images.githubusercontent.com/25535045/76454015-e2205e00-63f9-11ea-9c56-3fe07f453919.gif)


**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
