### PR TITLE
Fix blurry org icons in controls container

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -163,6 +163,8 @@ body {
   width: 35px;
   vertical-align: top;
   border-radius: 4px;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  image-rendering: -webkit-optimize-contrast;
 }
 
 .tab .server-tab {


### PR DESCRIPTION
**What's this PR do?**
Fixes blurry org icons 

**Any background context you want to provide?**
Let me know if the width fix is preferred, but figure fixing without changing the size is a better approach. 

**Screenshots?**
![Screenshot from 2022-04-15 13-17-24](https://user-images.githubusercontent.com/1620062/163628406-ce6b1d2d-feec-41b2-adec-14be115daa23.png)
![Screenshot from 2022-04-15 13-14-14](https://user-images.githubusercontent.com/1620062/163628412-09397327-792f-4699-801e-60382419ad64.png)
![Screenshot from 2022-04-15 12-09-15](https://user-images.githubusercontent.com/1620062/163628414-137f95f1-b096-4000-92de-60849804e1f5.png)


**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu
- [ ] macOS
