### PR TITLE
darwin-notifications: Migrate darwin-notifications to electron's native Notifications.

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -274,8 +274,8 @@ ${error}`
 		toggleApp();
 	});
 
-	ipcMain.on('create-notification', (event, notificationOptions: Electron.NotificationConstructorOptions) => {
-		showDarwinNotification(event, notificationOptions);
+	ipcMain.on('create-notification', async (event, notificationOptions: Electron.NotificationConstructorOptions, profilePicURL: string) => {
+		await showDarwinNotification(event, notificationOptions, profilePicURL);
 	});
 
 	ipcMain.on('toggle-badge-option', () => {

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -11,6 +11,7 @@ import * as ProxyUtil from '../renderer/js/utils/proxy-util';
 import {sentryInit} from '../renderer/js/utils/sentry-util';
 
 import {appUpdater} from './autoupdater';
+import {showDarwinNotification} from './ipc-helpers';
 import * as AppMenu from './menu';
 import {_getServerSettings, _saveServerIcon, _isOnline} from './request';
 import {setAutoLaunch} from './startup';
@@ -271,6 +272,10 @@ ${error}`
 
 	ipcMain.on('toggle-app', () => {
 		toggleApp();
+	});
+
+	ipcMain.on('create-notification', (event, notificationOptions: Electron.NotificationConstructorOptions) => {
+		showDarwinNotification(event, notificationOptions);
 	});
 
 	ipcMain.on('toggle-badge-option', () => {

--- a/app/main/ipc-helpers.ts
+++ b/app/main/ipc-helpers.ts
@@ -1,0 +1,16 @@
+/**
+ * This file contains the functions which make use of Main process APIs with already functioning code in Renderer process.
+ */
+import {Notification} from 'electron';
+
+export const showDarwinNotification = (
+	event: Electron.IpcMainEvent,
+	notificationOptions: Electron.NotificationConstructorOptions
+) => {
+	const notification = new Notification(notificationOptions);
+	notification.show();
+
+	notification.on('reply', (_event, response) => {
+		event.sender.send('replied', response);
+	});
+};

--- a/app/main/ipc-helpers.ts
+++ b/app/main/ipc-helpers.ts
@@ -1,16 +1,38 @@
 /**
  * This file contains the functions which make use of Main process APIs with already functioning code in Renderer process.
  */
-import {Notification} from 'electron';
+import {Notification, nativeImage} from 'electron';
 
-export const showDarwinNotification = (
+import fetch from 'node-fetch';
+
+export const showDarwinNotification = async (
 	event: Electron.IpcMainEvent,
-	notificationOptions: Electron.NotificationConstructorOptions
+	notificationOptions: Electron.NotificationConstructorOptions,
+	profilePicURL: string
 ) => {
+	const profilePic = await getNativeImagefromUrl(profilePicURL);
+	notificationOptions.icon = profilePic;
+
 	const notification = new Notification(notificationOptions);
 	notification.show();
-
 	notification.on('reply', (_event, response) => {
 		event.sender.send('replied', response);
 	});
+};
+
+/* TODO: Migrate url->dataUri conversion part to renderer process
+	to make use of browser caching of images.
+*/
+const getNativeImagefromUrl = async (imageURL: string) => {
+	try {
+		const response = await fetch(imageURL);
+		const buffer = await response.buffer();
+		const base64String = buffer.toString('base64');
+		const dataUri = `data:image/png;base64,${base64String}`;
+		const image = nativeImage.createFromDataURL(dataUri);
+		return image;
+	} catch (error) {
+		console.error(error);
+		return null;
+	}
 };

--- a/app/renderer/js/notification/darwin-notifications.ts
+++ b/app/renderer/js/notification/darwin-notifications.ts
@@ -20,18 +20,17 @@ class DarwinNotification {
 	tag: number;
 
 	constructor(title: string, options: NotificationOptions) {
-		// X const profilePic = new URL(options.icon, location.href).href;
+		const profilePicURL = new URL(options.icon, location.href).href;
 		this.tag = Number.parseInt(options.tag, 10);
 		const notificationOptions: Electron.NotificationConstructorOptions = {
 			title,
 			body: options.body,
 			silent: ConfigUtil.getConfigItem('silent') || false,
-			// X icon: profilePic,
 			hasReply: true,
 			timeoutType: 'default'
 		};
 
-		ipcRenderer.send('create-notification', notificationOptions);
+		ipcRenderer.send('create-notification', notificationOptions, profilePicURL);
 		ipcRenderer.on('replied', async (_event: Electron.IpcRendererEvent, response: string) => {
 			await this.notificationHandler({response});
 			ipcRenderer.removeAllListeners('replied');

--- a/package-lock.json
+++ b/package-lock.json
@@ -750,6 +750,27 @@
       "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8089,17 +8089,6 @@
         }
       }
     },
-    "node-mac-notifier": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-mac-notifier/-/node-mac-notifier-1.2.0.tgz",
-      "integrity": "sha512-+9FZ01BbPMv3pQVRWgPlaIKbhQl35Pn3WmRg96zIrCJHb4XvClnAqc0+aPfHrWs8o1PYMAQFeYK5tF69ljkKQw==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.2.1",
-        "event-target-shim": "^1.1.1",
-        "uuid": "^3.3.2"
-      }
-    },
     "node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -164,9 +164,6 @@
     "node-json-db": "^1.1.0",
     "semver": "^7.3.2"
   },
-  "optionalDependencies": {
-    "node-mac-notifier": "^1.1.0"
-  },
   "devDependencies": {
     "@types/adm-zip": "^0.4.33",
     "@types/auto-launch": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   "dependencies": {
     "@electron-elements/send-feedback": "^2.0.3",
     "@sentry/electron": "^2.0.1",
+    "@types/node-fetch": "^2.5.7",
     "@yaireo/tagify": "^3.20.2",
     "adm-zip": "^0.4.16",
     "auto-launch": "^5.0.5",
@@ -161,6 +162,7 @@
     "i18n": "^0.13.2",
     "iso-639-1": "^2.1.4",
     "nan": "^2.14.2",
+    "node-fetch": "^2.6.0",
     "node-json-db": "^1.1.0",
     "semver": "^7.3.2"
   },


### PR DESCRIPTION
**What's this PR do?**
Electron's native Notifications now supports inline replies on macOS and thus we don't need any 3rd party package.
This commit removes the usage of node-mac-notifier and brings native Notification in picture.

For comprehensibility, ipc-helpers.ts will contain the functions which make use of Main process APIs with already functioning code in Renderer process.

**Any background context you want to provide?**
This is a potential solution to people not getting notifications on macOS.

**You have tested this PR on:**
  - [X] macOS Catalina 10.15.6

**Follow-ups**
  - [x] Display sender's profile picture on each notification