### PR TITLE
Spacing b/w tool tips of organizations added

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -379,7 +379,7 @@ webview.focus {
 .server-tooltip {
   font-family: "arial", sans-serif;
   background: rgba(34, 44, 49, 1);
-  left: 56px;
+  left: 60px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;


### PR DESCRIPTION
---
**What's this PR do?**
Fixes spacing between tooltip of organisation and the sidebar. This PR is associated to issue #1087.

**Screenshots?**
![Screenshot from 2021-06-11 10-58-39](https://user-images.githubusercontent.com/64978837/121635701-5128ae80-caa4-11eb-86dc-b7053e4111c7.png)


**You have tested this PR on:**

- [x] Windows
- [x] Linux/Ubuntu
- [ ] macOS

Please review and suggest changes if any.