### PR TITLE
Remove the insecure ignoreCerts option

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -225,7 +225,6 @@ app.on('ready', () => {
 	) /* eslint-disable-line max-params */ => {
 		// TODO: The entire concept of selectively ignoring certificate errors
 		// is ill-conceived, and this handler needs to be deleted.
-		event.preventDefault();
 
 		const {origin} = new URL(url);
 		const filename = CertificateUtil.getCertificate(encodeURIComponent(origin));
@@ -237,6 +236,7 @@ app.on('ready', () => {
 				);
 				if (certificate.data.replace(/[\r\n]/g, '') ===
 					savedCertificate.replace(/[\r\n]/g, '')) {
+					event.preventDefault();
 					callback(true);
 					return;
 				}
@@ -245,20 +245,11 @@ app.on('ready', () => {
 			}
 		}
 
-		page.send(
-			'certificate-error',
-			webContents.id === mainWindow.webContents.id ? null : webContents.id,
-			makeRendererCallback(ignore => {
-				callback(ignore);
-				if (!ignore) {
-					dialog.showErrorBox(
-						'Certificate error',
-						`The server presented an invalid certificate for ${origin}:
+		dialog.showErrorBox(
+			'Certificate error',
+			`The server presented an invalid certificate for ${origin}:
 
 ${error}`
-					);
-				}
-			})
 		);
 	});
 

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -24,7 +24,6 @@ interface WebViewProps {
 	nodeIntegration: boolean;
 	preload: boolean;
 	onTitleChange: () => void;
-	ignoreCerts?: boolean;
 	hasPermission?: (origin: string, permission: string) => boolean;
 }
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -360,7 +360,6 @@ class ServerManagerView {
 				url: server.url,
 				role: 'server',
 				name: CommonUtil.decodeString(server.alias),
-				ignoreCerts: server.ignoreCerts,
 				hasPermission: (origin: string, permission: string) =>
 					origin === server.url && permission === 'notifications',
 				isActive: () => {
@@ -815,21 +814,6 @@ class ServerManagerView {
 				}
 			});
 		}
-
-		ipcRenderer.on('certificate-error', (
-			event: Event,
-			webContentsId: number | null,
-			rendererCallbackId: number
-		) => {
-			const ignore = webContentsId !== null &&
-				this.tabs.some(
-					({webview}) =>
-						!webview.loading &&
-						webview.$el.getWebContentsId() === webContentsId &&
-						webview.props.ignoreCerts
-				);
-			ipcRenderer.send('renderer-callback', rendererCallbackId, ignore);
-		});
 
 		ipcRenderer.on('permission-request', (
 			event: Event,

--- a/app/renderer/js/utils/reconnect-util.ts
+++ b/app/renderer/js/utils/reconnect-util.ts
@@ -5,7 +5,6 @@ import backoff from 'backoff';
 import request from 'request';
 import Logger from './logger-util';
 import * as RequestUtil from './request-util';
-import * as DomainUtil from './domain-util';
 
 const logger = new Logger({
 	file: 'domain-util.log',
@@ -35,15 +34,10 @@ export default class ReconnectUtil {
 	async isOnline(): Promise<boolean> {
 		return new Promise(resolve => {
 			try {
-				const ignoreCerts = DomainUtil.shouldIgnoreCerts(this.url);
-				if (ignoreCerts === null) {
-					return;
-				}
-
 				request(
 					{
 						url: `${this.url}/static/favicon.ico`,
-						...RequestUtil.requestOptions(this.url, ignoreCerts)
+						...RequestUtil.requestOptions(this.url)
 					},
 					(error: Error, response: request.Response) => {
 						const isValidResponse =

--- a/app/renderer/js/utils/request-util.ts
+++ b/app/renderer/js/utils/request-util.ts
@@ -20,12 +20,9 @@ interface RequestUtilResponse {
 	proxy: string | void | ProxyUtil.ProxyRule;
 	ecdhCurve: 'auto';
 	headers: { 'User-Agent': string };
-	rejectUnauthorized: boolean;
 }
 
-// ignoreCerts parameter helps in fetching server icon and
-// other server details when user chooses to ignore certificate warnings
-export function requestOptions(domain: string, ignoreCerts: boolean): RequestUtilResponse {
+export function requestOptions(domain: string): RequestUtilResponse {
 	domain = formatUrl(domain);
 	const certificate = CertificateUtil.getCertificate(
 		encodeURIComponent(domain)
@@ -56,8 +53,7 @@ export function requestOptions(domain: string, ignoreCerts: boolean): RequestUti
 		ca: certificateLocation ? certificateLocation : '',
 		proxy: proxyEnabled ? ProxyUtil.getProxy(domain) : '',
 		ecdhCurve: 'auto',
-		headers: {'User-Agent': SystemUtil.getUserAgent()},
-		rejectUnauthorized: !ignoreCerts
+		headers: {'User-Agent': SystemUtil.getUserAgent()}
 	};
 }
 

--- a/app/resources/messages.ts
+++ b/app/resources/messages.ts
@@ -19,14 +19,12 @@ export function noOrgsError(domain: string): string {
 }
 
 export function certErrorMessage(domain: string, error: string): string {
-	return `Do you trust certificate from ${domain}? \n ${error}`;
+	return `Certificate error for ${domain}\n${error}`;
 }
 
 export function certErrorDetail(): string {
 	return `The organization you're connecting to is either someone impersonating the Zulip server you entered, or the server you're trying to connect to is configured in an insecure way.
-	\nIf you have a valid certificate please add it from Settings>Organizations and try to add the organization again.
-	\nUnless you have a good reason to believe otherwise, you should not proceed.
-	\nYou can click here if you'd like to proceed with the connection.`;
+	\nIf you have a valid certificate please add it from Settings>Organizations and try to add the organization again.`;
 }
 
 export function enterpriseOrgError(length: number, domains: string[]): DialogBoxError {


### PR DESCRIPTION
We deprecated this option in the [5.2.0 blog post](https://blog.zulip.org/2020/05/06/zulip-desktop-5-2-0-security-release/). This option is insecure by definition, and its existence also led to a critical security vulnerability even for users who didn’t enable it. Removing it will also help with the transition from the deprecated `request` module to `electron.net` (#886), which will allow us manage network and certificate configuration in one place rather than two.

Users of Zulip servers with self-signed certificates should be able to install the certificate in the UI, although we continue to strongly encourage server administrators to obtain a valid certificate with Certbot.