### PR TITLE
translations: Prevent i18n to automatically add strings.

### DIFF
--- a/app/renderer/js/utils/translation-util.ts
+++ b/app/renderer/js/utils/translation-util.ts
@@ -3,7 +3,8 @@ import i18n from 'i18n';
 import * as ConfigUtil from './config-util';
 
 i18n.configure({
-	directory: path.join(__dirname, '../../../translations/')
+	directory: path.join(__dirname, '../../../translations/'),
+	updateFiles: false
 });
 
 /* Fetches the current appLocale from settings.json */


### PR DESCRIPTION
**What's this PR do?**

Now that we have moved to Transifex, auto updation of translation strings is not required.
We would not want any of these changes to be getting committed.
We only need to update the resource file (en.json) and push it to Transifex and pulling the rest <lang>.json
The PR prevents auto updation of the strings not present
**You have tested this PR on:**
  - [X] macOS Catalina 10.15.4
  - [ ] Linux/Ubuntu
  - [ ] Windows
