### PR TITLE
release: New release v5.8.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Zulip desktop app are documented in this file.
 
+### v5.8.0 --2021-07-21
+
+**Fixes**:
+
+- Fixed the spell checker on macOS.
+- Fixed `TypeError` after closing the About page.
+
+**Enhancements**:
+
+- Removed `Ctrl`+`L`/`⌘L` keyboard shortcut to prevent accidental logouts.
+
+**Dependencies**:
+
+- Upgraded all dependencies, including Electron 13.1.7.
+
 ### v5.7.0 --2021-04-30
 
 **Fixes**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zulip",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zulip",
   "productName": "Zulip",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "main": "./app/main",
   "description": "Zulip Desktop App",
   "license": "Apache-2.0",


### PR DESCRIPTION
### v5.8.0 --2021-07-21

**Fixes**:

- Fixed the spell checker on macOS.
- Fixed `TypeError` after closing the About page.

**Enhancements**:

- Removed `Ctrl`+`L`/`⌘L` keyboard shortcut to prevent accidental logouts.

**Dependencies**:

- Upgraded all dependencies, including Electron 13.1.7.