### PR TITLE
No spacing between tooltips of organisations

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -377,7 +377,7 @@ webview.focus {
 .server-tooltip {
     font-family: 'arial';
     background: rgba(34, 44, 49, 1.000);
-    left: 56px;
+    left: 60px;
     padding: 10px 20px;
     position: fixed;
     margin-top: 11px;


### PR DESCRIPTION
---

**Description**
Fixed spacing between tooltip of organisation and the sidebar.  in #1087


**I have tested this PR on**

  

 Linux/Ubuntu


**code?**
``` CSS
#add-server-tooltip,
.server-tooltip {
    font-family: 'arial';
    background: rgba(34, 44, 49, 1.000);
    left: 60px; ```

