### PR TITLE
settings: Make Do not disturb icon brigther when it's on. 

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -114,12 +114,12 @@ body {
 }
 
 .action-button i {
-  color: rgb(108 133 146 / 100%);
+  color: hsl(200.53deg 14.96% 49.8%);
   font-size: 28px;
 }
 
 .action-button:hover i {
-  color: rgb(152 169 179 / 100%);
+  color: hsl(202.22deg 15.08% 64.9%);
 }
 
 .action-button.active {

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -122,6 +122,14 @@ body {
   color: hsl(202.22deg 15.08% 64.9%);
 }
 
+.action-button > .dnd-on {
+  color: hsl(200.53deg 14.96% 85%);
+}
+
+.action-button:hover > .dnd-on {
+  color: hsl(202.22deg 15.08% 95%);
+}
+
 .action-button.active {
   /* background-color: rgba(255, 255, 255, 0.25); */
   background-color: rgb(239 239 239 / 100%);

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -798,9 +798,14 @@ export class ServerManagerView {
   toggleDndButton(alert: boolean): void {
     this.$dndTooltip.textContent =
       (alert ? "Disable" : "Enable") + " Do Not Disturb";
-    this.$dndButton.querySelector("i")!.textContent = alert
-      ? "notifications_off"
-      : "notifications";
+    const $dndIcon = this.$dndButton.querySelector("i")!;
+    $dndIcon.textContent = alert ? "notifications_off" : "notifications";
+
+    if (alert) {
+      $dndIcon.classList.add("dnd-on");
+    } else {
+      $dndIcon.classList.remove("dnd-on");
+    }
   }
 
   async isLoggedIn(tabIndex: number): Promise<boolean> {


### PR DESCRIPTION
It was not so obvious to users when they were in DND mode, making the icon brigther when in DND mode hopes to address that.
https://chat.zulip.org/#narrow/channel/101-design/topic/zulip-desktop.20DND.20icon.20contrast

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| ---- | ----- |
| <img width="1097" alt="before_dnd" src="https://github.com/user-attachments/assets/221c8b50-f82f-4d28-9354-60e3be84144d" /> | <img width="1097" alt="after_dnd" src="https://github.com/user-attachments/assets/24f5667d-3f04-474d-a034-e64c8f5cba84" /> |
| <img width="1098" alt="before_dnd_hover" src="https://github.com/user-attachments/assets/dc812b43-4f1d-4e90-8d33-d873fdfb3cd8" /> |  <img width="1097" alt="after_dnd_hover" src="https://github.com/user-attachments/assets/4dd8c0c5-ae33-4dab-8eda-592309d2645a" /> |




**Platforms this PR was tested on:**

- [ ] Windows
- [x] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
