### PR TITLE
Feature/dnd duration dropdown

### DIFF
--- a/app/common/config-schemata.ts
+++ b/app/common/config-schemata.ts
@@ -8,6 +8,7 @@ export const dndSettingsSchemata = {
 
 export const configSchemata = {
   ...dndSettingsSchemata,
+  dndExpiration: z.number().nullable().default(null),
   appLanguage: z.string().nullable(),
   autoHideMenubar: z.boolean(),
   autoUpdate: z.boolean(),

--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -69,7 +69,12 @@ export type RendererMessage = {
     autoHideMenubar: boolean,
     updateMenu: boolean,
   ) => void;
-  "toggle-dnd": (state: boolean, newSettings: Partial<DndSettings>) => void;
+  "toggle-dnd-request": (duration?: number) => void;
+  "toggle-dnd": (
+    state: boolean,
+    newSettings: Partial<DndSettings>,
+    duration?: number,
+  ) => void;
   "toggle-sidebar": (show: boolean) => void;
   "toggle-silent": (state: boolean) => void;
   "toggle-tray": (state: boolean) => void;

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -18,6 +18,7 @@ import * as remoteMain from "@electron/remote/main";
 import windowStateKeeper from "electron-window-state";
 
 import * as ConfigUtil from "../common/config-util.js";
+import * as DNDUtil from "../common/dnd-util.js";
 import {bundlePath, bundleUrl, publicPath} from "../common/paths.js";
 import * as t from "../common/translation-util.js";
 import type {RendererMessage} from "../common/typed-ipc.js";
@@ -48,6 +49,7 @@ let badgeCount: number;
 
 let isQuitting = false;
 
+let dndRevertTimeout: NodeJS.Timeout | null = null;
 // Load this file in main window
 const mainUrl = new URL("app/renderer/main.html", bundleUrl).href;
 
@@ -407,6 +409,29 @@ function createMainWindow(): BrowserWindow {
       listener: Channel,
       ...parameters: Parameters<RendererMessage[Channel]>
     ) => {
+      if (listener === "toggle-dnd-request") {
+        const [duration] = parameters as [number?];
+        const result = DNDUtil.toggle();
+        send(_event.sender, "toggle-dnd", result.dnd, result.newSettings);
+
+        if (result.dnd && duration && !Number.isNaN(duration)) {
+          if (dndRevertTimeout) clearTimeout(dndRevertTimeout);
+
+          dndRevertTimeout = setTimeout(
+            () => {
+              const revert = DNDUtil.toggle();
+              send(_event.sender, "toggle-dnd", revert.dnd, revert.newSettings);
+            },
+            duration * 60 * 1000,
+          );
+        } else if (dndRevertTimeout) {
+          clearTimeout(dndRevertTimeout);
+          dndRevertTimeout = null;
+        }
+
+        return;
+      }
+
       send(page, listener, ...parameters);
     },
   );

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -386,6 +386,31 @@ webview.focus {
   font-size: 14px;
 }
 
+.dnd-dropdown {
+  position: absolute;
+  left: 60px;
+  background-color: rgb(32 33 36 / 100%); /* closer to Zulip's sidebars */
+  border: 1px solid rgb(60 60 60 / 100%);
+  border-radius: 8px;
+  color: rgb(240 240 240 / 100%);
+  z-index: 1000;
+  padding: 4px 0;
+  font-size: 13px;
+  font-family: arial, sans-serif;
+  min-width: 150px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
+}
+
+.dnd-dropdown-item {
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.dnd-dropdown-item:hover {
+  background-color: rgb(60 60 60 / 100%);
+}
+
 #loading-tooltip::after,
 #dnd-tooltip::after,
 #back-tooltip::after,

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1215,6 +1215,23 @@ window.addEventListener("load", async () => {
               >${t.__("Do Not Disturb")}</span
             >
           </div>
+          <div id="dnd-dropdown" class="dnd-dropdown hidden">
+            <div class="dnd-dropdown-item" data-minutes="30">
+              ${t.__("30 minutes")}
+            </div>
+            <div class="dnd-dropdown-item" data-minutes="60">
+              ${t.__("1 hour")}
+            </div>
+            <div class="dnd-dropdown-item" data-minutes="180">
+              ${t.__("3 hours")}
+            </div>
+            <div class="dnd-dropdown-item" data-minutes="720">
+              ${t.__("12 hours")}
+            </div>
+            <div class="dnd-dropdown-item" data-minutes="forever">
+              ${t.__("Until I resume")}
+            </div>
+          </div>
           <div class="action-button hidden" id="reload-action">
             <i class="material-icons md-48">refresh</i>
             <span id="reload-tooltip" style="display: none"


### PR DESCRIPTION
Added drop down menu for users to enable Do Not Disturb (DND) mode for a selectable duration, after which the app will automatically restore the original notification settings.

First had the logic in the dnd-util.ts. Got this working, but wanted to handle the dnd-toggle request logic in app/main/index.ts to better follow Zulip's contribuiting guide.

We listen for our LeftSidebarEvents() & dndButton EventListener() aka our renderer to send a message to our ipcMain.on() in app/main/index.ts. This is where we now handle the logic and send message back to the renderer with the new parameters.

Had some small UI issues, with modal overlays covering things. Was able to fix. Tested functionality with numerous test cases, logging results to console. Haven't found an edge case that breaks the code.

Feel free to comment on style or content within the dropdown.

This is my first open source contribution. Please bare with me. Thanks!


Fixes: (https://github.com/zulip/zulip-desktop/issues/561)


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/b87ad203-c8e0-4cb1-90ab-725e56fa1a0d)
![issue#561](https://github.com/user-attachments/assets/0b780340-1515-42f0-a156-2380369a5986)


**Platforms this PR was tested on:**

- [x] Windows
- [ ] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
