### PR TITLE
Show sidebar on navigating to Settings page

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -977,6 +977,23 @@ class ServerManagerView {
     });
 
     ipcRenderer.on("open-settings", async () => {
+      let numberServers = 0;
+      for (const tab of this.tabs) {
+        if (tab.props.role === "server") {
+          numberServers++;
+        }
+      }
+
+      if (numberServers === 1) {
+        const value = ConfigUtil.getConfigItem("showSidebar");
+        if (!value) {
+          const newValue = !value;
+          this.toggleSidebar(newValue);
+          this.updateGeneralSettings("toggle-sidebar-setting", newValue);
+          ConfigUtil.setConfigItem("showSidebar", newValue);
+        }
+      }
+
       await this.openSettings();
     });
 


### PR DESCRIPTION
Signed-off-by: tarun8718 <tarunkumar8718@gmail.com>

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Shows Sidebar(if disabled) on navigating to the settings page(for users with single-organizations).
Fixes: #1077  
![sidebar](https://user-images.githubusercontent.com/40015660/109602590-69546d80-7b46-11eb-8b7e-13e09140084d.gif)


**You have tested this PR on:**
  - [ ] Windows
  - [X] Linux/Ubuntu
  - [ ] macOS
