### PR TITLE
Fixed : No spacing between tooltips of organizations #1087

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -397,6 +397,7 @@ webview.focus {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
   left: 56px;
+  margin-left: 4px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
**Issue** : #1087 
**Zulip Desktop App Version** : 5.12.0
Fixes: <!-- Issue link, or clear description.-->
Fixed the space between "Add Organization" Button and its tooltip.
Spacing is same as other buttons like settings, reload, dnd and back.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Before** 
![image](https://github.com/user-attachments/assets/abec505e-303f-4a19-bb5e-91d725da0efe)

![image](https://github.com/user-attachments/assets/99f38fa7-e4a6-4fe2-96ce-650802d506dc)

**After**
![image](https://github.com/user-attachments/assets/4d804750-1dc0-42ff-9948-a768ab22c13b)

![image](https://github.com/user-attachments/assets/320fe124-0d01-424c-b129-291216d84866)

**Platforms this PR was tested on:**

- [x] Windows
- [ ] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
