### PR TITLE
context menu:Toggle Org Shortcut on Sidebar

### DIFF
--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -227,6 +227,14 @@ function getViewSubmenu(): Electron.MenuItemConstructorOptions[] {
       },
     },
     {
+      label: t.__("Toggle Organization Shortcuts"),
+      click(_item, focusedWindow) {
+        if (focusedWindow) {
+          focusedWindow.webContents.send("toggleOrgShortcuts");
+        }
+      },
+    },
+    {
       label: t.__("Toggle Sidebar"),
       accelerator: "CommandOrControl+Shift+S",
       click(_item, focusedWindow) {

--- a/app/renderer/js/components/server-tab.ts
+++ b/app/renderer/js/components/server-tab.ts
@@ -31,7 +31,7 @@ export default class ServerTab extends Tab {
         <div class="server-tab">
           <img class="server-icons" src="${this.props.icon}" />
         </div>
-        <div class="server-tab-shortcut">${this.generateShortcutText()}</div>
+        <div class="server-tab-shortcut style="display:none"">${this.generateShortcutText()}</div>
       </div>
     `;
   }

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -74,6 +74,7 @@ class ServerManagerView {
   $loadingTooltip: HTMLElement;
   $settingsTooltip: HTMLElement;
   $serverIconTooltip: HTMLCollectionOf<HTMLElement>;
+  $serverShortcuts: HTMLCollectionOf<HTMLElement>;
   $backTooltip: HTMLElement;
   $dndTooltip: HTMLElement;
   $sidebar: Element;
@@ -113,6 +114,10 @@ class ServerManagerView {
     // eslint-disable-next-line unicorn/prefer-query-selector
     this.$serverIconTooltip = document.getElementsByClassName(
       "server-tooltip",
+    ) as HTMLCollectionOf<HTMLElement>;
+    // eslint-disable-next-line unicorn/prefer-query-selector
+    this.$serverShortcuts = document.getElementsByClassName(
+      "server-tab-shortcut",
     ) as HTMLCollectionOf<HTMLElement>;
     this.$backTooltip = $actionsContainer.querySelector("#back-tooltip")!;
     this.$dndTooltip = $actionsContainer.querySelector("#dnd-tooltip")!;
@@ -1023,6 +1028,19 @@ class ServerManagerView {
 
       // Toggle sidebar switch in the general settings
       this.updateGeneralSettings("toggle-sidebar-setting", show);
+    });
+
+    ipcRenderer.on("toggleOrgShortcuts", () => {
+      for (const $serverShortcut of this.$serverShortcuts) {
+        if (
+          $serverShortcut.getAttribute("style") === null ||
+          $serverShortcut.getAttribute("style") === ""
+        ) {
+          $serverShortcut.style.display = "none";
+        } else {
+          $serverShortcut.removeAttribute("style");
+        }
+      }
     });
 
     ipcRenderer.on("toggle-silent", (event: Event, state: boolean) => {


### PR DESCRIPTION
Signed-off-by: tarun8718 <tarunkumar8718@gmail.com>

---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Toggles Display of Org Shortcuts on Sidebar.

**Any background context you want to provide?**
Refer [CZO](https://chat.zulip.org/#narrow/stream/16-desktop/topic/Toggle.20Org.20shortcuts)

**Screenshots?**
![orgShortcuts](https://user-images.githubusercontent.com/40015660/113936255-25274d80-9815-11eb-97fb-2071501e1a61.gif)

**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu
- [ ] macOS
