### PR TITLE
Use arch=amd64 in APT sources to avoid warnings on multiarch systems.

### DIFF
--- a/how-to-install.md
+++ b/how-to-install.md
@@ -60,7 +60,7 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 69AD12704E71A4803DCA3A6
 - Add the repo to your apt source list :
 
 ```bash
-echo "deb https://download.zulip.com/desktop/apt stable main" |
+echo "deb [arch=amd64] https://download.zulip.com/desktop/apt stable main" |
   sudo tee -a /etc/apt/sources.list.d/zulip.list
 ```
 

--- a/packaging/deb-apt.list
+++ b/packaging/deb-apt.list
@@ -1,1 +1,1 @@
-deb https://download.zulip.com/desktop/apt stable main
+deb [arch=amd64] https://download.zulip.com/desktop/apt stable main


### PR DESCRIPTION
I do development for various architectures, so I have my Ubuntu system set up to use [multiarch](https://wiki.debian.org/Multiarch). Since Zulip does not specify an architecture in its APT sources, I get this during `apt update`:

```
N: Skipping acquire of configured file 'main/binary-ppc64el/Packages' as repository 'https://download.zulip.com/desktop/apt stable InRelease' doesn't support architecture 'ppc64el'
N: Skipping acquire of configured file 'main/binary-armhf/Packages' as repository 'https://download.zulip.com/desktop/apt stable InRelease' doesn't support architecture 'armhf'
N: Skipping acquire of configured file 'main/binary-s390x/Packages' as repository 'https://download.zulip.com/desktop/apt stable InRelease' doesn't support architecture 's390x'
N: Skipping acquire of configured file 'main/binary-arm64/Packages' as repository 'https://download.zulip.com/desktop/apt stable InRelease' doesn't support architecture 'arm64'
N: Skipping acquire of configured file 'main/binary-riscv64/Packages' as repository 'https://download.zulip.com/desktop/apt stable InRelease' doesn't support architecture 'riscv64'
```

The fix is simply to set `[arch=amd64]` so APT knows to only fetch packages for that architecture instead of all enabled architectures.

See also: https://github.com/zulip/zulip/pull/30310