### PR TITLE
settings: Fixed spellchecker language selection

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -372,6 +372,7 @@ img.server-info-icon {
   margin: 6px;
 }
 
+.note,
 #note {
   font-size: 10px;
 }
@@ -742,21 +743,12 @@ i.open-network-button {
 
 .lang-menu {
   font-size: 13px;
+  padding-left: 6px;
+  padding-right: 6px;
   font-weight: bold;
   background: rgb(78 191 172 / 100%);
   width: 100px;
   height: 38px;
   color: rgb(255 255 255 / 100%);
   border-color: rgb(0 0 0 / 0%);
-}
-
-/* stylelint-disable-next-line selector-class-pattern */
-.tagify__input {
-  min-width: 130px !important;
-}
-
-/* stylelint-disable-next-line selector-class-pattern */
-.tagify__input::before {
-  top: 0;
-  bottom: 0;
 }


### PR DESCRIPTION
---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixed issue #1286 

**Any background context you want to provide?**
I noticed using Tagify on the input fields makes the section behave in a weird manner.

So in [f2972c0](https://github.com/zulip/zulip-desktop/pull/1290/commits/f2972c0800b1b5c35361eb4a3da7491ee92f79f0) I replaced it with a drop-down list of system-available language spellcheckers for users to select from without having to guess or input the wrong spellcheck language hereby making it easier for users to obviously know the list of available/supported languages to pick from thereby improving the user experience on the platform.

**Screenshots?**
![spellchecker_image](https://user-images.githubusercontent.com/41521163/228079402-2cbd3067-8cf3-40c7-8d77-992e9a542a6d.PNG)

**You have tested this PR on:**

- [x] Windows
- [ ] Linux/Ubuntu
- [ ] macOS
