### PR TITLE
Enable context isolation on local content

### DIFF
--- a/app/common/config-util.ts
+++ b/app/common/config-util.ts
@@ -1,4 +1,3 @@
-import electron from "electron";
 import fs from "fs";
 import path from "path";
 
@@ -9,13 +8,11 @@ import type * as z from "zod";
 import {configSchemata} from "./config-schemata";
 import * as EnterpriseUtil from "./enterprise-util";
 import Logger from "./logger-util";
+import {app, dialog} from "./remote";
 
 export type Config = {
   [Key in keyof typeof configSchemata]: z.output<typeof configSchemata[Key]>;
 };
-
-/* To make the util runnable in both main and renderer process */
-const {app, dialog} = process.type === "renderer" ? electron.remote : electron;
 
 const logger = new Logger({
   file: "config-util.log",

--- a/app/common/default-util.ts
+++ b/app/common/default-util.ts
@@ -1,7 +1,6 @@
-import electron from "electron";
 import fs from "fs";
 
-const {app} = process.type === "renderer" ? electron.remote : electron;
+import {app} from "./remote";
 
 let setupCompleted = false;
 

--- a/app/common/logger-util.ts
+++ b/app/common/logger-util.ts
@@ -4,9 +4,8 @@ import fs from "fs";
 import os from "os";
 
 import {initSetUp} from "./default-util";
+import {app} from "./remote";
 import {captureException, sentryInit} from "./sentry-util";
-
-const {app} = process.type === "renderer" ? electron.remote : electron;
 
 interface LoggerOptions {
   file?: string;

--- a/app/common/remote.ts
+++ b/app/common/remote.ts
@@ -1,0 +1,4 @@
+import electron from "electron";
+
+export const {app, dialog} =
+  process.type === "renderer" ? electron.remote : electron;

--- a/app/common/remote.ts
+++ b/app/common/remote.ts
@@ -1,4 +1,7 @@
 import electron from "electron";
 
 export const {app, dialog} =
-  process.type === "renderer" ? electron.remote : electron;
+  process.type === "renderer"
+    ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      (require("@electron/remote") as typeof import("@electron/remote"))
+    : electron;

--- a/app/common/sentry-util.ts
+++ b/app/common/sentry-util.ts
@@ -1,8 +1,6 @@
-import electron from "electron";
-
 import {init} from "@sentry/electron";
 
-const {app} = process.type === "renderer" ? electron.remote : electron;
+import {app} from "./remote";
 
 export const sentryInit = (): void => {
   if (app.isPackaged) {

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -67,8 +67,8 @@ function createMainWindow(): Electron.BrowserWindow {
     minHeight: 400,
     webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true,
       partition: "persist:webviewsession",
+      preload: require.resolve("../renderer/js/main"),
       webviewTag: true,
       worldSafeExecuteJavaScript: true,
     },

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -2,6 +2,7 @@ import electron, {app, dialog, session} from "electron";
 import fs from "fs";
 import path from "path";
 
+import * as remoteMain from "@electron/remote/main";
 import windowStateKeeper from "electron-window-state";
 
 import * as ConfigUtil from "../common/config-util";
@@ -66,7 +67,6 @@ function createMainWindow(): Electron.BrowserWindow {
     minHeight: 400,
     webPreferences: {
       contextIsolation: false,
-      enableRemoteModule: true,
       nodeIntegration: true,
       partition: "persist:webviewsession",
       webviewTag: true,
@@ -74,6 +74,7 @@ function createMainWindow(): Electron.BrowserWindow {
     },
     show: false,
   });
+  remoteMain.enable(win.webContents);
 
   win.on("focus", () => {
     send(win.webContents, "focus");
@@ -144,6 +145,8 @@ function createMainWindow(): Electron.BrowserWindow {
 
   // Used for notifications on Windows
   app.setAppUserModelId("org.zulip.zulip-electron");
+
+  remoteMain.initialize();
 
   app.on("second-instance", () => {
     if (mainWindow) {

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -66,7 +66,7 @@ function createMainWindow(): Electron.BrowserWindow {
     minWidth: 500,
     minHeight: 400,
     webPreferences: {
-      contextIsolation: false,
+      contextIsolation: true,
       partition: "persist:webviewsession",
       preload: require.resolve("../renderer/js/main"),
       webviewTag: true,

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -299,34 +299,27 @@ body {
 
 /* When the active webview is loaded */
 #webviews-container.loaded::before {
-  opacity: 0;
   z-index: -1;
   visibility: hidden;
 }
 
 webview,
 .functional-view {
-  /* transition: opacity 0.3s ease-in; */
   position: absolute;
   width: 100%;
   height: 100%;
   flex-grow: 1;
 }
 
-webview.onload {
-  transition: opacity 1s cubic-bezier(0.95, 0.05, 0.795, 0.035);
-}
-
 webview.active,
 .functional-view.active {
-  opacity: 1;
   z-index: 1;
   visibility: visible;
 }
 
 webview.disabled,
 .functional-view.disabled {
-  opacity: 0;
+  visibility: hidden;
 }
 
 webview.focus {

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -309,17 +309,13 @@ webview,
   width: 100%;
   height: 100%;
   flex-grow: 1;
+  visibility: hidden;
 }
 
 webview.active,
 .functional-view.active {
   z-index: 1;
   visibility: visible;
-}
-
-webview.disabled,
-.functional-view.disabled {
-  visibility: hidden;
 }
 
 webview.focus {

--- a/app/renderer/js/components/context-menu.ts
+++ b/app/renderer/js/components/context-menu.ts
@@ -1,9 +1,8 @@
 import type {ContextMenuParams} from "electron";
-import {remote} from "electron";
+
+import {Menu, clipboard} from "@electron/remote";
 
 import * as t from "../../../common/translation-util";
-
-const {clipboard, Menu} = remote;
 
 export const contextMenu = (
   webContents: Electron.WebContents,

--- a/app/renderer/js/components/functional-tab.ts
+++ b/app/renderer/js/components/functional-tab.ts
@@ -26,18 +26,18 @@ export default class FunctionalTab extends Tab {
     }
   }
 
-  override activate(): void {
-    super.activate();
+  override async activate(): Promise<void> {
+    await super.activate();
     this.$view.classList.add("active");
   }
 
-  override deactivate(): void {
-    super.deactivate();
+  override async deactivate(): Promise<void> {
+    await super.deactivate();
     this.$view.classList.remove("active");
   }
 
-  override destroy(): void {
-    super.destroy();
+  override async destroy(): Promise<void> {
+    await super.destroy();
     this.$view.remove();
   }
 

--- a/app/renderer/js/components/functional-tab.ts
+++ b/app/renderer/js/components/functional-tab.ts
@@ -29,12 +29,10 @@ export default class FunctionalTab extends Tab {
   override activate(): void {
     super.activate();
     this.$view.classList.add("active");
-    this.$view.classList.remove("disabled");
   }
 
   override deactivate(): void {
     super.deactivate();
-    this.$view.classList.add("disabled");
     this.$view.classList.remove("active");
   }
 

--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -58,7 +58,7 @@ export default function handleExternalLink(
             body: "Download failed",
           });
         } else {
-          this.$el!.downloadURL(url.href);
+          this.$el.downloadURL(url.href);
         }
       }
 

--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -10,11 +10,9 @@ const dingSound = new Audio("../resources/sounds/ding.ogg");
 
 export default function handleExternalLink(
   this: WebView,
-  event: Electron.NewWindowEvent,
+  details: Electron.HandlerDetails,
 ): void {
-  event.preventDefault();
-
-  const url = new URL(event.url);
+  const url = new URL(details.url);
   const downloadPath = ConfigUtil.getConfigItem(
     "downloadsPath",
     `${app.getPath("downloads")}`,

--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -58,7 +58,7 @@ export default function handleExternalLink(
             body: "Download failed",
           });
         } else {
-          this.$el.downloadURL(url.href);
+          this.getWebContents().downloadURL(url.href);
         }
       }
 

--- a/app/renderer/js/components/handle-external-link.ts
+++ b/app/renderer/js/components/handle-external-link.ts
@@ -1,12 +1,10 @@
-import {remote} from "electron";
+import {app, shell} from "@electron/remote";
 
 import * as ConfigUtil from "../../../common/config-util";
 import {ipcRenderer} from "../typed-ipc-renderer";
 import * as LinkUtil from "../utils/link-util";
 
 import type WebView from "./webview";
-
-const {shell, app} = remote;
 
 const dingSound = new Audio("../resources/sounds/ding.ogg");
 

--- a/app/renderer/js/components/server-tab.ts
+++ b/app/renderer/js/components/server-tab.ts
@@ -8,11 +8,11 @@ import Tab from "./tab";
 import type WebView from "./webview";
 
 export interface ServerTabProps extends TabProps {
-  webview: WebView;
+  webview: Promise<WebView>;
 }
 
 export default class ServerTab extends Tab {
-  webview: WebView;
+  webview: Promise<WebView>;
   $el: Element;
   $badge: Element;
 
@@ -26,19 +26,19 @@ export default class ServerTab extends Tab {
     this.$badge = this.$el.querySelector(".server-tab-badge")!;
   }
 
-  override activate(): void {
-    super.activate();
-    this.webview.load();
+  override async activate(): Promise<void> {
+    await super.activate();
+    (await this.webview).load();
   }
 
-  override deactivate(): void {
-    super.deactivate();
-    this.webview.hide();
+  override async deactivate(): Promise<void> {
+    await super.deactivate();
+    (await this.webview).hide();
   }
 
-  override destroy(): void {
-    super.destroy();
-    this.webview.$el!.remove();
+  override async destroy(): Promise<void> {
+    await super.destroy();
+    (await this.webview).$el!.remove();
   }
 
   templateHTML(): HTML {

--- a/app/renderer/js/components/server-tab.ts
+++ b/app/renderer/js/components/server-tab.ts
@@ -38,7 +38,7 @@ export default class ServerTab extends Tab {
 
   override async destroy(): Promise<void> {
     await super.destroy();
-    (await this.webview).$el!.remove();
+    (await this.webview).$el.remove();
   }
 
   templateHTML(): HTML {

--- a/app/renderer/js/components/tab.ts
+++ b/app/renderer/js/components/tab.ts
@@ -34,15 +34,15 @@ export default abstract class Tab {
     }
   }
 
-  activate(): void {
+  async activate(): Promise<void> {
     this.$el.classList.add("active");
   }
 
-  deactivate(): void {
+  async deactivate(): Promise<void> {
     this.$el.classList.remove("active");
   }
 
-  destroy(): void {
+  async destroy(): Promise<void> {
     this.$el.remove();
   }
 }

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -53,14 +53,14 @@ export default class WebView {
     )!.classList;
   }
 
-  templateHTML(): HTML {
+  static templateHTML(props: WebViewProps): HTML {
     return html`
       <webview
-        data-tab-id="${this.props.tabIndex}"
-        src="${this.props.url}"
-        ${this.props.preload === undefined
+        data-tab-id="${props.tabIndex}"
+        src="${props.url}"
+        ${props.preload === undefined
           ? html``
-          : html`preload="${this.props.preload}"`}
+          : html`preload="${props.preload}"`}
         partition="persist:webviewsession"
         webpreferences="
           contextIsolation,
@@ -75,7 +75,9 @@ export default class WebView {
   }
 
   init(): void {
-    this.$el = generateNodeFromHTML(this.templateHTML()) as Electron.WebviewTag;
+    this.$el = generateNodeFromHTML(
+      WebView.templateHTML(this.props),
+    ) as Electron.WebviewTag;
     this.whenAttached = new Promise((resolve) => {
       this.$el!.addEventListener(
         "did-attach",

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -175,8 +175,8 @@ export default class WebView {
     return messageCountInTitle ? Number(messageCountInTitle[1]) : 0;
   }
 
-  async showNotificationSettings(): Promise<void> {
-    await this.send("show-notification-settings");
+  showNotificationSettings(): void {
+    this.send("show-notification-settings");
   }
 
   show(): void {
@@ -250,12 +250,12 @@ export default class WebView {
     this.$el!.setZoomFactor(this.zoomFactor);
   }
 
-  async logOut(): Promise<void> {
-    await this.send("logout");
+  logOut(): void {
+    this.send("logout");
   }
 
-  async showKeyboardShortcuts(): Promise<void> {
-    await this.send("show-keyboard-shortcuts");
+  showKeyboardShortcuts(): void {
+    this.send("show-keyboard-shortcuts");
   }
 
   openDevTools(): void {
@@ -295,10 +295,10 @@ export default class WebView {
     this.$el!.reload();
   }
 
-  async send<Channel extends keyof RendererMessage>(
+  send<Channel extends keyof RendererMessage>(
     channel: Channel,
     ...args: Parameters<RendererMessage[Channel]>
-  ): Promise<void> {
+  ): void {
     ipcRenderer.sendTo(this.$el!.getWebContentsId(), channel, ...args);
   }
 }

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -143,10 +143,6 @@ export default class WebView {
     });
 
     this.$el!.addEventListener("dom-ready", () => {
-      if (this.props.role === "server") {
-        this.$el!.classList.add("onload");
-      }
-
       this.loading = false;
       this.props.switchLoading(false, this.props.url);
       this.show();
@@ -197,11 +193,6 @@ export default class WebView {
 
     this.$el!.classList.remove("disabled");
     this.$el!.classList.add("active");
-    setTimeout(() => {
-      if (this.props.role === "server") {
-        this.$el!.classList.remove("onload");
-      }
-    }, 1000);
     this.focus();
     this.props.onTitleChange();
     // Injecting preload css in webview to override some css rules

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -1,6 +1,8 @@
-import {remote} from "electron";
 import fs from "fs";
 import path from "path";
+
+import * as remote from "@electron/remote";
+import {app, dialog} from "@electron/remote";
 
 import * as ConfigUtil from "../../../common/config-util";
 import {HTML, html} from "../../../common/html";
@@ -12,8 +14,6 @@ import * as SystemUtil from "../utils/system-util";
 import {generateNodeFromHTML} from "./base";
 import {contextMenu} from "./context-menu";
 import handleExternalLink from "./handle-external-link";
-
-const {app, dialog} = remote;
 
 const shouldSilentWebview = ConfigUtil.getConfigItem("silent", false);
 

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -40,12 +40,12 @@ export default class WebView {
   loading: boolean;
   customCSS: string | false | null;
   $webviewsContainer: DOMTokenList;
-  $el: Electron.WebviewTag;
+  $el: HTMLElement;
   webContentsId: number;
 
   private constructor(
     props: WebViewProps,
-    $element: Electron.WebviewTag,
+    $element: HTMLElement,
     webContentsId: number,
   ) {
     this.props = props;
@@ -86,7 +86,7 @@ export default class WebView {
   static async create(props: WebViewProps): Promise<WebView> {
     const $element = generateNodeFromHTML(
       WebView.templateHTML(props),
-    ) as Electron.WebviewTag;
+    ) as HTMLElement;
     props.$root.append($element);
 
     // Wait for did-navigate rather than did-attach to work around

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -56,7 +56,6 @@ export default class WebView {
   templateHTML(): HTML {
     return html`
       <webview
-        class="disabled"
         data-tab-id="${this.props.tabIndex}"
         src="${this.props.url}"
         ${new HTML({html: this.props.nodeIntegration ? "nodeIntegration" : ""})}
@@ -191,7 +190,6 @@ export default class WebView {
       this.$webviewsContainer.add("loaded");
     }
 
-    this.$el!.classList.remove("disabled");
     this.$el!.classList.add("active");
     this.focus();
     this.props.onTitleChange();
@@ -237,7 +235,6 @@ export default class WebView {
   }
 
   hide(): void {
-    this.$el!.classList.add("disabled");
     this.$el!.classList.remove("active");
   }
 

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -227,18 +227,9 @@ export default class WebView {
   }
 
   focus(): void {
-    // Focus Webview and it's contents when Window regain focus.
-    const webContents = remote.webContents.fromId(this.$el!.getWebContentsId());
-    // HACK: webContents.isFocused() seems to be true even without the element
-    // being in focus. So, we check against `document.activeElement`.
-    if (webContents && this.$el !== document.activeElement) {
-      // HACK: Looks like blur needs to be called on the previously focused
-      // element to transfer focus correctly, in Electron v3.0.10
-      // See https://github.com/electron/electron/issues/15718
-      (document.activeElement as HTMLElement).blur();
-      this.$el!.focus();
-      webContents.focus();
-    }
+    this.$el!.focus();
+    // Work around https://github.com/electron/electron/issues/31918
+    this.$el!.shadowRoot?.querySelector("iframe")?.focus();
   }
 
   hide(): void {

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -5,7 +5,8 @@ import * as remote from "@electron/remote";
 import {app, dialog} from "@electron/remote";
 
 import * as ConfigUtil from "../../../common/config-util";
-import {HTML, html} from "../../../common/html";
+import type {HTML} from "../../../common/html";
+import {html} from "../../../common/html";
 import type {RendererMessage} from "../../../common/typed-ipc";
 import type {TabRole} from "../../../common/types";
 import {ipcRenderer} from "../typed-ipc-renderer";
@@ -27,7 +28,7 @@ interface WebViewProps {
   switchLoading: (loading: boolean, url: string) => void;
   onNetworkError: (index: number) => void;
   nodeIntegration: boolean;
-  preload: boolean;
+  preload?: string;
   onTitleChange: () => void;
   hasPermission?: (origin: string, permission: string) => boolean;
 }
@@ -58,8 +59,10 @@ export default class WebView {
       <webview
         data-tab-id="${this.props.tabIndex}"
         src="${this.props.url}"
-        ${new HTML({html: this.props.nodeIntegration ? "nodeIntegration" : ""})}
-        ${new HTML({html: this.props.preload ? 'preload="js/preload.js"' : ""})}
+        ${this.props.nodeIntegration ? html`nodeIntegration` : html``}
+        ${this.props.preload === undefined
+          ? html``
+          : html`preload="${this.props.preload}"`}
         partition="persist:webviewsession"
         webpreferences="
           contextIsolation=${!this.props.nodeIntegration},

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -113,7 +113,7 @@ export default class WebView {
     });
 
     if (shouldSilentWebview) {
-      this.$el.setAudioMuted(true);
+      this.getWebContents().setAudioMuted(true);
     }
 
     this.$el.addEventListener("page-title-updated", (event) => {
@@ -207,7 +207,7 @@ export default class WebView {
     this.props.onTitleChange();
     // Injecting preload css in webview to override some css rules
     (async () =>
-      this.$el.insertCSS(
+      this.getWebContents().insertCSS(
         fs.readFileSync(path.join(__dirname, "/../../css/preload.css"), "utf8"),
       ))();
 
@@ -225,7 +225,7 @@ export default class WebView {
       }
 
       (async () =>
-        this.$el.insertCSS(
+        this.getWebContents().insertCSS(
           fs.readFileSync(path.resolve(__dirname, customCSS), "utf8"),
         ))();
     }
@@ -247,17 +247,17 @@ export default class WebView {
 
   zoomIn(): void {
     this.zoomFactor += 0.1;
-    this.$el.setZoomFactor(this.zoomFactor);
+    this.getWebContents().setZoomFactor(this.zoomFactor);
   }
 
   zoomOut(): void {
     this.zoomFactor -= 0.1;
-    this.$el.setZoomFactor(this.zoomFactor);
+    this.getWebContents().setZoomFactor(this.zoomFactor);
   }
 
   zoomActualSize(): void {
     this.zoomFactor = 1;
-    this.$el.setZoomFactor(this.zoomFactor);
+    this.getWebContents().setZoomFactor(this.zoomFactor);
   }
 
   logOut(): void {
@@ -269,12 +269,12 @@ export default class WebView {
   }
 
   openDevTools(): void {
-    this.$el.openDevTools();
+    this.getWebContents().openDevTools();
   }
 
   back(): void {
-    if (this.$el.canGoBack()) {
-      this.$el.goBack();
+    if (this.getWebContents().canGoBack()) {
+      this.getWebContents().goBack();
       this.focus();
     }
   }
@@ -283,7 +283,7 @@ export default class WebView {
     const $backButton = document.querySelector(
       "#actions-container #back-action",
     )!;
-    if (this.$el.canGoBack()) {
+    if (this.getWebContents().canGoBack()) {
       $backButton.classList.remove("disable");
     } else {
       $backButton.classList.add("disable");
@@ -291,8 +291,8 @@ export default class WebView {
   }
 
   forward(): void {
-    if (this.$el.canGoForward()) {
-      this.$el.goForward();
+    if (this.getWebContents().canGoForward()) {
+      this.getWebContents().goForward();
     }
   }
 
@@ -302,7 +302,7 @@ export default class WebView {
     this.$webviewsContainer.remove("loaded");
     this.loading = true;
     this.props.switchLoading(true, this.props.url);
-    this.$el.reload();
+    this.getWebContents().reload();
   }
 
   send<Channel extends keyof RendererMessage>(

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -42,7 +42,7 @@ export default class WebView {
   $el?: Electron.WebviewTag;
   whenAttached?: Promise<void>;
 
-  constructor(props: WebViewProps) {
+  private constructor(props: WebViewProps) {
     this.props = props;
     this.zoomFactor = 1;
     this.loading = true;
@@ -72,6 +72,10 @@ export default class WebView {
       >
       </webview>
     `;
+  }
+
+  static create(props: WebViewProps): WebView {
+    return new WebView(props);
   }
 
   init(): void {

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -39,7 +39,7 @@ export default class WebView {
   loading: boolean;
   customCSS: string | false | null;
   $webviewsContainer: DOMTokenList;
-  $el?: Electron.WebviewTag;
+  $el: Electron.WebviewTag;
 
   private constructor(props: WebViewProps, $element: Electron.WebviewTag) {
     this.props = props;
@@ -98,29 +98,29 @@ export default class WebView {
   }
 
   registerListeners(): void {
-    this.$el!.addEventListener("new-window", (event) => {
+    this.$el.addEventListener("new-window", (event) => {
       handleExternalLink.call(this, event);
     });
 
     if (shouldSilentWebview) {
-      this.$el!.setAudioMuted(true);
+      this.$el.setAudioMuted(true);
     }
 
-    this.$el!.addEventListener("page-title-updated", (event) => {
+    this.$el.addEventListener("page-title-updated", (event) => {
       const {title} = event;
       this.badgeCount = this.getBadgeCount(title);
       this.props.onTitleChange();
     });
 
-    this.$el!.addEventListener("did-navigate-in-page", () => {
+    this.$el.addEventListener("did-navigate-in-page", () => {
       this.canGoBackButton();
     });
 
-    this.$el!.addEventListener("did-navigate", () => {
+    this.$el.addEventListener("did-navigate", () => {
       this.canGoBackButton();
     });
 
-    this.$el!.addEventListener("page-favicon-updated", (event) => {
+    this.$el.addEventListener("page-favicon-updated", (event) => {
       const {favicons} = event;
 
       // This returns a string of favicons URL. If there is a PM counts in unread messages then the URL would be like
@@ -138,18 +138,18 @@ export default class WebView {
       }
     });
 
-    const webContents = remote.webContents.fromId(this.$el!.getWebContentsId());
+    const webContents = remote.webContents.fromId(this.$el.getWebContentsId());
     webContents.addListener("context-menu", (event, menuParameters) => {
       contextMenu(webContents, event, menuParameters);
     });
 
-    this.$el!.addEventListener("dom-ready", () => {
+    this.$el.addEventListener("dom-ready", () => {
       this.loading = false;
       this.props.switchLoading(false, this.props.url);
       this.show();
     });
 
-    this.$el!.addEventListener("did-fail-load", (event) => {
+    this.$el.addEventListener("did-fail-load", (event) => {
       const {errorDescription} = event;
       const hasConnectivityError =
         SystemUtil.connectivityERR.includes(errorDescription);
@@ -161,11 +161,11 @@ export default class WebView {
       }
     });
 
-    this.$el!.addEventListener("did-start-loading", () => {
+    this.$el.addEventListener("did-start-loading", () => {
       this.props.switchLoading(true, this.props.url);
     });
 
-    this.$el!.addEventListener("did-stop-loading", () => {
+    this.$el.addEventListener("did-stop-loading", () => {
       this.props.switchLoading(false, this.props.url);
     });
   }
@@ -192,12 +192,12 @@ export default class WebView {
       this.$webviewsContainer.add("loaded");
     }
 
-    this.$el!.classList.add("active");
+    this.$el.classList.add("active");
     this.focus();
     this.props.onTitleChange();
     // Injecting preload css in webview to override some css rules
     (async () =>
-      this.$el!.insertCSS(
+      this.$el.insertCSS(
         fs.readFileSync(path.join(__dirname, "/../../css/preload.css"), "utf8"),
       ))();
 
@@ -215,20 +215,20 @@ export default class WebView {
       }
 
       (async () =>
-        this.$el!.insertCSS(
+        this.$el.insertCSS(
           fs.readFileSync(path.resolve(__dirname, customCSS), "utf8"),
         ))();
     }
   }
 
   focus(): void {
-    this.$el!.focus();
+    this.$el.focus();
     // Work around https://github.com/electron/electron/issues/31918
-    this.$el!.shadowRoot?.querySelector("iframe")?.focus();
+    this.$el.shadowRoot?.querySelector("iframe")?.focus();
   }
 
   hide(): void {
-    this.$el!.classList.remove("active");
+    this.$el.classList.remove("active");
   }
 
   load(): void {
@@ -237,17 +237,17 @@ export default class WebView {
 
   zoomIn(): void {
     this.zoomFactor += 0.1;
-    this.$el!.setZoomFactor(this.zoomFactor);
+    this.$el.setZoomFactor(this.zoomFactor);
   }
 
   zoomOut(): void {
     this.zoomFactor -= 0.1;
-    this.$el!.setZoomFactor(this.zoomFactor);
+    this.$el.setZoomFactor(this.zoomFactor);
   }
 
   zoomActualSize(): void {
     this.zoomFactor = 1;
-    this.$el!.setZoomFactor(this.zoomFactor);
+    this.$el.setZoomFactor(this.zoomFactor);
   }
 
   logOut(): void {
@@ -259,12 +259,12 @@ export default class WebView {
   }
 
   openDevTools(): void {
-    this.$el!.openDevTools();
+    this.$el.openDevTools();
   }
 
   back(): void {
-    if (this.$el!.canGoBack()) {
-      this.$el!.goBack();
+    if (this.$el.canGoBack()) {
+      this.$el.goBack();
       this.focus();
     }
   }
@@ -273,7 +273,7 @@ export default class WebView {
     const $backButton = document.querySelector(
       "#actions-container #back-action",
     )!;
-    if (this.$el!.canGoBack()) {
+    if (this.$el.canGoBack()) {
       $backButton.classList.remove("disable");
     } else {
       $backButton.classList.add("disable");
@@ -281,8 +281,8 @@ export default class WebView {
   }
 
   forward(): void {
-    if (this.$el!.canGoForward()) {
-      this.$el!.goForward();
+    if (this.$el.canGoForward()) {
+      this.$el.goForward();
     }
   }
 
@@ -292,13 +292,13 @@ export default class WebView {
     this.$webviewsContainer.remove("loaded");
     this.loading = true;
     this.props.switchLoading(true, this.props.url);
-    this.$el!.reload();
+    this.$el.reload();
   }
 
   send<Channel extends keyof RendererMessage>(
     channel: Channel,
     ...args: Parameters<RendererMessage[Channel]>
   ): void {
-    ipcRenderer.sendTo(this.$el!.getWebContentsId(), channel, ...args);
+    ipcRenderer.sendTo(this.$el.getWebContentsId(), channel, ...args);
   }
 }

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -27,7 +27,6 @@ interface WebViewProps {
   isActive: () => boolean;
   switchLoading: (loading: boolean, url: string) => void;
   onNetworkError: (index: number) => void;
-  nodeIntegration: boolean;
   preload?: string;
   onTitleChange: () => void;
   hasPermission?: (origin: string, permission: string) => boolean;
@@ -59,13 +58,12 @@ export default class WebView {
       <webview
         data-tab-id="${this.props.tabIndex}"
         src="${this.props.url}"
-        ${this.props.nodeIntegration ? html`nodeIntegration` : html``}
         ${this.props.preload === undefined
           ? html``
           : html`preload="${this.props.preload}"`}
         partition="persist:webviewsession"
         webpreferences="
-          contextIsolation=${!this.props.nodeIntegration},
+          contextIsolation,
           spellcheck=${Boolean(
           ConfigUtil.getConfigItem("enableSpellchecker", true),
         )},

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -933,7 +933,7 @@ export class ServerManagerView {
                     if (!(tab instanceof ServerTab)) return false;
                     const webview = await tab.webview;
                     return (
-                      webview.$el.getWebContentsId() === webContentsId &&
+                      webview.webContentsId === webContentsId &&
                       webview.props.hasPermission?.(origin, permission)
                     );
                   }),

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -362,7 +362,7 @@ export class ServerManagerView {
         tabIndex,
         onHover: this.onHover.bind(this, index),
         onHoverOut: this.onHoverOut.bind(this, index),
-        webview: new WebView({
+        webview: WebView.create({
           $root: this.$webviewsContainer,
           index,
           tabIndex,

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -43,6 +43,8 @@ const logger = new Logger({
 const rendererDirectory = path.resolve(__dirname, "..");
 type ServerOrFunctionalTab = ServerTab | FunctionalTab;
 
+const rootWebContents = remote.getCurrentWebContents();
+
 export class ServerManagerView {
   $addServerButton: HTMLButtonElement;
   $tabsContainer: Element;
@@ -364,6 +366,7 @@ export class ServerManagerView {
         onHoverOut: this.onHoverOut.bind(this, index),
         webview: WebView.create({
           $root: this.$webviewsContainer,
+          rootWebContents,
           index,
           tabIndex,
           url: server.url,

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -613,7 +613,7 @@ export class ServerManagerView {
     const webview = await tab.webview;
     const reconnectUtil = new ReconnectUtil(webview);
     reconnectUtil.pollInternetAndReload();
-    await webview.$el!.loadURL(`file://${rendererDirectory}/network.html`);
+    await webview.$el.loadURL(`file://${rendererDirectory}/network.html`);
   }
 
   async activateLastTab(index: number): Promise<void> {
@@ -781,7 +781,7 @@ export class ServerManagerView {
     const tab = this.tabs[tabIndex];
     if (!(tab instanceof ServerTab)) return false;
     const webview = await tab.webview;
-    const url = webview.$el!.src;
+    const url = webview.$el.src;
     return !(url.endsWith("/login/") || webview.loading);
   }
 
@@ -933,7 +933,7 @@ export class ServerManagerView {
                     if (!(tab instanceof ServerTab)) return false;
                     const webview = await tab.webview;
                     return (
-                      webview.$el!.getWebContentsId() === webContentsId &&
+                      webview.$el.getWebContentsId() === webContentsId &&
                       webview.props.hasPermission?.(origin, permission)
                     );
                   }),

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -388,7 +388,6 @@ export class ServerManagerView {
             await this.openNetworkTroubleshooting(index);
           },
           onTitleChange: this.updateBadge.bind(this),
-          nodeIntegration: false,
           preload: "js/preload.js",
         }),
       }),

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -389,7 +389,7 @@ export class ServerManagerView {
           },
           onTitleChange: this.updateBadge.bind(this),
           nodeIntegration: false,
-          preload: true,
+          preload: "js/preload.js",
         }),
       }),
     );

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -818,7 +818,7 @@ export class ServerManagerView {
             await this.activateTab(index);
             const tab = this.tabs[index];
             if (tab instanceof ServerTab)
-              await (await tab.webview).showNotificationSettings();
+              (await tab.webview).showNotificationSettings();
           },
         },
         {
@@ -835,7 +835,7 @@ export class ServerManagerView {
 
   registerIpcs(): void {
     const webviewListeners: Array<
-      [WebviewListener, (webview: WebView) => void | Promise<void>]
+      [WebviewListener, (webview: WebView) => void]
     > = [
       [
         "webview-reload",
@@ -881,14 +881,14 @@ export class ServerManagerView {
       ],
       [
         "log-out",
-        async (webview) => {
-          await webview.logOut();
+        (webview) => {
+          webview.logOut();
         },
       ],
       [
         "show-keyboard-shortcuts",
-        async (webview) => {
-          await webview.showKeyboardShortcuts();
+        (webview) => {
+          webview.showKeyboardShortcuts();
         },
       ],
       [
@@ -904,7 +904,7 @@ export class ServerManagerView {
         const tab = this.tabs[this.activeTabIndex];
         if (tab instanceof ServerTab) {
           const activeWebview = await tab.webview;
-          if (activeWebview) await listener(activeWebview);
+          if (activeWebview) listener(activeWebview);
         }
       });
     }

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1,5 +1,8 @@
-import {clipboard, remote} from "electron";
+import {clipboard} from "electron";
 import path from "path";
+
+import {Menu, app, dialog, session} from "@electron/remote";
+import * as remote from "@electron/remote";
 
 import type {Config} from "../../common/config-util";
 import * as ConfigUtil from "../../common/config-util";
@@ -20,8 +23,6 @@ import {ipcRenderer} from "./typed-ipc-renderer";
 import * as DomainUtil from "./utils/domain-util";
 import * as LinkUtil from "./utils/link-util";
 import ReconnectUtil from "./utils/reconnect-util";
-
-const {session, app, Menu, dialog} = remote;
 
 type WebviewListener =
   | "webview-reload"

--- a/app/renderer/js/pages/about.ts
+++ b/app/renderer/js/pages/about.ts
@@ -1,8 +1,6 @@
-import {remote} from "electron";
+import {app} from "@electron/remote";
 
 import {html} from "../../../common/html";
-
-const {app} = remote;
 
 export class AboutView {
   readonly $view: HTMLElement;

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -1,8 +1,9 @@
 import type {OpenDialogOptions} from "electron";
-import {remote} from "electron";
 import fs from "fs";
 import path from "path";
 
+import * as remote from "@electron/remote";
+import {app, dialog, session} from "@electron/remote";
 import Tagify from "@yaireo/tagify";
 import ISO6391 from "iso-639-1";
 import * as z from "zod";
@@ -16,7 +17,6 @@ import {ipcRenderer} from "../../typed-ipc-renderer";
 
 import {generateSelectHTML, generateSettingOption} from "./base-section";
 
-const {app, dialog, session} = remote;
 const currentBrowserWindow = remote.getCurrentWindow();
 
 interface GeneralSectionProps {

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -1,4 +1,4 @@
-import {remote} from "electron";
+import {dialog} from "@electron/remote";
 
 import {html} from "../../../../common/html";
 import * as t from "../../../../common/translation-util";
@@ -6,8 +6,6 @@ import {generateNodeFromHTML} from "../../components/base";
 import {ipcRenderer} from "../../typed-ipc-renderer";
 import * as DomainUtil from "../../utils/domain-util";
 import * as LinkUtil from "../../utils/link-util";
-
-const {dialog} = remote;
 
 interface NewServerFormProps {
   $root: Element;

--- a/app/renderer/js/pages/preference/server-info-form.ts
+++ b/app/renderer/js/pages/preference/server-info-form.ts
@@ -1,4 +1,4 @@
-import {remote} from "electron";
+import {dialog} from "@electron/remote";
 
 import {html} from "../../../../common/html";
 import * as Messages from "../../../../common/messages";
@@ -7,8 +7,6 @@ import type {ServerConf} from "../../../../common/types";
 import {generateNodeFromHTML} from "../../components/base";
 import {ipcRenderer} from "../../typed-ipc-renderer";
 import * as DomainUtil from "../../utils/domain-util";
-
-const {dialog} = remote;
 
 interface ServerInfoFormProps {
   $root: Element;

--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -1,14 +1,13 @@
 import type {NativeImage} from "electron";
-import {remote} from "electron";
 import path from "path";
+
+import {BrowserWindow, Menu, Tray, nativeImage} from "@electron/remote";
 
 import * as ConfigUtil from "../../common/config-util";
 import type {RendererMessage} from "../../common/typed-ipc";
 
 import type {ServerManagerView} from "./main";
 import {ipcRenderer} from "./typed-ipc-renderer";
-
-const {Tray, Menu, nativeImage, BrowserWindow} = remote;
 
 let tray: Electron.Tray | null = null;
 

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -1,7 +1,7 @@
-import {remote} from "electron";
 import fs from "fs";
 import path from "path";
 
+import {app, dialog} from "@electron/remote";
 import {JsonDB} from "node-json-db";
 import {DataError} from "node-json-db/dist/lib/Errors";
 import * as z from "zod";
@@ -11,8 +11,6 @@ import Logger from "../../../common/logger-util";
 import * as Messages from "../../../common/messages";
 import type {ServerConf} from "../../../common/types";
 import {ipcRenderer} from "../typed-ipc-renderer";
-
-const {app, dialog} = remote;
 
 const logger = new Logger({
   file: "domain-util.log",

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -53,10 +53,4 @@
       </div>
     </div>
   </body>
-
-  <script>
-    // we don't use src='./js/main' in the script tag because
-    // it messes up require module path resolution
-    require("./js/main");
-  </script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,10 @@
         }
       }
     },
+    "@electron/remote": {
+      "version": "github:andersk/electron-remote#9436ea742cf2e7a56780be0a079c6a490ff5540d",
+      "from": "github:andersk/electron-remote#2.0.6-fixes"
+    },
     "@electron/universal": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "InstantMessaging"
   ],
   "dependencies": {
+    "@electron/remote": "github:andersk/electron-remote#2.0.6-fixes",
     "@sentry/electron": "^2.5.1",
     "@yaireo/tagify": "^4.5.0",
     "adm-zip": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -288,6 +288,7 @@
               "disallowTypeAnnotations": false
             }
           ],
+          "@typescript-eslint/no-confusing-void-expression": "off",
           "@typescript-eslint/no-redeclare": "error",
           "@typescript-eslint/no-unused-vars": [
             "error",


### PR DESCRIPTION
This is an important security hardening measure that’s been blocked on an upstream Electron bug I filed last year (electron/electron#26904); however, I think I’ve gotten it working with an ugly workaround.

This is still a draft because Spectron doesn’t support context isolation. So I’m also working on migrating the E2E tests from Spectron to Playwright in #1155. That PR seems to pass the E2E tests by itself, but not yet in combination with this one due to an upstream issue that needs further investigation.