### PR TITLE
Exposing Whitelisted Protocols to User Settings

### DIFF
--- a/app/common/config-schemata.ts
+++ b/app/common/config-schemata.ts
@@ -36,6 +36,7 @@ export const configSchemata = {
   useManualProxy: z.boolean(),
   useProxy: z.boolean(),
   useSystemProxy: z.boolean(),
+  whitelistedProtocols: z.string().array(),
 };
 
 export const enterpriseConfigSchemata = {

--- a/app/common/config-schemata.ts
+++ b/app/common/config-schemata.ts
@@ -36,6 +36,7 @@ export const configSchemata = {
   useManualProxy: z.boolean(),
   useProxy: z.boolean(),
   useSystemProxy: z.boolean(),
+  whitelistedProtocols: z.string().array(),
 };
 export type ConfigSchemata = typeof configSchemata;
 

--- a/app/common/config-util.ts
+++ b/app/common/config-util.ts
@@ -49,6 +49,28 @@ export function getConfigItem<Key extends keyof Config>(
   }
 }
 
+// The function getConfigItem stores the default in settings.json which means that
+// if the defaults change in the future, that change will not be propagated
+// to anyone having a pre-installed desktop app. We should phase out getConfigItem
+// in favour of this function and rename this to getConfigItem when it is done
+// for all existing occurences.
+export function getConfigItemWithoutSettingDefault<Key extends keyof Config>(
+  key: Key,
+  defaultValue: Config[Key],
+): z.output<ConfigSchemata[Key]> {
+  if (isConfigItemExists(key)) {
+    const typedSchemata: {
+      [Key in keyof Config]: z.ZodType<
+        z.output<ConfigSchemata[Key]>,
+        z.input<ConfigSchemata[Key]>
+      >;
+    } = configSchemata; // https://github.com/colinhacks/zod/issues/5154
+    return typedSchemata[key].parse(database.getObject<unknown>(`/${key}`));
+  }
+
+  return defaultValue;
+}
+
 // This function returns whether a key exists in the configuration file (settings.json)
 export function isConfigItemExists(key: string): boolean {
   try {
@@ -86,6 +108,7 @@ function reloadDatabase(): void {
     app.getPath("userData"),
     "/config/settings.json",
   );
+  console.log(settingsJsonPath);
   try {
     const file = fs.readFileSync(settingsJsonPath, "utf8");
     JSON.parse(file);

--- a/app/common/link-util.ts
+++ b/app/common/link-util.ts
@@ -3,11 +3,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import * as ConfigUtil from "./config-util.ts";
 import {Html, html} from "./html.ts";
 import * as t from "./translation-util.ts";
 
+const whitelistedProtocols = ConfigUtil.getConfigItemWithoutSettingDefault(
+  "whitelistedProtocols",
+  ["http:", "https:", "mailto:", "tel:", "sip:"],
+);
+
 export async function openBrowser(url: URL): Promise<void> {
-  if (["http:", "https:", "mailto:"].includes(url.protocol)) {
+  if (whitelistedProtocols.includes(url.protocol)) {
     await shell.openExternal(url.href);
   } else {
     // For security, indirect links to non-whitelisted protocols

--- a/app/common/link-util.ts
+++ b/app/common/link-util.ts
@@ -3,11 +3,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import * as ConfigUtil from "./config-util.ts";
 import {Html, html} from "./html.ts";
 import * as t from "./translation-util.ts";
 
+/* Fetches the current protocolLaunchers from settings.json */
+const whitelistedProtocols = ConfigUtil.getConfigItem("whitelistedProtocols", [
+  "http:",
+  "https:",
+  "mailto:",
+  "tel:",
+  "sip:",
+]);
+
 export async function openBrowser(url: URL): Promise<void> {
-  if (["http:", "https:", "mailto:"].includes(url.protocol)) {
+  if (whitelistedProtocols.includes(url.protocol)) {
     await shell.openExternal(url.href);
   } else {
     // For security, indirect links to non-whitelisted protocols

--- a/docs/howto/customize-link-protocols.md
+++ b/docs/howto/customize-link-protocols.md
@@ -1,0 +1,35 @@
+# Customizing link protocols
+
+The Zulip app supports opening certain link protocols directly in their associated system applications. These are known as **whitelisted protocols**.
+
+## Default whitelisted protocols
+
+By default, the following protocols are whitelisted:
+
+```
+http, https, mailto, tel, sip
+```
+
+Links using these protocols are opened directly by the system.
+
+All other protocols are considered potentially unsafe and are therefore opened indirectly—through a local HTML file in your default web browser.
+
+## Extending the whitelisted protocols
+
+It is possible to customize the list of whitelisted protocols by editing the `settings.json` file located at: `userdata/Zulip/config/settings.json`
+
+To modify the list, the `whitelistedProtocols` key can be updated. For example:
+
+```json
+{
+    ...
+    "whitelistedProtocols": [
+        "http:",
+        "https:",
+        "mailto:"
+    ]
+    ...
+}
+```
+
+Note: Each protocol should include the trailing (:), e.g., "mailto:" instead of "mailto".

--- a/docs/howto/customize-link-protocols.md
+++ b/docs/howto/customize-link-protocols.md
@@ -1,0 +1,35 @@
+# Customizing Link Protocols
+
+The Zulip app supports opening certain link protocols directly in their associated system applications. These are known as **whitelisted protocols**.
+
+## Default Whitelisted Protocols
+
+By default, the following protocols are whitelisted:
+
+```
+http https mailto tel sip
+```
+
+Links using these protocols are opened directly by the system.
+
+All other protocols are considered potentially unsafe and are therefore opened indirectly—through a local HTML file—in your default web browser.
+
+## Extending the Whitelisted Protocols
+
+It is possible to customize the list of whitelisted protocols by editing the `settings.json` file located at: `userdata/Zulip/config/settings.json`
+
+To add or modify the list, the `whitelistedProtocols` key can be updated. For example:
+
+```json
+{
+    ...
+    "whitelistedProtocols": [
+        "http:",
+        "https:",
+        "mailto:"
+    ]
+    ...
+}
+```
+
+Note: Each protocol should include the trailing colon (:), e.g., "mailto:" instead of "mailto".


### PR DESCRIPTION
**What's this PR do?**

It exposes the whitelisted protocols list so users can add additional protocols that should not use the link wrapper. 
Adresses Issue: #1284

**You have tested this PR on:**

- [x] Windows
- [x] Linux/Ubuntu