### PR TITLE
Removes Toggle Tray icon in Linux 

### DIFF
--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -148,6 +148,7 @@ function getViewSubmenu(): Electron.MenuItemConstructorOptions[] {
 		type: 'separator'
 	}, {
 		label: t.__('Toggle Tray Icon'),
+		enabled: process.platform !== 'linux',
 		click(_item, focusedWindow) {
 			if (focusedWindow) {
 				focusedWindow.webContents.send('toggletray');

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -32,7 +32,7 @@ export default class GeneralSection extends BaseSection {
             <div class="settings-pane">
                 <div class="title">${t.__('Appearance')}</div>
                 <div id="appearance-option-settings" class="settings-card">
-					<div class="setting-row" id="tray-option">
+					<div class="setting-row" id="tray-option" style="display:${process.platform === 'linux' ? 'none' : ''}">
 						<div class="setting-description">${t.__('Show app icon in system tray')}</div>
 						<div class="setting-control"></div>
 					</div>


### PR DESCRIPTION
Signed-off-by: tarun8718 <tarunkumar8718@gmail.com>

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Removes the Toggle Tray icon feature in Linux OS.

please refer to this [issue](https://github.com/zulip/zulip-desktop/issues/1057)

**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
