### PR TITLE
[WIP] darwin-notifications: Migrate from node-mac-notifier to node-notifier

### DIFF
--- a/app/renderer/js/notification/darwin-notifications.ts
+++ b/app/renderer/js/notification/darwin-notifications.ts
@@ -1,40 +1,47 @@
 import {ipcRenderer} from 'electron';
 
-import MacNotifier from 'node-mac-notifier';
+import notifier from 'node-notifier';
+import NotificationCenter from 'node-notifier/notifiers/notificationcenter';
 
 import electron_bridge from '../electron-bridge';
 import * as ConfigUtil from '../utils/config-util';
 
-import {
-	appId, customReply, focusCurrentServer, parseReply
-} from './helpers';
+import {customReply, focusCurrentServer, parseReply} from './helpers';
 
 type ReplyHandler = (response: string) => void;
 type ClickHandler = () => void;
 let replyHandler: ReplyHandler;
 let clickHandler: ClickHandler;
 
-interface NotificationHandlerArgs {
-	response: string;
-}
-
 class DarwinNotification {
 	tag: number;
 
 	constructor(title: string, options: NotificationOptions) {
-		const silent: boolean = ConfigUtil.getConfigItem('silent') || false;
-		const {icon} = options;
-		const profilePic = new URL(icon, location.href).href;
-
+		// Const silent: boolean = ConfigUtil.getConfigItem('silent') || false;
+		const profilePic = new URL(options.icon, location.href).href;
 		this.tag = Number.parseInt(options.tag, 10);
-		const notification = new MacNotifier(title, Object.assign(options, {
-			bundleId: appId,
-			canReply: true,
-			silent,
-			icon: profilePic
-		}));
 
-		notification.addEventListener('click', () => {
+		const notification: NotificationCenter.Notification = {
+			title,
+			message: options.body,
+			icon: '../../../resources/Icon.icns',
+			contentImage: profilePic,
+			wait: true,
+			timeout: 1000, // If not large, response is timed out and reply is not sent
+			closeLabel: 'Close',
+			dropdownLabel: undefined,
+			reply: true
+		};
+
+		notifier.notify(notification, async (_error, _response, metadata) => {
+			console.log(_response);
+			console.log(metadata);
+			if (metadata.activationType === 'replied') {
+				await this.notificationHandler(metadata.activationValue);
+			}
+		});
+
+		notifier.on('click', () => {
 			// Focus to the server who sent the
 			// notification if not focused already
 			if (clickHandler) {
@@ -44,8 +51,6 @@ class DarwinNotification {
 			focusCurrentServer();
 			ipcRenderer.send('focus-app');
 		});
-
-		notification.addEventListener('reply', this.notificationHandler);
 	}
 
 	static requestPermission(): void {
@@ -86,7 +91,7 @@ class DarwinNotification {
 		}
 	}
 
-	async notificationHandler({response}: NotificationHandlerArgs): Promise<void> {
+	async notificationHandler(response: string): Promise<void> {
 		response = await parseReply(response);
 		focusCurrentServer();
 		if (electron_bridge.send_notification_reply_message_supported) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -689,6 +689,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.25.tgz",
       "integrity": "sha512-okMqUHqrMlGOxfDZliX1yFX5MV6qcd5PpRz96XYtjkM0Ws/hwg23FMUqt6pETrVRZS+EKUB5HY19mmo54EuQbA=="
     },
+    "@types/node-notifier": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-6.0.1.tgz",
+      "integrity": "sha512-PBkKwgjxu2aA24zh5Rng8FlL03R4zopZbTtzeKbWLfF+AMeHBMk3Ls12K/yZchYhe/riuiarPXcRJGUBLGb15w==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1772,7 +1780,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -4519,7 +4527,7 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -5531,6 +5539,11 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
     "gulp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
@@ -6334,8 +6347,7 @@
     "is-docker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
-      "dev": true
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -6624,7 +6636,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6650,8 +6661,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "iso-639-1": {
       "version": "2.1.3",
@@ -7634,7 +7644,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -7846,15 +7856,32 @@
         }
       }
     },
-    "node-mac-notifier": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-mac-notifier/-/node-mac-notifier-1.2.0.tgz",
-      "integrity": "sha512-+9FZ01BbPMv3pQVRWgPlaIKbhQl35Pn3WmRg96zIrCJHb4XvClnAqc0+aPfHrWs8o1PYMAQFeYK5tF69ljkKQw==",
-      "optional": true,
+    "node-notifier": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+      "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
       "requires": {
-        "bindings": "^1.2.1",
-        "event-target-shim": "^1.1.1",
-        "uuid": "^3.3.2"
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.0",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "node-preload": {
@@ -9924,6 +9951,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "side-channel": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   "dependencies": {
     "@electron-elements/send-feedback": "^2.0.3",
     "@sentry/electron": "^1.5.0",
+    "@types/node-notifier": "^6.0.1",
     "@yaireo/tagify": "^3.15.4",
     "adm-zip": "^0.4.16",
     "auto-launch": "^5.0.5",
@@ -162,10 +163,8 @@
     "iso-639-1": "^2.1.3",
     "nan": "^2.14.0",
     "node-json-db": "^1.1.0",
+    "node-notifier": "^8.0.0",
     "semver": "^7.3.2"
-  },
-  "optionalDependencies": {
-    "node-mac-notifier": "^1.1.0"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.33",


### PR DESCRIPTION
**What's this PR do?**
node-mac-notifier was less maintained as compared to node-notifier and some bugs were being noticed where notifications were not seen.
This is a potential solution to that bug.

**You have tested this PR on:**
  - [X] macOS Catalina 10.15.6
