### PR TITLE
Fix autocomplete url

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -263,6 +263,7 @@ label.setting-input-value:focus-within {
 }
 
 .setting-input-add-server {
+  width: 34ch;
   color: rgb(34 44 49 / 100%);
 }
 

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -238,12 +238,37 @@ img.server-info-icon {
   max-width: 450px;
 }
 
-.setting-input-value:focus {
+.setting-input-value:focus,
+label.setting-input-value:focus-within {
   border: rgb(78 191 172 / 100%) 2px solid;
 }
 
 .invalid-input-value:focus {
   border: rgb(239 83 80 / 100%) 2px solid;
+}
+
+.setting-input-add-server,
+.add-server-domain,
+.server-url-size-calc {
+  outline: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  float: left;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+  background: inherit;
+}
+
+.setting-input-add-server {
+  color: rgb(34 44 49 / 100%);
+}
+
+.server-url-size-calc {
+  visibility: hidden;
+  height: 0;
 }
 
 .manual-proxy-block {

--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -258,13 +258,16 @@ label.setting-input-value:focus-within {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
-  color: inherit;
+  color: rgb(34 44 49 / 100%);
   background: inherit;
 }
 
 .setting-input-add-server {
   width: 34ch;
-  color: rgb(34 44 49 / 100%);
+}
+
+.setting-input-add-server:focus + .add-server-domain {
+  color: inherit;
 }
 
 .server-url-size-calc {

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -111,6 +111,7 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
     }
   });
   $newServerUrl.addEventListener("input", async () => {
+    $newServerUrl.value = $newServerUrl.value.trim();
     const url = $newServerUrl.value;
     $urlSizeCalc.textContent = url;
     $newServerUrl.style.width = `${$urlSizeCalc.offsetWidth}px`;

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -60,7 +60,9 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
     $saveServerButton.textContent = "Connecting...";
     let serverConf;
     try {
-      serverConf = await DomainUtil.checkDomain($newServerUrl.value.trim());
+      serverConf = await DomainUtil.checkDomain(
+        await autoComplete($newServerUrl.value.trim()),
+      );
     } catch (error: unknown) {
       $saveServerButton.textContent = "Connect";
       await dialog.showMessageBox({
@@ -76,6 +78,17 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
 
     await DomainUtil.addDomain(serverConf);
     onChange();
+  }
+
+  async function autoComplete(url: string): Promise<string> {
+    const pattern = /^[a-zA-Z\d-]*$/;
+    let serverUrl = url.trim();
+
+    if (pattern.test(serverUrl)) {
+      serverUrl = "https://" + serverUrl + ".zulipchat.com";
+    }
+
+    return serverUrl;
   }
 
   $saveServerButton.addEventListener("click", async () => {

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -22,7 +22,6 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
             class="setting-input-add-server"
             autofocus
             placeholder="your-organization.zulipchat.com"
-            style="width: 34ch"
           />
           <span class="add-server-domain"></span>
           <span class="server-url-size-calc"></span>

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -17,11 +17,16 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
     <div class="server-input-container">
       <div class="title">${t.__("Organization URL")}</div>
       <div class="add-server-info-row">
-        <input
-          class="setting-input-value"
-          autofocus
-          placeholder="your-organization.zulipchat.com or zulip.your-organization.com"
-        />
+        <label class="setting-input-value">
+          <input
+            class="setting-input-add-server"
+            autofocus
+            placeholder="your-organization.zulipchat.com"
+            style="width: 34ch"
+          />
+          <span class="add-server-domain"></span>
+          <span class="server-url-size-calc"></span>
+        </label>
       </div>
       <div class="server-center">
         <button id="connect">${t.__("Connect")}</button>
@@ -53,8 +58,15 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
   $root.textContent = "";
   $root.append($newServerForm);
   const $newServerUrl: HTMLInputElement = $newServerForm.querySelector(
-    "input.setting-input-value",
+    "input.setting-input-add-server",
   )!;
+  const $serverDomain: HTMLSpanElement = $newServerForm.querySelector(
+    "span.add-server-domain",
+  )!;
+  const $urlSizeCalc: HTMLSpanElement = $newServerForm.querySelector(
+    "span.server-url-size-calc",
+  )!;
+  const urlValidationPattern = /^[a-zA-Z\d-]*$/;
 
   async function submitFormHandler(): Promise<void> {
     $saveServerButton.textContent = "Connecting...";
@@ -98,6 +110,15 @@ export function initNewServerForm({$root, onChange}: NewServerFormProps): void {
     if (event.key === "Enter") {
       await submitFormHandler();
     }
+  });
+  $newServerUrl.addEventListener("input", async () => {
+    const url = $newServerUrl.value;
+    $urlSizeCalc.textContent = url;
+    $newServerUrl.style.width = `${$urlSizeCalc.offsetWidth}px`;
+
+    $serverDomain.textContent = urlValidationPattern.test(url)
+      ? ".zulipchat.com"
+      : "";
   });
 
   // Open create new org link in default browser


### PR DESCRIPTION
---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**

Add auto complete domain when adding a new server, similar UX to the mobile apps when adding a new server. 

Fixes #1012 

**Any background context you want to provide?**

This is my first implementation and I anticipate that this could be farther improved. My main goal was to keep this logic in the scope of the new-server-form. I suspect this could be better implemented in a separate module

**Screenshots**
![zulip-autocomplete-domain](https://user-images.githubusercontent.com/3621543/163942895-67e5ce42-93b4-4af6-ab35-3d9ab440070f.gif)

**You have tested this PR on:**

- [ ] Windows
- [ ] Linux/Ubuntu
- [x] macOS
