### PR TITLE
server-tab: Fix upper limit of generateShortcutText()

### DIFF
--- a/app/renderer/js/components/server-tab.ts
+++ b/app/renderer/js/components/server-tab.ts
@@ -45,8 +45,8 @@ export default class ServerTab extends Tab {
 	}
 
 	generateShortcutText(): string {
-		// Only provide shortcuts for server [0..10]
-		if (this.props.index >= 10) {
+		// Only provide shortcuts for server [0..9]
+		if (this.props.index >= 9) {
 			return '';
 		}
 


### PR DESCRIPTION
Signed-off-by: tarun8718 <tarunkumar8718@gmail.com>

---
<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes the upper limit of generateShortcutText() function.

**Any background context you want to provide?**
generateShortcutText() function is used to generate and display shortcuts of organisations(tabs) in the zulip-desktop sidebar.

## Before:
```
generateShortcutText(): string {

// Only provide shortcuts for server [0..10]
		if (this.props.index >= 10) {
			return '';
		}
                const shownIndex = this.props.index + 1;
		let shortcutText = '';
		shortcutText = SystemUtil.getOS() === 'Mac' ? `⌘ ${shownIndex}` : `Ctrl+${shownIndex}`;
		// Array index == Shown index - 1
		ipcRenderer.send('switch-server-tab', shownIndex - 1);
		return shortcutText;
}
```
Returns Shortcut text for indexes 0 to 9 and empty text for index greater than or equal to 10 
When the index is 9 the shortcut text generated will be ⌘10 or Ctrl+10. Hence the limit of if block should be equal to or greater than 9.

## After:
```
generateShortcutText(): string {

// Only provide shortcuts for server [0..9]
		if (this.props.index >= 9) {
			return '';
		}
                const shownIndex = this.props.index + 1;
		let shortcutText = '';
		shortcutText = SystemUtil.getOS() === 'Mac' ? `⌘ ${shownIndex}` : `Ctrl+${shownIndex}`;
		// Array index == Shown index - 1
		ipcRenderer.send('switch-server-tab', shownIndex - 1);
		return shortcutText;
}
```

**Screenshots?**
## Before:
![Index](https://user-images.githubusercontent.com/40015660/112718890-e68fba00-8f1b-11eb-8a50-af15bb7a7591.jpg)
Ctrl + 10

## After:
![Screenshot from 2021-03-27 16-29-37](https://user-images.githubusercontent.com/40015660/112718953-3d958f00-8f1c-11eb-8fe1-27269bb65f85.png)

Empty text after Ctrl + 9


**You have tested this PR on:**
  - [ ] Windows
  - [x] Linux/Ubuntu
  - [ ] macOS
