### PR TITLE
1087 issue: Update main.css in renderer directory, left has been changed to 60px in server-tooltip

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -396,7 +396,7 @@ webview.focus {
 .server-tooltip {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
-  left: 56px;
+  left: 60px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;


### PR DESCRIPTION
**The changes are tested on Ubuntu.**
**The zulip-desktop version is 5.8.1.**

**You have tested this PR on:**

- [x] Windows
- [x] Linux/Ubuntu
