### PR TITLE
release: New release v5.12.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Zulip desktop app are documented in this file.
 
+### v5.12.2 --2025-09-01
+
+**Fixes**:
+
+- Corrected broken translations in Chinese (simplified), Finnish, German, Greek, and Tamil that crashed the app.
+
 ### v5.12.1 --2025-08-29
 
 **Enhancements**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zulip",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zulip",
-      "version": "5.12.1",
+      "version": "5.12.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zulip",
   "productName": "Zulip",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "main": "./dist-electron/index.cjs",
   "description": "Zulip Desktop App",
   "license": "Apache-2.0",


### PR DESCRIPTION
### v5.12.2 --2025-09-01

**Fixes**:

- Corrected broken translations in Chinese (simplified), Finnish, German, Greek, and Tamil that crashed the app.
