### PR TITLE
help: Update Help Center URL.

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -861,7 +861,7 @@ class ServerManagerView {
 
 		ipcRenderer.on('open-help', async () => {
 			// Open help page of current active server
-			await LinkUtil.openBrowser(new URL('/help', this.getCurrentActiveServer()));
+			await LinkUtil.openBrowser(new URL('https://zulipchat.com/help/'));
 		});
 
 		ipcRenderer.on('reload-viewer', this.reloadView.bind(this, this.tabs[this.activeTabIndex].props.index));


### PR DESCRIPTION
Please refer: #948 
Earlier the menu option used to redirect to *.zulipchat.com/help which is already reachable from the webapp.
This will enable the desktop app to redirect only to zulipchat.com/help instead of the help page of the corresponding organization.

**You have tested this PR on:**
  - [X] macOS Catalina 10.15.2

Tested on 4 added organizations, About Zulip page, Add New Server page
Fixes: #948 