### PR TITLE
Fix: add spacing between organization tooltip and sidebar

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -404,7 +404,7 @@ webview.focus {
 .server-tooltip {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
-  left: 56px;
+  margin-left: 48px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;
@@ -424,7 +424,7 @@ webview.focus {
   border-right: 8px solid rgb(34 44 49 / 100%);
   position: absolute;
   top: 10px;
-  left: -5px;
+  left: -6px;
 }
 
 #collapse-button {


### PR DESCRIPTION
Fixes: Tooltip spacing issue for organization/add organization button in the sidebar. Previously, the tooltip was flush against the sidebar. This fix adds spacing so that it aligns consistently with tooltips for other sidebar buttons like Settings, DND, Back, and Reload.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->





**Platforms this PR was tested on:**

- [x] Linux (Ubuntu-based)
- [ ] Windows
- [x] macOS

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>