### PR TITLE
Alignment corrected and Subtitle text modified

### DIFF
--- a/app/renderer/css/network.css
+++ b/app/renderer/css/network.css
@@ -17,7 +17,7 @@ body {
 }
 
 #title {
-  text-align: left;
+  text-align: center;
   font-size: 24px;
   font-weight: bold;
   margin: 20px 0;
@@ -25,7 +25,7 @@ body {
 
 #subtitle {
   font-size: 20px;
-  text-align: left;
+  text-align: center;
   margin: 12px 0;
 }
 
@@ -33,25 +33,36 @@ body {
   text-align: left;
   font-size: 16px;
   list-style-position: inside;
+  width: 400px;
+  margin: 0 auto;
 }
 
 #reconnect {
   float: left;
+  -ms-transform: translateX(460%);
+  transform: translateX(460%);
+  margin: 20px;
+  text-align: center;
 }
 
 #settings {
+  margin: 20px;
   margin-left: 116px;
+  -ms-transform: translateX(490%);
+  transform: translateX(490%);
+  text-align: left;
 }
 
 .button {
   font-size: 16px;
   background: rgba(0, 150, 136, 1);
   color: rgba(255, 255, 255, 1);
-  width: 96px;
-  height: 32px;
+  width: 100px;
+  height: 36px;
   border-radius: 5px;
   line-height: 32px;
   cursor: pointer;
+
 }
 
 .button:hover {

--- a/app/renderer/network.html
+++ b/app/renderer/network.html
@@ -15,7 +15,7 @@
     <div id="content">
       <div id="picture"><img src="img/zulip_network.png" /></div>
       <div id="title">We can't connect to this organization</div>
-      <div id="subtitle">This could be because</div>
+      <div id="subtitle">This could be because: </div>
       <ul id="description">
         <li>You're not online or your proxy is misconfigured.</li>
         <li>There is no Zulip organization hosted at this URL.</li>


### PR DESCRIPTION
**What's this PR do?**
This PR improves the reconnect error page by ensuring proper alignment between the Zulip icon, text, and buttons (center alignment has been made). Also, subtitle text has been modified to ensure better readability.
Fixes #862 

**Screenshots?**
![image](https://user-images.githubusercontent.com/75558322/144952263-15e78a4e-fc7e-45e5-8d12-4de7b1c0f69a.png)


**You have tested this PR on:**

- [ ] Windows

