### PR TITLE
Update installation instructions for macOS

### DIFF
--- a/how-to-install.md
+++ b/how-to-install.md
@@ -7,7 +7,7 @@
 
 [lr]: https://github.com/zulip/zulip-desktop/releases
 
-## OS X
+## macOS
 
 **DMG or zip**:
 
@@ -17,7 +17,7 @@
 
 **Using brew**:
 
-1. Run `brew cask install zulip` in your terminal
+1. Run `brew install --cask zulip` in your terminal
 2. The app will be installed in your `Applications`
 3. Done! The app will update automatically (you can also use `brew update && brew upgrade zulip`)
 


### PR DESCRIPTION
**What's this PR do?**

Update the installation instructions for macOS, in particular the `brew cask install ...` command, which has been replaced with `brew install --cask ...` in more recent versions of Homebrew.