### PR TITLE
downloadFiles: Fix issue of showing two Save As dialog box.

### DIFF
--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -34,19 +34,22 @@ export default function handleExternalLink(this: WebView, event: Electron.NewWin
 			}
 		});
 
-		ipcRenderer.once('downloadFileFailed', () => {
+		ipcRenderer.once('downloadFileFailed', (_event: Event, state: string) => {
 			// Automatic download failed, so show save dialog prompt and download
 			// through webview
 			// Only do this if it is the automatic download, otherwise show an error (so we aren't showing two save
 			// prompts right after each other)
-			if (ConfigUtil.getConfigItem('promptDownload', false)) {
-				// We need to create a "new Notification" to display it, but just `Notification(...)` on its own
-				// doesn't work
-				new Notification('Download Complete', { // eslint-disable-line no-new
-					body: 'Download failed'
-				});
-			} else {
-				this.$el.downloadURL(url.href);
+			// Check that the download is not cancelled by user
+			if (state !== 'cancelled') {
+				if (ConfigUtil.getConfigItem('promptDownload', false)) {
+					// We need to create a "new Notification" to display it, but just `Notification(...)` on its own
+					// doesn't work
+					new Notification('Download Complete', { // eslint-disable-line no-new
+						body: 'Download failed'
+					});
+				} else {
+					this.$el.downloadURL(url.href);
+				}
 			}
 
 			ipcRenderer.removeAllListeners('downloadFileCompleted');


### PR DESCRIPTION
Currently, there are two dialog boxes shown while downloading files (in Ubuntu). One by default behavior of electron and other by the dialog box for save as feature.
This PR fixes this issue by using electron's save as dialog box.
