### PR TITLE
Padding added between tooltip and sidebar, changes made in Main.css

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -155,12 +155,11 @@ body {
 
 .tab {
   position: relative;
-  margin: 2px 0;
+  margin: 2px 2px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
 }
 
 .tab:first-child {
@@ -174,25 +173,24 @@ body {
 }
 
 .tab .server-tab {
-  width: 100%;
-  height: 35px;
   position: relative;
-  margin-top: 5px;
+  display:flex;
   z-index: 11;
   line-height: 31px;
   color: rgba(238, 238, 238, 1);
   text-align: center;
   overflow: hidden;
   opacity: 0.6;
-  padding: 6px 0;
+  padding: 11px;
 }
+
 
 .server-tab .alt-icon {
   font-family: Verdana, sans-serif;
   font-weight: 600;
   font-size: 22px;
   border: 2px solid rgba(34, 44, 49, 1);
-  margin-left: 17%;
+  margin-left: 37%;
   width: 35px;
   border-radius: 4px;
 }


### PR DESCRIPTION
This PR has added spacing between the tooltip and sidebar like tooltips of setting, reload, dnd and back button

All changes have been made in the main.css file in render folder in apps folder.

spacing between tooltip and sidebar
![image](https://user-images.githubusercontent.com/75558322/142719712-4d5c9807-3bb0-46ff-bd2d-49ec708b92ea.png)
spacing between sidebar and tooltips of setting,reload,dnd and back button
![image](https://user-images.githubusercontent.com/75558322/142719724-fa905956-079c-4fc6-9fa6-94d5b8e31211.png)
Image of site
![image](https://user-images.githubusercontent.com/75558322/142719731-87635731-72c5-41ef-8b66-de2e19b19c0c.png)
This PR has been tested on

 Windows