### PR TITLE
Fix spell checker on macOS

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -176,9 +176,13 @@ function createMainWindow(): Electron.BrowserWindow {
 
   ipcMain.on("set-spellcheck-langs", () => {
     ses.setSpellCheckerLanguages(
-      ConfigUtil.getConfigItem("spellcheckerLanguages", null) ?? [],
+      process.platform === "darwin"
+        ? // Work around https://github.com/electron/electron/issues/30215.
+          mainWindow.webContents.session.getSpellCheckerLanguages()
+        : ConfigUtil.getConfigItem("spellcheckerLanguages", null) ?? [],
     );
   });
+
   AppMenu.setMenu({
     tabs: [],
   });


### PR DESCRIPTION
Although `ses.setSpellCheckerLanguages` is documented as a no-op on macOS, `ses.setSpellCheckerLanguages([])` actually disables spell checking as of Electron 8.1.0 (electron/electron#30215). This effect is persistent in our persistent session, so we attempt to undo it by copying the language list from the main `BrowserWindow`.

(Before commit 892f7c8e476f04f2e929df484c42c7150391760f we were running `ses.setSpellCheckerLanguages(null)`, which just crashed with “TypeError: Error processing argument at index 0, conversion failure from null”.)

Fixes #1132.