### PR TITLE
ci: Migrate Windows CI from Appveyor to Github Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Node.js CI
+
+on: push
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - run: npm test
+
+  windows-artifact:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - uses: samuelmeuli/action-electron-builder@v1
+        with:
+          args: --x64 --win nsis-web
+          github_token: ${{ secrets.github_token }}
+          windows_certs: ${{ secrets.windows_certs }}
+          windows_certs_password: ${{ secrets.windows_certs_password }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-dist
+          path: ./dist
+
+  linux-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - uses: samuelmeuli/action-electron-builder@v1
+        with:
+          args: --linux AppImage
+          github_token: ${{ secrets.github_token }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-dist
+          path: ./dist

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "test-e2e": "tsc && tape 'tests/*.js'",
     "pack": "tsc && electron-builder --dir",
     "dist": "tsc && electron-builder",
-    "mas": "tsc && electron-builder --mac mas"
+    "mas": "tsc && electron-builder --mac mas",
+    "build": "tsc",
+    "publish": "never"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
This also builds artifacts for all three platforms using CI.

Fixes #1070, fixes #406

**You have tested this PR on:**
  - [x] Linux/Ubuntu
  - [x] Windows
