### PR TITLE
Upgrade dependencies, including Electron 25.2.0.

### DIFF
--- a/app/main/handle-external-link.ts
+++ b/app/main/handle-external-link.ts
@@ -1,5 +1,6 @@
 import {shell} from "electron/common";
 import type {
+  Event,
   HandlerDetails,
   SaveDialogOptions,
   WebContents,

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -1,5 +1,5 @@
 import {clipboard} from "electron/common";
-import type {IpcMainEvent, WebContents} from "electron/main";
+import type {Event, IpcMainEvent, WebContents} from "electron/main";
 import {BrowserWindow, app, dialog, powerMonitor, session} from "electron/main";
 import {Buffer} from "node:buffer";
 import crypto from "node:crypto";

--- a/app/renderer/js/components/context-menu.ts
+++ b/app/renderer/js/components/context-menu.ts
@@ -1,5 +1,5 @@
 import {clipboard} from "electron/common";
-import type {WebContents} from "electron/main";
+import type {Event, WebContents} from "electron/main";
 import type {
   ContextMenuParams,
   MenuItemConstructorOptions,

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1,4 +1,5 @@
 import {clipboard} from "electron/common";
+import type {Event} from "electron/main";
 import path from "node:path";
 import process from "node:process";
 import url from "node:url";

--- a/app/renderer/js/pages/preference/preference.ts
+++ b/app/renderer/js/pages/preference/preference.ts
@@ -1,3 +1,4 @@
+import type {Event} from "electron/common";
 import process from "node:process";
 
 import type {DndSettings} from "../../../../common/dnd-util.js";

--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -1,4 +1,4 @@
-import type {NativeImage} from "electron/common";
+import type {Event, NativeImage} from "electron/common";
 import {nativeImage} from "electron/common";
 import type {Tray as ElectronTray} from "electron/main";
 import path from "node:path";

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "auto-launch": "^5.0.5",
         "backoff": "^2.5.0",
         "dotenv": "^16.0.0",
-        "electron": "^24.2.0",
+        "electron": "^25.2.0",
         "electron-builder": "^23.0.3",
         "electron-log": "^4.3.5",
         "electron-updater": "^5.0.1",
@@ -3185,9 +3185,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.2.0.tgz",
-      "integrity": "sha512-fEYAftYqFhveniWJbEHXjNMWjooFFIuqNj/eEFJkGzycInfBJq/c4E/dew++s6s0YLubxFnjoF2qZiqapLj0gA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
+      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "auto-launch": "^5.0.5",
     "backoff": "^2.5.0",
     "dotenv": "^16.0.0",
-    "electron": "^24.2.0",
+    "electron": "^25.2.0",
     "electron-builder": "^23.0.3",
     "electron-log": "^4.3.5",
     "electron-updater": "^5.0.1",


### PR DESCRIPTION
I thought this would fix #1315, but it did not. Hopefully the contribution will still be useful.

The `Event` type now has to be manually imported from electron, as it is mistakenly picked up from Node in the newest version. This is the only meaningful change in the zulip client.

Test plan:
```
$ npm test

> zulip@5.10.0 test
> tsc && npm run lint-html && npm run lint-css && npm run lint-js && npm run prettier-non-js

> zulip@5.10.0 lint-html
> htmlhint "app/**/*.html"

   Config loaded: /home/pounce/programming/zulip-desktop/.htmlhintrc

Scanned 4 files, no errors found (13 ms).

> zulip@5.10.0 lint-css
> stylelint "app/**/*.css"

> zulip@5.10.0 lint-js
> xo

> zulip@5.10.0 prettier-non-js
> prettier --check --loglevel=warn . "!**/*.{js,ts}"
```

---

<!--
Remove the fields that are not appropriate
Please include:
-->

**What's this PR do?**
Upgrades electron

**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu
- [ ] macOS
