### PR TITLE
zoom: Fix zoom issues.

### DIFF
--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -120,7 +120,7 @@ function getViewSubmenu(): Electron.MenuItemConstructorOptions[] {
 		role: 'togglefullscreen'
 	}, {
 		label: t.__('Zoom In'),
-		role: 'zoomIn',
+		accelerator: 'CommandOrControl+=',
 		click(_item, focusedWindow) {
 			if (focusedWindow) {
 				sendAction('zoomIn');
@@ -128,7 +128,6 @@ function getViewSubmenu(): Electron.MenuItemConstructorOptions[] {
 		}
 	}, {
 		label: t.__('Zoom Out'),
-		role: 'zoomOut',
 		accelerator: 'CommandOrControl+-',
 		click(_item, focusedWindow) {
 			if (focusedWindow) {
@@ -137,7 +136,6 @@ function getViewSubmenu(): Electron.MenuItemConstructorOptions[] {
 		}
 	}, {
 		label: t.__('Actual Size'),
-		role: 'resetZoom',
 		accelerator: 'CommandOrControl+0',
 		click(_item, focusedWindow) {
 			if (focusedWindow) {


### PR DESCRIPTION
**Any background context you want to provide?**

The zoom issues seemed to be caused due to electron roles.
We also had our own definitions firing up along with the roles which might be clashing and the other instances of roles not being much effective in our use case.


**What's this PR do?**

* Remove roles from zoom options
* Add accelerator for zoomIn - Change both zoomIn, zoomOut accelerators as 'Ctrl/Cmd + Plus' seems not to work most of the time


**You have tested this PR on:**
  - [X] macOS Catalina 10.15.4
  - [ ] Linux/Ubuntu
  - [ ] Windows
