### PR TITLE
preload: Drop compatibility code for Zulip Server < 4.0

### DIFF
--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -7,61 +7,15 @@ import {ipcRenderer} from "./typed-ipc-renderer.js";
 contextBridge.exposeInMainWorld("raw_electron_bridge", electron_bridge);
 
 ipcRenderer.on("logout", () => {
-  if (bridgeEvents.emit("logout")) {
-    return;
-  }
-
-  // Create the menu for the below
-  const dropdown: HTMLElement = document.querySelector(".dropdown-toggle")!;
-  dropdown.click();
-
-  const nodes: NodeListOf<HTMLElement> = document.querySelectorAll(
-    ".dropdown-menu li:last-child a",
-  );
-  nodes[nodes.length - 1].click();
+  bridgeEvents.emit("logout");
 });
 
 ipcRenderer.on("show-keyboard-shortcuts", () => {
-  if (bridgeEvents.emit("show-keyboard-shortcuts")) {
-    return;
-  }
-
-  // Create the menu for the below
-  const node: HTMLElement = document.querySelector(
-    "a[data-overlay-trigger=keyboard-shortcuts]",
-  )!;
-  // Additional check
-  if (node.textContent!.trim().toLowerCase() === "keyboard shortcuts (?)") {
-    node.click();
-  } else {
-    // At least click the dropdown
-    const dropdown: HTMLElement = document.querySelector(".dropdown-toggle")!;
-    dropdown.click();
-  }
+  bridgeEvents.emit("show-keyboard-shortcuts");
 });
 
 ipcRenderer.on("show-notification-settings", () => {
-  if (bridgeEvents.emit("show-notification-settings")) {
-    return;
-  }
-
-  // Create the menu for the below
-  const dropdown: HTMLElement = document.querySelector(".dropdown-toggle")!;
-  dropdown.click();
-
-  const nodes: NodeListOf<HTMLElement> = document.querySelectorAll(
-    ".dropdown-menu li a",
-  );
-  nodes[2].click();
-
-  const notificationItem: NodeListOf<HTMLElement> = document.querySelectorAll(
-    ".normal-settings-list li div",
-  );
-
-  // Wait until the notification dom element shows up
-  setTimeout(() => {
-    notificationItem[2].click();
-  }, 100);
+  bridgeEvents.emit("show-notification-settings");
 });
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
The server was updated in zulip/zulip@bfd9999cf874e506592fda254dfe0fe06b5b2738 (`4.0-rc1~2192`) to expose a proper API for this functionality, so we don’t need to trigger fake click events to access it.