### PR TITLE
release: New release v5.6.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Zulip desktop app are documented in this file.
 
+### v5.6.0 --2021-02-16
+
+**Fixes**:
+* Fixed zoom in keyboard shortcut not to zoom twice.
+
+**Enhancements**:
+* Restored hardware acceleration to the Electron default.
+
+**Dependencies**:
+* Upgraded all dependencies, including Electron 11.2.3.
+
 ### v5.5.0 --2020-12-01
 
 **Removed features**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zulip",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zulip",
   "productName": "Zulip",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "main": "./app/main",
   "description": "Zulip Desktop App",
   "license": "Apache-2.0",


### PR DESCRIPTION
### v5.6.0 --2021-02-16

**Fixes**:
* Fixed zoom in keyboard shortcut not to zoom twice.

**Enhancements**:
* Restored hardware acceleration to the Electron default.

**Dependencies**:
* Upgraded all dependencies, including Electron 11.2.3.
