### PR TITLE
Replace Travis CI badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zulip Desktop Client
 
-[![Build Status](https://travis-ci.com/zulip/zulip-desktop.svg?branch=main)](https://travis-ci.com/github/zulip/zulip-desktop)
+[![Build Status](https://github.com/zulip/zulip-desktop/actions/workflows/node.js.yml/badge.svg)](https://github.com/zulip/zulip-desktop/actions/workflows/node.js.yml?query=branch%3Amain)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/zulip/zulip-desktop?branch=main&svg=true)](https://ci.appveyor.com/project/zulip/zulip-desktop/branch/main)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org)


### PR DESCRIPTION
Travis CI was replaced with GitHub Actions in this project, and the [current badge][1] appears broken, and the [project link][2] shows an error:

> This is not an active repository

Since this PR doesn't update any code, we can [skip ci] to save resources.

[1]: https://travis-ci.com/zulip/zulip-desktop.svg?branch=main
[2]: https://travis-ci.com/github/zulip/zulip-desktop

---

**What's this PR do?**

Updates badge from Travis CI to GitHub Actions.

**Any background context you want to provide?**

Self-evident, I think.

**Screenshots?**

Even better, here's a live preview!

Current, i.e., before my change (yes, it's actually broken):

> [![Build Status](https://travis-ci.com/zulip/zulip-desktop.svg?branch=main)](https://travis-ci.com/github/zulip/zulip-desktop)

After my change:

> [![Build Status](https://github.com/zulip/zulip-desktop/actions/workflows/node.js.yml/badge.svg)](https://github.com/zulip/zulip-desktop/actions/workflows/node.js.yml?query=branch%3Amain)