### PR TITLE
WebView: Enable allowpopups

### DIFF
--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -71,6 +71,7 @@ export default class WebView {
           ? html``
           : html`preload="${props.preload}"`}
         partition="persist:webviewsession"
+        allowpopups
       >
       </webview>
     `;


### PR DESCRIPTION
This is required for Electron ≥ 15 to continue invoking our new window handler (`handleExternalLink`), following the `nativeWindowOpen` migration.

https://github.com/electron/electron/issues/30886