### PR TITLE
Revert to upstream undo and redo roles

### DIFF
--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -364,20 +364,10 @@ function getDarwinTpl(props: MenuProps): Electron.MenuItemConstructorOptions[] {
 		label: t.__('Edit'),
 		submenu: [{
 			label: t.__('Undo'),
-			accelerator: 'Cmd+Z',
-			click(_item, focusedWindow) {
-				if (focusedWindow) {
-					sendAction('undo');
-				}
-			}
+			role: 'undo'
 		}, {
 			label: t.__('Redo'),
-			accelerator: 'Cmd+Shift+Z',
-			click(_item, focusedWindow) {
-				if (focusedWindow) {
-					sendAction('redo');
-				}
-			}
+			role: 'redo'
 		}, {
 			type: 'separator'
 		}, {

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1018,11 +1018,6 @@ class ServerManagerView {
 			await this.openSettings('AddServer');
 		});
 
-		// Redo and undo functionality since the default API doesn't work on macOS
-		ipcRenderer.on('undo', () => this.getActiveWebview().undo());
-
-		ipcRenderer.on('redo', () => this.getActiveWebview().redo());
-
 		ipcRenderer.on('set-active', async () => {
 			const webviews: NodeListOf<Electron.WebviewTag> = document.querySelectorAll('webview');
 			await Promise.all([...webviews].map(async webview => webview.send('set-active')));


### PR DESCRIPTION
This reverts part of commit 01f6e772379095a3d4a58b3fe69236a58a30c5cc (#866). The Electron bug was fixed upstream in Electron 9.0.0-beta.23.

Closes #899.

@chrisbobbe Do you want to test on macOS?