### PR TITLE
Fixes #1087

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -357,6 +357,10 @@ webview.focus {
   right: 68px;
 }
 
+span#add-server-tooltip {
+  margin-left: 4px;
+}
+
 #add-server-tooltip,
 .server-tooltip {
   font-family: arial, sans-serif;


### PR DESCRIPTION
Added 4px margin between add-server-tooltip and sidebar

---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes #1087 by adding a left margin to span#add-server-tooltip.

**Screenshots?**
<img width="482" alt="image" src="https://user-images.githubusercontent.com/66767648/226839067-adf8bdc9-91e4-4940-9726-8262eff13170.png">


**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu (WSL - Windows Subsystem for Linux)
- [ ] macOS
