### PR TITLE
Zoom In with 'CTRL/CMD + =' issue fixed

### DIFF
--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -73,7 +73,7 @@ document.addEventListener('keydown', event => {
 	const cmdOrCtrl = event.ctrlKey || event.metaKey;
 	if (event.code === 'F5') {
 		ipcRenderer.send('forward-message', 'hard-reload');
-	} else if (cmdOrCtrl && (event.code === 'NumpadAdd' || event.code === 'Equal')) {
+	} else if (cmdOrCtrl && event.code === 'NumpadAdd') {
 		ipcRenderer.send('forward-message', 'zoomIn');
 	} else if (cmdOrCtrl && event.code === 'NumpadSubtract') {
 		ipcRenderer.send('forward-message', 'zoomOut');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10126,7 +10126,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -10800,6 +10801,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }


### PR DESCRIPTION
**What's this PR do?**
Closes #1031 & Closes #1060. 
Single zoom-in with both `ControlOrCommand++` and `ControlOrCommand+=`.

**Any background context you want to provide?**
This issue was taking place because the zoomIn function was called twice when we press `ControlOrCommand+=`.
- Called using  accelerators and
- Called while adding global shortcuts

**You have tested this PR on:**
  - [x] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
