### PR TITLE
Enable fullscreen video on macOS

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -961,20 +961,22 @@ export class ServerManagerView {
         permissionCallbackId: number,
       ) => {
         const grant =
-          webContentsId === null
-            ? origin === "null" && permission === "notifications"
-            : (
-                await Promise.all(
-                  this.tabs.map(async (tab) => {
-                    if (!(tab instanceof ServerTab)) return false;
-                    const webview = await tab.webview;
-                    return (
-                      webview.webContentsId === webContentsId &&
-                      webview.properties.hasPermission?.(origin, permission)
-                    );
-                  }),
-                )
-              ).some(Boolean);
+          permission === "fullscreen"
+            ? true
+            : webContentsId === null
+              ? origin === "null" && permission === "notifications"
+              : (
+                  await Promise.all(
+                    this.tabs.map(async (tab) => {
+                      if (!(tab instanceof ServerTab)) return false;
+                      const webview = await tab.webview;
+                      return (
+                        webview.webContentsId === webContentsId &&
+                        webview.properties.hasPermission?.(origin, permission)
+                      );
+                    }),
+                  )
+                ).some(Boolean);
         console.log(
           grant ? "Granted" : "Denied",
           "permissions request for",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15134,9 +15134,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Problem
On macOS, videos embedded in Zulip Desktop could not enter fullscreen mode. 
This was caused by the app’s permission handler not explicitly granting the `fullscreen` permission.

### Solution
Updated the `ipcRenderer.on("permission-request")` handler to grant `fullscreen` permission in addition to existing ones (e.g., notifications).  
This ensures video players and other elements can properly request fullscreen.

Fixes: #1409

Screen Capture:-

https://github.com/user-attachments/assets/e3ee63aa-3a76-47e3-9053-586e20ab2e90


Embedding Check:-

https://github.com/user-attachments/assets/4faff2a4-3533-45e7-8435-7261469dd7bf

Platforms Tested
 - [ ] Windows
 - [x] macOS
 - [ ] Linux
 
 Self-review checklist
 - [x] Code changes are minimal and scoped to permission handling.

  - [x] Commit message explains the fix clearly.

  - [x] Verified fullscreen works on macOS video players (tested on YouTube and Zulip-embedded media).

  - [ ] Tested on Windows/Linux to confirm no regressions.