### PR TITLE
Settings: improved visibility of text and buttons

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -381,6 +381,10 @@ img.server-info-icon {
   margin: 6px;
 }
 
+.setting-description {
+  color: rgb(34 34 34 / 100%);
+}
+
 #note {
   font-size: 10px;
 }
@@ -459,7 +463,7 @@ i.open-tab-button {
 }
 
 .disallowed:hover {
-  background-color: rgb(241 241 241 / 100%);
+  background-color: rgb(153 153 153 / 100%);
   cursor: not-allowed;
 }
 
@@ -467,7 +471,7 @@ input.toggle-round + label {
   padding: 2px;
   width: 50px;
   height: 25px;
-  background-color: rgb(221 221 221 / 100%);
+  background-color: rgb(136 136 136 / 100%);
   border-radius: 25px;
 }
 
@@ -482,7 +486,7 @@ input.toggle-round + label::after {
 }
 
 input.toggle-round + label::before {
-  background-color: rgb(241 241 241 / 100%);
+  background-color: rgb(153 153 153 / 100%);
   border-radius: 25px;
   inset: 0;
 }


### PR DESCRIPTION
**What's this PR do?**
Improves text and button visibility in settings page as reported in #1357 


**Screenshots?**
Old:
![image](https://github.com/zulip/zulip-desktop/assets/45175270/47bd30e2-74de-4b79-b0e8-7a3ee107a085)


New:
![image](https://github.com/zulip/zulip-desktop/assets/45175270/a0520cc0-beda-4f5a-b693-e797bd0cfbbc)


**You have tested this PR on:**

- [ ] Windows
- [x] Linux/Ubuntu
- [ ] macOS
