### PR TITLE
Generate User-Agent when app starts, thus avoiding storing it on disk

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -158,6 +158,9 @@ app.on('activate', () => {
 });
 
 app.on('ready', () => {
+	const ses = session.fromPartition('persist:webviewsession');
+	ses.setUserAgent(`ZulipElectron/${app.getVersion()} ${ses.getUserAgent()}`);
+
 	AppMenu.setMenu({
 		tabs: []
 	});
@@ -190,10 +193,10 @@ app.on('ready', () => {
 		} else {
 			mainWindow.show();
 		}
-		if (!ConfigUtil.isConfigItemExists('userAgent')) {
-			const userAgent = session.fromPartition('webview:persistsession').getUserAgent();
-			ConfigUtil.setConfigItem('userAgent', userAgent);
-		}
+	});
+
+	ipcMain.on('fetch-user-agent', event => {
+		event.returnValue = session.fromPartition('persist:webviewsession').getUserAgent();
 	});
 
 	page.once('did-frame-finish-load', () => {

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -149,12 +149,6 @@ export default class WebView extends BaseComponent {
 			if (!isSettingPage) {
 				this.props.switchLoading(true, this.props.url);
 			}
-			let userAgent = SystemUtil.getUserAgent();
-			if (!userAgent) {
-				SystemUtil.setUserAgent(this.$el.getUserAgent());
-				userAgent = SystemUtil.getUserAgent();
-			}
-			this.$el.setUserAgent(userAgent);
 		});
 
 		this.$el.addEventListener('did-stop-loading', () => {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -140,6 +140,7 @@ class ServerManagerView {
 		await this.loadProxy();
 		this.initDefaultSettings();
 		this.initSidebar();
+		this.removeUAfromDisk();
 		if (EnterpriseUtil.configFile) {
 			this.initPresetOrgs();
 		}
@@ -237,6 +238,12 @@ class ServerManagerView {
 	initSidebar(): void {
 		const showSidebar = ConfigUtil.getConfigItem('showSidebar', true);
 		this.toggleSidebar(showSidebar);
+	}
+
+	// Remove the stale UA string from the disk if the app is not freshly
+	// installed.  This should be removed in a further release.
+	removeUAfromDisk(): void {
+		ConfigUtil.removeConfigItem('userAgent');
 	}
 
 	async queueDomain(domain: any): Promise<boolean> {

--- a/app/renderer/js/utils/system-util.ts
+++ b/app/renderer/js/utils/system-util.ts
@@ -1,9 +1,6 @@
-import { remote } from 'electron';
+import { ipcRenderer } from 'electron';
 
 import os from 'os';
-import * as ConfigUtil from './config-util';
-
-const { app } = remote;
 
 export const connectivityERR: string[] = [
 	'ERR_INTERNET_DISCONNECTED',
@@ -14,7 +11,7 @@ export const connectivityERR: string[] = [
 	'ERR_NETWORK_CHANGED'
 ];
 
-let userAgent: string | null = null;
+const userAgent = ipcRenderer.sendSync('fetch-user-agent');
 
 export function getOS(): string {
 	const platform = os.platform();
@@ -32,14 +29,6 @@ export function getOS(): string {
 		return '';
 	}
 }
-
-export function setUserAgent(webViewUserAgent: string): void {
-	userAgent = `ZulipElectron/${app.getVersion()} ${webViewUserAgent}`;
-}
-
-export function getUserAgent(): string | null {
-	if (!userAgent) {
-		setUserAgent(ConfigUtil.getConfigItem('userAgent', null));
-	}
+export function getUserAgent(): string {
 	return userAgent;
 }


### PR DESCRIPTION
Fixes: #921 

**What's this PR do?**
Fetch and send UA from main process and use ipc call to catch it in renderer process: system-util.ts and use it elsewhere in the app as required, avoiding storing it on disk.

**Any background context you want to provide?**
Please refer #921 

**You have tested this PR on:**
  - [ ] Linux/Ubuntu
  - [X] macOS Catalina 10.15.2
