### PR TITLE
Fix tooltip spacing

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -404,7 +404,7 @@ webview.focus {
 .server-tooltip {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
-  margin-left: 48px;
+  left: calc(54px + 6px); /* Sidebar width + spacing */
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -404,7 +404,7 @@ webview.focus {
 .server-tooltip {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
-  left: 56px;
+  margin-left: 48px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;
@@ -424,7 +424,7 @@ webview.focus {
   border-right: 8px solid rgb(34 44 49 / 100%);
   position: absolute;
   top: 10px;
-  left: -5px;
+  left: -6px;
 }
 
 #collapse-button {


### PR DESCRIPTION
**Fixes:** Tooltip spacing issue for **organization/add organization** button in the sidebar.  
Previously, the tooltip was **flush against the sidebar**, unlike other sidebar buttons (e.g., Settings, DND, Back, Reload).  
This PR introduces proper spacing so that the tooltip now aligns **consistently** with others, improving visual coherence and user experience.

---

### 📸 Before vs. After

| Before (tooltip flush) | After (proper spacing) |
|------------------------|------------------------|
| ![Before Tooltip](https://github.com/user-attachments/assets/4f2563df-ce26-49c4-81d3-dbe2fdd2e5c3) | ![After Tooltip](https://github.com/user-attachments/assets/d3aef6f9-5ded-4fdc-9a2a-b5d0da51b952) |

---

### 🧪 Platforms this PR was tested on:

- [x] Linux (Ubuntu-based)
- [x] Linux (Arch)
- [ ] Windows
- [x] macOS

---

<details>
<summary>🧠 Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (e.g., variable names, readability, minimal duplication).
- [x] Clearly explains differences from previous behavior (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Flags any remaining decisions, assumptions, or concerns.
- [x] Automated tests verify logic where appropriate.

🧩 **Commit discipline:**

- [x] Each commit represents a coherent change.
- [x] Commit messages explain the reasoning and motivation for the changes.

🧪 **Manual review and testing includes:**

- [x] Visual appearance of the fix.
- [x] Responsiveness and internationalization.
- [x] Tooltip behavior and string correctness.
- [x] End-to-end interaction of relevant buttons.
- [x] Corner cases, error conditions, and potential edge bugs.

</details>

---


