### PR TITLE
dock: Do not toggle window on clicking dock.

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -147,10 +147,11 @@ app.on('certificate-error', (event: Event, _webContents: Electron.WebContents, _
 	callback(true);
 });
 
+// this event is only available on macOS. Triggers when you click on the dock icon.
 app.on('activate', () => {
 	if (mainWindow) {
-		// if there is already a window toggle the app
-		toggleApp();
+		// if there is already a window show it
+		mainWindow.show();
 	} else {
 		mainWindow = createMainWindow();
 	}


### PR DESCRIPTION
We are reverting back our decision after getting a lot of feedback
on this behaviour. From now on, when you click on the dock icon we'll
show the app window and won't hide it after clicking again on dock.

Fixes: #914.

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
<img src="https://cl.ly/8bd033e45ae3/download/Screen%20Recording%202020-04-03%20at%2012.46%20PM.gif">

**Any background context you want to provide?**

**Screenshots?**

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
