### PR TITLE
Main.css updated and padding added

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -155,12 +155,11 @@ body {
 
 .tab {
   position: relative;
-  margin: 2px 2px 0px 0px;
+  margin: 2px 2px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
 }
 
 .tab:first-child {
@@ -185,7 +184,6 @@ body {
   padding: 11px;
 }
 
-div#add-action {}
 
 .server-tab .alt-icon {
   font-family: Verdana, sans-serif;

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -155,7 +155,7 @@ body {
 
 .tab {
   position: relative;
-  margin: 2px 0;
+  margin: 2px 2px 0px 0px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -174,25 +174,25 @@ body {
 }
 
 .tab .server-tab {
-  width: 100%;
-  height: 35px;
   position: relative;
-  margin-top: 5px;
+  display:flex;
   z-index: 11;
   line-height: 31px;
   color: rgba(238, 238, 238, 1);
   text-align: center;
   overflow: hidden;
   opacity: 0.6;
-  padding: 6px 0;
+  padding: 11px;
 }
+
+div#add-action {}
 
 .server-tab .alt-icon {
   font-family: Verdana, sans-serif;
   font-weight: 600;
   font-size: 22px;
   border: 2px solid rgba(34, 44, 49, 1);
-  margin-left: 17%;
+  margin-left: 37%;
   width: 35px;
   border-radius: 4px;
 }


### PR DESCRIPTION
This PR has added spacing between the tooltip and sidebar like tooltips of setting, reload, dnd and back button

All changes have been made in the main.css file in render folder in apps folder.

spacing between tooltip and sidebar
![![image](https://user-images.githubusercontent.com/75558322/142719020-4ddeaead-7607-49f4-9651-e6c6d5d3c66e.png)](https://user-images.githubusercontent.com/75558322/142719012-867c2a2a-2d20-4e91-853b-ecca1622592c.png)

spacing between sidebar and tooltips of setting,reload,dnd and back button
image
![image](https://user-images.githubusercontent.com/75558322/142719020-4ddeaead-7607-49f4-9651-e6c6d5d3c66e.png)
Image of site
![image](https://user-images.githubusercontent.com/75558322/142719032-85e109f7-45e2-4000-89f9-26071b760f1d.png)


This PR has been tested on

 Windows