### PR TITLE
Fixes #1187: Cannot close the app from full screen mode on macOS

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -110,7 +110,14 @@ function createMainWindow(): BrowserWindow {
       event.preventDefault();
 
       if (process.platform === "darwin") {
-        app.hide();
+        if (win.isFullScreen()) {
+          win.setFullScreen(false);
+          win.once("leave-full-screen", () => {
+            app.hide();
+          });
+        } else {
+          app.hide();
+        }
       } else {
         win.hide();
       }


### PR DESCRIPTION
---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Fixes #1187. App was not closing at fullscreen mode at macOS. Changed the behavior for windows to leave fullscreen and then hide itself for macOS when pressed close button as many applications do so.

**Any background context you want to provide?**


**Screenshots?**
![ezgif-4-f031ceac53](https://user-images.githubusercontent.com/94247411/229111761-9f9ef7e2-dd5b-44e7-b42c-6576790fb4ab.gif)


**You have tested this PR on:**

- [ ] Windows
- [ ] Linux/Ubuntu
- [x] macOS
