### PR TITLE
Remove third party certificate modal popups

### DIFF
--- a/app/common/domain-util.ts
+++ b/app/common/domain-util.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import * as Sentry from "@sentry/electron";
+import {JsonDB} from "node-json-db";
+import {app, dialog} from "zulip:remote";
+
+import Logger from "./logger-util.js";
+
+const logger = new Logger({
+  file: "common-domain-util.log",
+});
+
+export function getDomainDb(): JsonDB {
+  const domainJsonPath = path.join(
+    app.getPath("userData"),
+    "config/domain.json",
+  );
+  try {
+    const file = fs.readFileSync(domainJsonPath, "utf8");
+    JSON.parse(file);
+  } catch (error: unknown) {
+    if (fs.existsSync(domainJsonPath)) {
+      fs.unlinkSync(domainJsonPath);
+      dialog.showErrorBox(
+        "Error saving new organization",
+        "There seems to be error while saving new organization, " +
+          "you may have to re-add your previous organizations back.",
+      );
+      logger.error("Error while JSON parsing domain.json: ");
+      logger.error(error);
+      Sentry.captureException(error);
+    }
+  }
+
+  return new JsonDB(domainJsonPath, true, true);
+}

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -1,12 +1,9 @@
-import fs from "node:fs";
-import path from "node:path";
-
-import {app, dialog} from "@electron/remote";
 import * as Sentry from "@sentry/electron";
-import {JsonDB} from "node-json-db";
+import type {JsonDB} from "node-json-db";
 import {DataError} from "node-json-db/dist/lib/Errors";
 import * as z from "zod";
 
+import {getDomainDb} from "../../../common/domain-util.js";
 import * as EnterpriseUtil from "../../../common/enterprise-util.js";
 import Logger from "../../../common/logger-util.js";
 import * as Messages from "../../../common/messages.js";
@@ -153,29 +150,8 @@ export async function updateSavedServer(
   }
 }
 
-function reloadDb(): void {
-  const domainJsonPath = path.join(
-    app.getPath("userData"),
-    "config/domain.json",
-  );
-  try {
-    const file = fs.readFileSync(domainJsonPath, "utf8");
-    JSON.parse(file);
-  } catch (error: unknown) {
-    if (fs.existsSync(domainJsonPath)) {
-      fs.unlinkSync(domainJsonPath);
-      dialog.showErrorBox(
-        "Error saving new organization",
-        "There seems to be error while saving new organization, " +
-          "you may have to re-add your previous organizations back.",
-      );
-      logger.error("Error while JSON parsing domain.json: ");
-      logger.error(error);
-      Sentry.captureException(error);
-    }
-  }
-
-  db = new JsonDB(domainJsonPath, true, true);
+function reloadDb() {
+  db = getDomainDb();
 }
 
 export function formatUrl(domain: string): string {


### PR DESCRIPTION
---

**What's this PR do?**
This fixes the issue #1119 

**Any background context you want to provide?**
This popup occurs constantly throughout the day while using Zulip for myself and all of my coworkers. The popup modal overlays all other system windows and usually pops up multiple times in a row, sometimes jumping between screens (just for added terror 🙃 )

As discussed in the issue, the popup should occur if there is a certificate issue with the server domain of the organization. However for any other third party URL, such as thumbnails, the popups are not necessary.

**Screenshots?**
Please see the screenshots shared in the linked issue

**You have tested this PR on:**

- [ ] Windows
- [ ] Linux/Ubuntu
- [x] macOS