### PR TITLE
Fix UI issue in input placeholder of Spellchecker Language setting.

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -751,3 +751,7 @@ i.open-network-button {
     color: rgba(255, 255, 255, 1.000);
     border-color: rgba(0, 0, 0, 0);
 }
+
+.tagify__input {
+    min-width: 130px !important;
+}

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -755,3 +755,8 @@ i.open-network-button {
 .tagify__input {
     min-width: 130px !important;
 }
+
+.tagify__input::before {
+    top: 0;
+    bottom: 0;
+}


### PR DESCRIPTION
---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes :  [#1054 ](https://github.com/zulip/zulip-desktop/issues/1054)
The input placeholder doesn't overflow outside the bounds. It is also vertically aligned in center.

**Any background context you want to provide?**
The overflow issue in placeholder value is due to `@yaireo/tagify` package used in `zulip-desktop` project. The issue [#675](https://github.com/yairEO/tagify/issues/675) in `tagify` repository gives solution to fix the overflow problem.

**Screenshots?**

Before commit
![image](https://user-images.githubusercontent.com/56691622/110949356-82d88f00-8368-11eb-95db-ba0262405029.png)

After commit
![image](https://user-images.githubusercontent.com/56691622/110949469-a4397b00-8368-11eb-8cde-0a4e906778bb.png)

**You have tested this PR on:**
 - [x] Linux (Manjaro Linux x86_64)

