### PR TITLE
add support for basic authentication

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -468,3 +468,9 @@ process.on('uncaughtException', err => {
 	console.error(err);
 	console.error(err.stack);
 });
+
+// For some reason, we can't prevent the default behaviour of this event (cancelling the authentication)
+// in app/renderer/js/main.ts, so we do it here. The actual logic is implented there.
+app.on('login', event => {
+	event.preventDefault();
+});

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -23,8 +23,6 @@ const globalPatched = global as PatchedGlobal;
 let mainWindow: Electron.BrowserWindow;
 let badgeCount: number;
 
-const appLoginEvents = new Map<number, (username?: string, password?: string) => void>();
-
 let isQuitting = false;
 
 // Load this url in main window
@@ -462,23 +460,7 @@ ${error}`
 
 	app.on('login', (event, webContents, details, authInfo, callback) => {
 		event.preventDefault();
-
-		// If there still is a callback stored for the host
-		const oldCallback = appLoginEvents.get(webContents.id);
-		if (oldCallback !== undefined) {
-			oldCallback();
-		}
-
-		appLoginEvents.set(webContents.id, callback);
-		page.send('app-on-login', webContents.id, details.url);
-	});
-
-	ipcMain.on('app-on-login-response', (event, webContentsId, {username, password}) => {
-		const callback = appLoginEvents.get(webContentsId);
-		if (callback !== undefined) {
-			callback(username, password);
-			appLoginEvents.delete(webContentsId);
-		}
+		page.send('app-on-login', webContents.id, details.url, makeRendererCallback(callback));
 	});
 });
 

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -564,3 +564,8 @@ send-feedback {
 .btn-row .btn {
     margin: 0 10px;
 }
+
+.muted {
+    color: rgb(100, 100, 100);
+    font-size: .75em;
+}

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -488,3 +488,79 @@ send-feedback {
 #feedback-modal.show {
     display: flex;
 }
+
+.dialog {
+    position: absolute;
+    background-color: rgb(255, 255, 255);
+    font-family: sans-serif;
+    padding: 20px;
+    top: 10%;
+    left: 50%;
+    z-index: 100;
+    width: 400px;
+    border: 1px solid rgba(0, 0, 0, .2);
+    border-radius: 5px;
+    margin-left: -200px;
+    box-sizing: border-box;
+    box-shadow: 0 5px 20px 0 rgba(0, 0, 0, .3);
+}
+
+.text-input {
+    width: 100%;
+    font-size: 14px;
+    border-radius: 4px;
+    padding: 13px;
+    border: rgba(237, 237, 237, 1.000) 2px solid;
+    outline-width: 0;
+    background: transparent;
+    max-width: 450px;
+    box-sizing: border-box;
+}
+
+.text-input:focus {
+    border: rgba(78, 191, 172, 1.000) 2px solid;
+}
+
+.text-input.invalid:focus {
+    border: rgba(239, 83, 80, 1) 2px solid;
+}
+
+.btn {
+    font-weight: bold;
+    font-size: 1.1rem;
+    margin: auto;
+    align-items: center;
+    text-align: center;
+    color: rgba(255, 255, 255, 1.000);
+    background: rgba(78, 191, 172, 1.000);
+    border-color: none;
+    border: none;
+    width: 100%;
+    height: 46px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn:hover {
+    background: rgba(50, 149, 136, 1.000);
+}
+
+.btn:focus {
+    background: rgba(50, 149, 136, 1.000);
+}
+
+.btn:disabled {
+    background: none;
+    color: rgba(0, 0, 0, .3);
+    border: 1px solid rgba(0, 0, 0, .3);
+    cursor: not-allowed;
+}
+
+.btn-row {
+    display: flex;
+    flex-direction: row;
+    margin: 0 -10px;
+}
+.btn-row .btn {
+    margin: 0 10px;
+}

--- a/app/renderer/js/components/dialog.ts
+++ b/app/renderer/js/components/dialog.ts
@@ -1,21 +1,22 @@
 import * as t from '../utils/translation-util';
-import BaseComponent from './base';
 
 export interface AuthenticationDialogResult {
 	username: string;
 	password: string;
 }
 
-export default class Dialog extends BaseComponent {
+export default class Dialog {
+	private readonly $root: HTMLElement;
 	private $el: HTMLElement;
 
-	init() {
-		this.$el = document.querySelector('#dialog');
+	constructor() {
+		this.$root = document.querySelector('body');
 	}
 
-	async showAuthenticationDialog(): Promise<AuthenticationDialogResult> {
+	async showAuthenticationDialog(url: string, hidden = false): Promise<AuthenticationDialogResult> {
 		return new Promise((resolve, reject) => {
-			this.$el.innerHTML = this.authenticationDialogTemplate();
+			this.init();
+			this.$el.innerHTML = this.authenticationDialogTemplate(url);
 			const $form = this.$el.querySelector('form');
 			const $user: HTMLInputElement = this.$el.querySelector('#dialogAuthUser');
 			const $pass: HTMLInputElement = this.$el.querySelector('#dialogAuthPass');
@@ -31,29 +32,53 @@ export default class Dialog extends BaseComponent {
 			$form.addEventListener('submit', event => {
 				event.preventDefault();
 				resolve({username: $user.value, password: $pass.value});
-				this.hide();
+				this.dismiss();
 				$pass.value = '';
 			});
 			$cancel.addEventListener('click', () => {
 				reject();
-				this.hide();
+				this.dismiss();
 				$pass.value = '';
 			});
-			this.show();
+			if (!hidden) {
+				this.show();
+			}
 		});
 	}
 
-	private show() {
-		this.$el.style.display = 'block';
+	show() {
+		if (this.$el !== undefined) {
+			this.$el.style.display = 'block';
+		}
 	}
 
-	private hide() {
-		this.$el.style.display = 'none';
+	hide() {
+		if (this.$el !== undefined) {
+			this.$el.style.display = 'none';
+		}
 	}
 
-	private authenticationDialogTemplate(): string {
+	dismiss() {
+		if (this.$el !== undefined) {
+			this.$el.remove();
+			this.$el = undefined;
+		}
+	}
+
+	private init() {
+		if (this.$el === undefined) {
+			this.$el = document.createElement('div');
+			this.$el.classList.add('dialog');
+			this.$el.style.display = 'none';
+			this.$root.append(this.$el);
+		}
+	}
+
+	private authenticationDialogTemplate(url = ''): string {
+		url = url ? `<p class="muted">${url}</p>` : '';
 		return `
 			<h3>${t.__('Authentication required')}</h3>
+			${url}
 			<form>
 				<p>
 					<input id="dialogAuthUser" class="text-input" type="text" placeholder="${t.__('Username')}" />

--- a/app/renderer/js/components/dialog.ts
+++ b/app/renderer/js/components/dialog.ts
@@ -1,0 +1,71 @@
+import * as t from '../utils/translation-util';
+import BaseComponent from './base';
+
+export interface AuthenticationDialogResult {
+	username: string;
+	password: string;
+}
+
+export default class Dialog extends BaseComponent {
+	private $el: HTMLElement;
+
+	init() {
+		this.$el = document.querySelector('#dialog');
+	}
+
+	async showAuthenticationDialog(): Promise<AuthenticationDialogResult> {
+		return new Promise((resolve, reject) => {
+			this.$el.innerHTML = this.authenticationDialogTemplate();
+			const $form = this.$el.querySelector('form');
+			const $user: HTMLInputElement = this.$el.querySelector('#dialogAuthUser');
+			const $pass: HTMLInputElement = this.$el.querySelector('#dialogAuthPass');
+			const $submit: HTMLButtonElement = this.$el.querySelector('#dialogAuthSubmit');
+			const $cancel = this.$el.querySelector('#dialogAuthCancel');
+
+			[$user, $pass].forEach(input => {
+				input.addEventListener('input', () => {
+					$submit.disabled = $user.value === '' || $pass.value === '';
+				});
+			});
+
+			$form.addEventListener('submit', event => {
+				event.preventDefault();
+				resolve({username: $user.value, password: $pass.value});
+				this.hide();
+				$pass.value = '';
+			});
+			$cancel.addEventListener('click', () => {
+				reject();
+				this.hide();
+				$pass.value = '';
+			});
+			this.show();
+		});
+	}
+
+	private show() {
+		this.$el.style.display = 'block';
+	}
+
+	private hide() {
+		this.$el.style.display = 'none';
+	}
+
+	private authenticationDialogTemplate(): string {
+		return `
+			<h3>${t.__('Authentication required')}</h3>
+			<form>
+				<p>
+					<input id="dialogAuthUser" class="text-input" type="text" placeholder="${t.__('Username')}" />
+				</p>
+				<p>
+					<input id="dialogAuthPass" class="text-input" type="password" placeholder="${t.__('Password')}" />
+				</p>
+				<p class="btn-row" style="margin-bottom: 0;">
+					<button id="dialogAuthCancel" class="btn">Cancel</button>
+					<button id="dialogAuthSubmit" class="btn" disabled>Login</button>
+				</p>
+			</form>
+		`;
+	}
+}

--- a/app/renderer/js/components/tab.ts
+++ b/app/renderer/js/components/tab.ts
@@ -1,5 +1,6 @@
 import WebView from './webview';
 import BaseComponent from './base';
+import Dialog from './dialog';
 
 export interface TabProps {
 	role: string;
@@ -19,12 +20,15 @@ export interface TabProps {
 export default class Tab extends BaseComponent {
 	props: TabProps;
 	webview: WebView;
+	dialog: Dialog;
 	$el: Element;
+
 	constructor(props: TabProps) {
 		super();
 
 		this.props = props;
 		this.webview = this.props.webview;
+		this.dialog = new Dialog();
 	}
 
 	registerListeners(): void {
@@ -39,11 +43,13 @@ export default class Tab extends BaseComponent {
 
 	activate(): void {
 		this.$el.classList.add('active');
+		this.dialog.show();
 		this.webview.load();
 	}
 
 	deactivate(): void {
 		this.$el.classList.remove('active');
+		this.dialog.hide();
 		this.webview.hide();
 	}
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -22,6 +22,7 @@ import * as EnterpriseUtil from './utils/enterprise-util';
 import * as LinkUtil from './utils/link-util';
 import * as Messages from '../../resources/messages';
 import type {DNDSettings} from './utils/dnd-util';
+import Dialog from './components/dialog';
 
 interface FunctionalTabProps {
 	name: string;
@@ -130,6 +131,7 @@ class ServerManagerView {
 		await this.loadProxy();
 		this.initDefaultSettings();
 		this.initSidebar();
+		this.initLoginEventHandler();
 		this.removeUAfromDisk();
 		if (EnterpriseUtil.hasConfigFile()) {
 			await this.initPresetOrgs();
@@ -1038,6 +1040,24 @@ class ServerManagerView {
 
 		ipcRenderer.on('open-network-settings', async () => {
 			await this.openSettings('Network');
+		});
+	}
+
+	initLoginEventHandler() {
+		// This event gets fired whenever a webview triggers a basic authentication.
+		// We show an authentication dialog and return the username and password.
+		app.on('login', async (event, webContents, details, authInfo, callback) => {
+			// This doesn't seem to work, so it's done in app/main/index.ts as well.
+			event.preventDefault();
+			const dialog = new Dialog();
+			dialog.init();
+			try {
+				const {username, password} = await dialog.showAuthenticationDialog();
+				callback(username, password);
+			} catch {
+				// Cancel authentication
+				callback();
+			}
 		});
 	}
 }

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -22,7 +22,6 @@ import * as EnterpriseUtil from './utils/enterprise-util';
 import * as LinkUtil from './utils/link-util';
 import * as Messages from '../../resources/messages';
 import type {DNDSettings} from './utils/dnd-util';
-import Dialog from './components/dialog';
 
 interface FunctionalTabProps {
 	name: string;
@@ -131,7 +130,6 @@ class ServerManagerView {
 		await this.loadProxy();
 		this.initDefaultSettings();
 		this.initSidebar();
-		this.initLoginEventHandler();
 		this.removeUAfromDisk();
 		if (EnterpriseUtil.hasConfigFile()) {
 			await this.initPresetOrgs();
@@ -1041,22 +1039,20 @@ class ServerManagerView {
 		ipcRenderer.on('open-network-settings', async () => {
 			await this.openSettings('Network');
 		});
-	}
 
-	initLoginEventHandler() {
-		// This event gets fired whenever a webview triggers a basic authentication.
-		// We show an authentication dialog and return the username and password.
-		app.on('login', async (event, webContents, details, authInfo, callback) => {
-			// This doesn't seem to work, so it's done in app/main/index.ts as well.
-			event.preventDefault();
-			const dialog = new Dialog();
-			dialog.init();
-			try {
-				const {username, password} = await dialog.showAuthenticationDialog();
-				callback(username, password);
-			} catch {
-				// Cancel authentication
-				callback();
+		ipcRenderer.on('app-on-login', async (event, webContentsId: number, url: string) => {
+			const tab = this.tabs.find(tab => tab.webview.$el?.getWebContentsId() === webContentsId);
+			if (tab !== undefined) {
+				try {
+					const {username, password} = await tab.dialog.showAuthenticationDialog(
+						new URL(url).origin,
+						this.tabs.indexOf(tab) !== this.activeTabIndex
+					);
+					ipcRenderer.send('app-on-login-response', webContentsId, {username, password});
+				} catch {
+					// Cancel authentication
+					ipcRenderer.send('app-on-login-response', webContentsId, {});
+				}
 			}
 		});
 	}

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -13,7 +13,6 @@
             <div class="popup">
                 <span class="popuptext hidden" id="fullscreen-popup"></span>
             </div>
-            <div id="dialog" class="dialog" style="display: none;"></div>
             <div id="sidebar" class="toggle-sidebar">
                 <div id="view-controls-container">
                     <div id="tabs-container"></div>

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -13,6 +13,7 @@
             <div class="popup">
                 <span class="popuptext hidden" id="fullscreen-popup"></span>
             </div>
+            <div id="dialog" class="dialog" style="display: none;"></div>
             <div id="sidebar" class="toggle-sidebar">
                 <div id="view-controls-container">
                     <div id="tabs-container"></div>

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -115,5 +115,8 @@
 	"keyboard shortcuts": "keyboard shortcuts",
 	"script": "script",
 	"Quit when the window is closed": "Quit when the window is closed",
-	"Ask where to save files before downloading": "Ask where to save files before downloading"
+	"Ask where to save files before downloading": "Ask where to save files before downloading",
+	"Authentication required": "Authentication required",
+	"Username": "Username",
+	"Password": "Password"
 }


### PR DESCRIPTION
**What's this PR do?**

This PR adds support for HTTP Basic Authentication.
Electron fires a `login` event whenever Basic Authentication is triggered within a webview. This event now gets handled by showing a authentication dialog.

**Any background context you want to provide?**

We have a special 2 Factor Authentication proxy in place, that uses Basic Authentication. If we want to use Zulip Desktop, we need it to support Basic Authentication as well.

**Screenshots?**

![image](https://user-images.githubusercontent.com/1710904/86244826-d2937380-bba8-11ea-8f6f-c8551efc4bf5.png)

**You have tested this PR on:**
  - [ ] Windows
  - [ ] Linux/Ubuntu
  - [x] macOS

I've noticed the CSS of the app is pretty messy. It would be a good refactoring task to streamline it, especially regarding form input styling.