### PR TITLE
Upgrade electron to final v18 release, especially for Wayland support on Linux.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/requestidlecallback": "^0.3.4",
         "@types/yaireo__tagify": "^4.3.2",
         "dotenv": "^16.0.0",
-        "electron": "^18.3.7",
+        "electron": "^18.3.15",
         "electron-builder": "^23.0.3",
         "electron-notarize": "^1.0.0",
         "eslint-import-resolver-typescript": "^2.4.0",
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.7.tgz",
-      "integrity": "sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==",
+      "version": "18.3.15",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.15.tgz",
+      "integrity": "sha512-frkBt8skyo8SmlG4TbByDxZw6/tqttRYYIBaeTBfkoG18OyD59IVwVaXXHO8UYKB5/1C2Rce0Gj6uoxlAHQHzQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -12324,9 +12324,9 @@
       }
     },
     "electron": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.7.tgz",
-      "integrity": "sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==",
+      "version": "18.3.15",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.15.tgz",
+      "integrity": "sha512-frkBt8skyo8SmlG4TbByDxZw6/tqttRYYIBaeTBfkoG18OyD59IVwVaXXHO8UYKB5/1C2Rce0Gj6uoxlAHQHzQ==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^16.11.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/requestidlecallback": "^0.3.4",
         "@types/yaireo__tagify": "^4.3.2",
         "dotenv": "^16.0.0",
-        "electron": "^18.0.1",
+        "electron": "^18.3.7",
         "electron-builder": "^23.0.3",
         "electron-notarize": "^1.0.0",
         "eslint-import-resolver-typescript": "^2.4.0",
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.0.tgz",
-      "integrity": "sha512-AN+CKalzA57beuvuI90PVgW/yj6zjw7rpb1h8FvIwBJ3toDC3x0Plfzbzh4Ondecbjci7pSg/NA5ngOk804WIQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.7.tgz",
+      "integrity": "sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -12324,9 +12324,9 @@
       }
     },
     "electron": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.0.tgz",
-      "integrity": "sha512-AN+CKalzA57beuvuI90PVgW/yj6zjw7rpb1h8FvIwBJ3toDC3x0Plfzbzh4Ondecbjci7pSg/NA5ngOk804WIQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.7.tgz",
+      "integrity": "sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^16.11.26",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@types/requestidlecallback": "^0.3.4",
     "@types/yaireo__tagify": "^4.3.2",
     "dotenv": "^16.0.0",
-    "electron": "^18.3.7",
+    "electron": "^18.3.15",
     "electron-builder": "^23.0.3",
     "electron-notarize": "^1.0.0",
     "eslint-import-resolver-typescript": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@types/requestidlecallback": "^0.3.4",
     "@types/yaireo__tagify": "^4.3.2",
     "dotenv": "^16.0.0",
-    "electron": "^18.0.1",
+    "electron": "^18.3.7",
     "electron-builder": "^23.0.3",
     "electron-notarize": "^1.0.0",
     "eslint-import-resolver-typescript": "^2.4.0",


### PR DESCRIPTION
**What's this PR do?**

Manually branched from zulip/zulip-desktop#1245 to update Electron to the [final version of the v18 series](https://github.com/electron/electron/releases/tag/v18.3.15), which Dependabot did not automatically pick up.
    
Notably, this upgrade includes [native Wayland support on Linux](https://github.com/electron/electron/releases/tag/v18.3.8), which is particularly useful to avoid fuzzy nearest-neighbor scaling of XWayland apps in some Wayland compositors (see my screenshots below).

**Screenshots?**

Currently-published `Zulip-5.9.3-x86_64.AppImage` on swaywm/sway v1.7, 1080p monitor scaled 125%. Note the blurry nearest-neighbor upscaling that occurs due to XWayland apps not understanding HiDPI in this environment:

![screenshot-2022-12-01-00:27:53Z](https://user-images.githubusercontent.com/799439/204937143-eb430432-e441-4a23-b0d5-4b5371909bb7.png)

After applying this patch and running `npm ci && npm run dist`, the resulting AppImage on the same setup supports Wayland natively (as confirmed by not seeing `[XWayland]` in my title bar, and by the DPI awareness the Chromium renderer exhibits). While it's subtle in the screenshots (less so if you focus on the octopus in the topic header...), the fonts and images are noticeably crisper, and the difference on my physical display is noteworthy 😃 

![screenshot-2022-12-01-00:27:12Z](https://user-images.githubusercontent.com/799439/204937275-0efe5cc1-c69b-4529-9d73-2c50782f7aed.png)

I manually spliced `~/.local/share/applications/Zulip.desktop` to provide the appropriate Ozone CLI flags; I'm not sure where to provide those as a default to new installs (or actually, I might have hand-written this file anyway, I'm not sure Zulip provides one... it's been a few weeks so I don't really remember).

```
[Desktop Entry]
Type=Application
Name=Zulip
Exec="/home/j/src/zulip/desktop/dist/Zulip-5.9.3-x86_64.AppImage" --ozone-platform-hint=auto %u
Icon=Zulip
Comment=
Terminal=false
Categories=Communication;
MimeType=x-scheme-handler/zulip;
```

**You have tested this PR on:**

- [ ] Windows
- [X] Linux (Void Linux glibc)
- [ ] macOS
