### PR TITLE
tsconfig: Downgrade target to ES2021

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2021",
     "module": "commonjs",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
The ES2022 definition of `Error#cause` conflicts with `@types/verror`.