### PR TITLE
server_form: Added autocomplete function to url.

### DIFF
--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -65,11 +65,22 @@ export default class NewServerForm extends BaseComponent {
 		this.$newServerUrl = this.$newServerForm.querySelectorAll('input.setting-input-value')[0] as HTMLInputElement;
 	}
 
+	autoComplete(url: string): string {
+		const pattern = /^[a-zA-Z\d-]*$/;
+		let serverUrl = url.trim();
+
+		if (pattern.test(serverUrl)) {
+			serverUrl = 'https://' + serverUrl + '.zulipchat.com';
+		}
+
+		return serverUrl;
+	}
+
 	async submitFormHandler(): Promise<void> {
 		this.$saveServerButton.textContent = 'Connecting...';
 		let serverConf;
 		try {
-			serverConf = await DomainUtil.checkDomain(this.$newServerUrl.value.trim());
+			serverConf = await DomainUtil.checkDomain(this.autoComplete(this.$newServerUrl.value));
 		} catch (error: unknown) {
 			this.$saveServerButton.textContent = 'Connect';
 			await dialog.showMessageBox({


### PR DESCRIPTION
Added functionality for autocomplete when the user only passes a Organization URL string .
As discussed <a href = 'https://github.com/zulip/zulip-desktop/issues/1012#issuecomment-698234662'>here</a> : 

The following interpretation is made keeping the rest as it is : 
foo → ht<span>tps://</span>foo.zulipchat.com 


Fixes #1012


**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
