### PR TITLE
Add feature to set application language.

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -724,3 +724,13 @@ i.open-network-button {
         margin-top: 10px;
     }
 }
+
+.lang-menu {
+    font-size: 13px;
+    font-weight: bold;
+    background: rgba(78, 191, 172, 1.000);
+    width: 100px;
+    height: 38px;
+    color: rgba(255, 255, 255, 1.000);
+    border-color: rgba(0, 0, 0, 0);
+}

--- a/app/renderer/js/pages/preference/base-section.ts
+++ b/app/renderer/js/pages/preference/base-section.ts
@@ -40,6 +40,18 @@ export default class BaseSection extends BaseComponent {
 		}
 	}
 
+	/* a method that in future can be used to create dropdown menus using <select> <option> tags.
+		it needs an object which has ``key: value`` pairs and will return a string that can be appended to HTML
+	*/
+	generateSelectTemplate(options: {[key: string]: string}, className?: string, idName?: string): string {
+		let select = `<select class='${className}' id='${idName}'>\n`;
+		Object.keys(options).forEach(key => {
+			select += `<option value="${key}">${options[key]}</option>\n`;
+		});
+		select += '</select>';
+		return select;
+	}
+
 	reloadApp(): void {
 		ipcRenderer.send('forward-message', 'reload-viewer');
 	}

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -92,10 +92,17 @@ export default class GeneralSection extends BaseSection {
 				</div>
 				<div class="title">${t.__('Advanced')}</div>
 				<div class="settings-card">
+
 					<div class="setting-row" id="enable-error-reporting">
 						<div class="setting-description">${t.__('Enable error reporting (requires restart)')}</div>
 						<div class="setting-control"></div>
 					</div>
+					
+					<div class="setting-row" id="app-language">
+						<div class="setting-description">${t.__('App language (requires restart)')}</div>
+						<div  id="lang-div" class="lang-div"></div>
+					</div>
+
 					<div class="setting-row" id="add-custom-css">
 						<div class="setting-description">
 							${t.__('Add custom CSS')}
@@ -135,7 +142,7 @@ export default class GeneralSection extends BaseSection {
 						<button class="reset-data-button red w-150">${t.__('Reset App Data')}</button>
 					</div>
 				</div>
-            </div>
+			</div>
 		`;
 	}
 
@@ -159,6 +166,7 @@ export default class GeneralSection extends BaseSection {
 		this.updateQuitOnCloseOption();
 		this.updatePromptDownloadOption();
 		this.enableErrorReporting();
+		this.setLocale();
 
 		// Platform specific settings
 
@@ -393,6 +401,29 @@ export default class GeneralSection extends BaseSection {
 		const resetDataButton = document.querySelector('#resetdata-option .reset-data-button');
 		resetDataButton.addEventListener('click', () => {
 			this.clearAppDataDialog();
+		});
+	}
+
+	setLocale(): void {
+		const langDiv: HTMLSelectElement = document.querySelector('.lang-div');
+		// This path is for the JSON file that stores key: value pairs for supported locales
+		const path = __dirname.replace('renderer/js/pages/preference', 'translations/supported-locales.json');
+		const data = fs.readFileSync(path, {encoding: 'utf8'});
+		const langs = JSON.parse(data);
+		const langList = this.generateSelectTemplate(langs, 'lang-menu');
+		langDiv.innerHTML += langList;
+		// langMenu is the select-option dropdown menu formed after executing the previous command
+		const langMenu: HTMLSelectElement = document.querySelector('.lang-menu');
+
+		// The next three lines set the selected language visible on the dropdown button
+		let langIndex = ConfigUtil.getConfigItem('languageIndex');
+		langIndex = (langIndex === null) ? 4 : langIndex;
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+		(langMenu.options[langIndex] as HTMLOptionElement).setAttribute('selected', '');
+
+		langMenu.addEventListener('change', (event: Event) => {
+			ConfigUtil.setConfigItem('appLanguage', (event.target as HTMLSelectElement).value);
+			ConfigUtil.setConfigItem('languageIndex', (event.target as HTMLSelectElement).selectedIndex);
 		});
 	}
 

--- a/app/renderer/js/utils/translation-util.ts
+++ b/app/renderer/js/utils/translation-util.ts
@@ -1,20 +1,15 @@
 import path from 'path';
-import electron from 'electron';
 import i18n from 'i18n';
-
-let app: Electron.App = null;
-
-/* To make the util runnable in both main and renderer process */
-if (process.type === 'renderer') {
-	app = electron.remote.app;
-} else {
-	app = electron.app;
-}
+import * as ConfigUtil from './config-util';
 
 i18n.configure({
 	directory: path.join(__dirname, '../../../translations/')
 });
 
+/* fetches the current appLocale from settings.json */
+const appLocale = ConfigUtil.getConfigItem('appLanguage');
+
+/* if no locale present in the json, en is set default */
 export function __(phrase: string): string {
-	return i18n.__({ phrase, locale: app.getLocale() ? app.getLocale() : 'en' });
+	return i18n.__({ phrase, locale: appLocale ? appLocale : 'en' });
 }

--- a/app/translations/supported-locales.json
+++ b/app/translations/supported-locales.json
@@ -1,0 +1,23 @@
+{
+    "bg": "Bulgarian",
+    "cs": "Czech",
+    "de": "Deutsch",
+    "en-GB": "English (UK)",
+    "en-US": "English (US)",
+    "en": "English",
+    "es": "Español",
+    "fr": "French",
+    "hi": "Hindi",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "ml": "Malayalam",
+    "nl": "Dutch",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "sr": "Macedonian",
+    "ta": "Tamil",
+    "tr": "Turkish"
+}


### PR DESCRIPTION
**What's this PR do?**
Fixes: #855 
Adds feature that lets user to change Zulip desktop client language without requiring to change the system language as was the case earlier

**Any background context you want to provide?**
Earlier, Zulip client used to fetch system locale thus setting default language to the client. Now we enable user to set custom language to the client.

**Screenshots?**
![Screenshot 2020-03-21 at 12 04 20 PM](https://user-images.githubusercontent.com/31139861/77222545-45d52480-6b7a-11ea-81a4-48c39db02d80.png)

**You have tested this PR on:**
[✓ ] macOS Catalina 10.15.2