### PR TITLE
Improve context-menu.

### DIFF
--- a/app/renderer/js/components/context-menu.ts
+++ b/app/renderer/js/components/context-menu.ts
@@ -41,6 +41,7 @@ export const contextMenu = (webContents: Electron.WebContents, event: Event, pro
 	}, {
 		label: t.__('Copy'),
 		accelerator: 'CommandOrControl+C',
+		enabled: props.editFlags.canCopy,
 		click(_item) {
 			webContents.copy();
 		}

--- a/app/renderer/js/components/context-menu.ts
+++ b/app/renderer/js/components/context-menu.ts
@@ -5,6 +5,7 @@ const {clipboard, Menu} = remote;
 export const contextMenu = (webContents: Electron.WebContents, event: Event, props: ContextMenuParams) => {
 	const isText = Boolean(props.selectionText.length);
 	const isLink = Boolean(props.linkURL);
+	const isEmailAddress = Boolean(props.linkURL.startsWith('mailto:'));
 
 	const makeSuggestion = (suggestion: string) => ({
 		label: suggestion,
@@ -55,12 +56,12 @@ export const contextMenu = (webContents: Electron.WebContents, event: Event, pro
 	}, {
 		type: 'separator'
 	}, {
-		label: t.__('Copy Link'),
-		visible: isText && isLink,
+		label: isEmailAddress ? t.__('Copy Email Address') : t.__('Copy Link'),
+		visible: isLink,
 		click(_item) {
 			clipboard.write({
 				bookmark: props.linkText,
-				text: props.linkURL
+				text: isEmailAddress ? props.linkText : props.linkURL
 			});
 		}
 	}, {


### PR DESCRIPTION
Fix bug in Copy Link and add copy Email.
Fixes: #986 

Enable copy only when copy is possible.


**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
