### PR TITLE
Added progress bar for electron

### DIFF
--- a/app/main/handle-external-link.ts
+++ b/app/main/handle-external-link.ts
@@ -1,5 +1,6 @@
 import {shell} from "electron/common";
 import type {
+  BrowserWindow,
   HandlerDetails,
   SaveDialogOptions,
   WebContents,
@@ -104,6 +105,7 @@ export default function handleExternalLink(
   contents: WebContents,
   details: HandlerDetails,
   mainContents: WebContents,
+  win: BrowserWindow,
 ): void {
   let url: URL;
   try {
@@ -118,22 +120,37 @@ export default function handleExternalLink(
   );
 
   if (isUploadsUrl(new URL(contents.getURL()).origin, url)) {
+    let currProgress = 0;
+    let interval = 0.5;
+    const progressInterval = setInterval(() => {
+      win.setProgressBar(currProgress);
+      if (currProgress < 1) {
+        currProgress += interval;
+        interval /= 2;
+      }
+    }, 1000);
     downloadFile({
       contents,
       url: url.href,
       downloadPath,
       async completed(filePath: string, fileName: string) {
+        win.setProgressBar(1);
+        clearInterval(progressInterval);
         const downloadNotification = new Notification({
           title: "Download Complete",
           body: `Click to show ${fileName} in folder`,
           silent: true, // We'll play our own sound - ding.ogg
         });
+        shell.showItemInFolder(filePath);
         downloadNotification.on("click", () => {
           // Reveal file in download folder
           shell.showItemInFolder(filePath);
         });
         downloadNotification.show();
-
+        setTimeout(() => {
+          downloadNotification.close();
+          win.setProgressBar(-1);
+        }, 3000);
         // Play sound to indicate download complete
         if (!ConfigUtil.getConfigItem("silent", false)) {
           send(mainContents, "play-ding-sound");

--- a/app/main/handle-external-link.ts
+++ b/app/main/handle-external-link.ts
@@ -35,6 +35,7 @@ function downloadFile({
 }) {
   contents.downloadURL(url);
   contents.session.once("will-download", async (_event: Event, item) => {
+    const totalFileSize = item.getTotalBytes();
     if (ConfigUtil.getConfigItem("promptDownload", false)) {
       const showDialogOptions: SaveDialogOptions = {
         defaultPath: path.join(downloadPath, item.getFilename()),
@@ -63,9 +64,8 @@ function downloadFile({
     }
 
     let currProgress = 0;
-    let interval = 0.5;
     const progressInterval = setInterval(() => {
-      win.setProgressBar(currProgress);
+      win.setProgressBar(currProgress / totalFileSize);
     }, 1000);
 
     const updatedListener = (_event: Event, state: string): void => {
@@ -87,11 +87,7 @@ function downloadFile({
             break;
           }
 
-          if (currProgress < 1) {
-            interval /= 2;
-          }
-
-          currProgress += interval;
+          currProgress = item.getReceivedBytes();
           break;
         }
 

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -179,7 +179,7 @@ function createMainWindow(): BrowserWindow {
 
   app.on("web-contents-created", (_event: Event, contents: WebContents) => {
     contents.setWindowOpenHandler((details) => {
-      handleExternalLink(contents, details, page);
+      handleExternalLink(contents, details, page, mainWindow);
       return {action: "deny"};
     });
   });

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -191,7 +191,7 @@ export class ServerManagerView {
       },
       downloadsPath: `${app.getPath("downloads")}`,
       quitOnClose: false,
-      promptDownload: false,
+      promptDownload: true,
     };
 
     // Platform specific settings


### PR DESCRIPTION
* Added progress on the icon to show progress of files downloaded.
* Dialog box for asking file location is switched on by default.
* File location where the file is downloaded is opened by default.

---

**What's this PR do?**
This PR is in reference to #1252 , where the user gets no notification about the file downloaded. This is currently Work in Progress, as it requires a review. 

**Any background context you want to provide?**
I used electron's native progress-bar to show the progress made on downloading. Since I didn't have the size of files downloaded, I used kind of a "hacky" way to deal out of it. 
If i could get the progress of how much file is being downloaded (i.e x MB/ y MB) format, I can show a real-time progress bar

Also this is currently below the

**Screenshots?**
It currently looks like this
<img width="87" alt="Screenshot 2023-01-21 at 02 58 00" src="https://user-images.githubusercontent.com/93476421/213808525-0b2a0d21-244d-43e9-97e4-3a2929640a92.png">


**I have tested this PR on:**

- [ ] Windows
- [ ] Linux/Ubuntu
- [x] macOS

Future: I'm looking for external packages in TypeScript, which provides a progress-bar in the UI, so i can render a component on the screen itself. 