### PR TITLE
tray: Work around Electron segfault on certain platforms

### DIFF
--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -116,7 +116,6 @@ function sendAction(action: string): void {
 }
 
 const createTray = function (): void {
-	window.tray = new Tray(iconPath());
 	const contextMenu = Menu.buildFromTemplate([
 		{
 			label: 'Zulip',
@@ -141,6 +140,7 @@ const createTray = function (): void {
 			}
 		}
 	]);
+	window.tray = new Tray(iconPath());
 	window.tray.setContextMenu(contextMenu);
 	if (process.platform === 'linux' || process.platform === 'win32') {
 		window.tray.on('click', () => {


### PR DESCRIPTION
Set the tray icon’s context menu immediately after creating the `Tray` object.  This seems to prevent an Electron segfault at startup on certain platforms, such as Ubuntu 16.04 i386.  See electron/electron#22652 and its linked issues.