### PR TITLE
Fix Organization logo not updating in the sidebar

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1072,13 +1072,18 @@ export class ServerManagerView {
         await Promise.all(
           DomainUtil.getDomains().map(async (domain, index) => {
             if (domain.url.includes(serverURL)) {
-              const localIconUrl: string = await DomainUtil.saveServerIcon(
-                iconURL,
+              const localIconUrl: string = path.resolve(
+                await DomainUtil.saveServerIcon(iconURL),
               );
               const serverImgsSelector = ".tab .server-icons";
               const serverImgs: NodeListOf<HTMLImageElement> =
                 document.querySelectorAll(serverImgsSelector);
-              serverImgs[index].src = localIconUrl;
+              serverImgs[
+                index
+              ].src = `data:application/octet-stream;base64,${fs.readFileSync(
+                localIconUrl,
+                "base64",
+              )}`;
               domain.icon = localIconUrl;
               DomainUtil.updateDomain(index, domain);
             }


### PR DESCRIPTION
---

<!--
Remove the fields that are not appropriate
Please include:
-->

## Fix #1256

when you update the organization logo it was not loading because of wrong `icon.src` config so I changed it to update the icon the same way it does when you first open the app



**You have tested this PR on:**

- [x] Windows
- [ ] Linux/Ubuntu
- [ ] macOS
