### PR TITLE
No spacing between tooltips of organisations

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -379,7 +379,7 @@ webview.focus {
 .server-tooltip {
   font-family: "arial", sans-serif;
   background: rgba(34, 44, 49, 1);
-  left: 56px;
+  left: 60px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;


### PR DESCRIPTION
---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixed spacing between the tooltip of organisation and the sidebar in #1087

**Any background context you want to provide?**
Solved the issue without any conflicts.

**Screenshots?**

Before commit 
![before](https://user-images.githubusercontent.com/73520373/113498701-fd8e6780-952c-11eb-84ce-ad0c65a498e1.png)

After commit 

![Screenshot from 2021-04-04 10-29-17](https://user-images.githubusercontent.com/73520373/113499091-d5a10300-9530-11eb-82c9-359e73af2f3f.png)



**You have tested this PR on:**


- [ ] Windows
- [x] Linux(Ubuntu 20.04 - Linux x86_64)
- [ ] macOS
