### PR TITLE
Adding basic rpm build

### DIFF
--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -47,4 +47,4 @@ npm run pack
 npm run dist
 ```
 
-It will start the packaging process. The ready for distribution file (e.g. dmg, windows installer, deb package) will be outputted to the `dist` directory.
+It will start the packaging process. The ready for distribution file (e.g. dmg, windows installer, deb package, rpm package) will be outputted to the `dist` directory.

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -16,7 +16,7 @@
 
 ## - All the installer i.e.
 
-- Linux (.deb, AppImage)
+- Linux (.deb, .rpm, AppImage)
 - Mac - (.dmg)
 - Windows - (web installer for 32/64bit)
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
       "description": "Zulip Desktop Client for Linux",
       "target": [
         "deb",
+        "rpm",
         "tar.xz",
         "AppImage",
         "snap"
@@ -97,6 +98,11 @@
         "./packaging/deb-apt.asc=/etc/apt/trusted.gpg.d/zulip-desktop.asc",
         "./packaging/deb-release-upgrades.cfg=/etc/update-manager/release-upgrades.d/zulip-desktop.cfg"
       ]
+    },
+    "rpm": {
+      "packageCategory": "net",
+      "synopsis": "Zulip Desktop App",
+      "afterInstall": "./packaging/rpm-after-install.sh"
     },
     "snap": {
       "synopsis": "Zulip Desktop App"

--- a/packaging/rpm-after-install.sh
+++ b/packaging/rpm-after-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Link to the binary
+ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
+
+# SUID chrome-sandbox for Electron 5+
+chmod 4755 '/opt/${productFilename}/chrome-sandbox' || true
+
+update-mime-database /usr/share/mime || true
+update-desktop-database /usr/share/applications || true
+
+# Clean up configuration for old Bintray repository
+rm -f /etc/apt/zulip.list


### PR DESCRIPTION
**What's this PR do?**
Adds a rpm build target to electron-builder

**Any background context you want to provide?**
Fixes #1139 
**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu
- [x] macOS
