### PR TITLE
Padding added between the tooltip and the sidebar, Issue resolved, Fixes #1087

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -155,7 +155,7 @@ body {
 
 .tab {
   position: relative;
-  margin: 2px 0;
+  margin: 2px 2px 0 0;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -174,17 +174,15 @@ body {
 }
 
 .tab .server-tab {
-  width: 100%;
-  height: 35px;
   position: relative;
-  margin-top: 5px;
+  display:flex;
   z-index: 11;
   line-height: 31px;
   color: rgba(238, 238, 238, 1);
   text-align: center;
   overflow: hidden;
   opacity: 0.6;
-  padding: 6px 0;
+  padding: 11px;
 }
 
 .server-tab .alt-icon {
@@ -192,7 +190,7 @@ body {
   font-weight: 600;
   font-size: 22px;
   border: 2px solid rgba(34, 44, 49, 1);
-  margin-left: 17%;
+  margin-left: 37%;
   width: 35px;
   border-radius: 4px;
 }


### PR DESCRIPTION
Fixes #1087 

This PR has added spacing between the tooltip and sidebar like tooltips of setting, reload, dnd and back button

All changes have been made in the main.css file in render folder in apps folder. 

spacing between tooltip and sidebar
![image](https://user-images.githubusercontent.com/75558322/141143117-f22bf650-1118-4fdf-aa84-8b3bd7317016.png)
spacing between sidebar and tooltips of setting,reload,dnd and back button
![image](https://user-images.githubusercontent.com/75558322/141143347-6f09cdab-3a85-4c08-a5da-229264d2386e.png)
Image of site
![image](https://user-images.githubusercontent.com/75558322/141143685-46c83730-c7c7-491f-86b7-46a21c1fa695.png)

This PR has been tested on
- [x] Windows

