### PR TITLE
webview: Remove did-navigate workaround

### DIFF
--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -56,11 +56,9 @@ export default class WebView {
     ) as HTMLElement;
     props.$root.append($element);
 
-    // Wait for did-navigate rather than did-attach to work around
-    // https://github.com/electron/electron/issues/31918
     await new Promise<void>((resolve) => {
       $element.addEventListener(
-        "did-navigate",
+        "did-attach",
         () => {
           resolve();
         },


### PR DESCRIPTION
The Electron bug seems to have been fixed upstream. Meanwhile, the workaround had been causing the app to hang if it can’t connect to an organization at startup.