### PR TITLE
tray: Mark tray tooltip messages for translation.

### DIFF
--- a/app/common/translation-util.ts
+++ b/app/common/translation-util.ts
@@ -13,6 +13,9 @@ i18n.configure({
 const appLocale = ConfigUtil.getConfigItem("appLanguage", "en");
 
 /* If no locale present in the json, en is set default */
-export function __(phrase: string): string {
-  return i18n.__({phrase, locale: appLocale ? appLocale : "en"});
+export function __(
+  phrase: string,
+  replacements: i18n.Replacements = {},
+): string {
+  return i18n.__({phrase, locale: appLocale ? appLocale : "en"}, replacements);
 }

--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -3,6 +3,7 @@ import {remote} from "electron";
 import path from "path";
 
 import * as ConfigUtil from "../../common/config-util";
+import * as t from "../../common/translation-util";
 import type {RendererMessage} from "../../common/typed-ipc";
 
 import {ipcRenderer} from "./typed-ipc-renderer";
@@ -191,12 +192,14 @@ ipcRenderer.on("tray", (_event: Event, arg: number): void => {
     if (arg === 0) {
       unread = arg;
       tray.setImage(iconPath());
-      tray.setToolTip("No unread messages");
+      tray.setToolTip(t.__("No unread messages"));
     } else {
       unread = arg;
       const image = renderNativeImage(arg);
       tray.setImage(image);
-      tray.setToolTip(`${arg} unread messages`);
+      tray.setToolTip(
+        t.__(`{{count}} unread messages`, {count: arg.toString()}),
+      );
     }
   }
 });


### PR DESCRIPTION
We also update the translation-utils to support passing variable
replacements.

---
**You have tested this PR on:**

- [x] Windows
- [ ] Linux/Ubuntu
- [ ] macOS
