### PR TITLE
settings: Update font size for spellchecker explanation.

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -389,6 +389,10 @@ img.server-info-icon {
     margin: 6px;
 }
 
+#note {
+    font-size: 10px;
+}
+
 .code {
     font-family: Courier New, Courier, monospace;
 }


### PR DESCRIPTION
**What's this PR do?**
It decreases the size of explanation text for the title spellchecker because the title and explanation practically had the same font-size.

**Any background context you want to provide?**
Fixes #978. 
Follow up for PR #987 

**Screenshots?**
![85768572-cafe4580-b736-11ea-9d98-537eadea3c13](https://user-images.githubusercontent.com/13183316/85921939-6b6e7a00-b89d-11ea-9288-2bb478947ef3.png)


**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS
