### PR TITLE
Replace Linux zip build with tar.xz

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       "description": "Zulip Desktop Client for Linux",
       "target": [
         "deb",
-        "zip",
+        "tar.xz",
         "AppImage",
         "snap"
       ],


### PR DESCRIPTION
The filename of the Linux zip now conflicts with the macOS zip needed by the auto-updater, and zip isn’t a usual format for Linux anyway.