### PR TITLE
download: Show in-app notification on downlaoding a file.

### DIFF
--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -13,6 +13,7 @@ export type MainMessage = {
   "realm-icon-changed": (serverURL: string, iconURL: string) => void;
   "realm-name-changed": (serverURL: string, realmName: string) => void;
   "reload-full-app": () => void;
+  "show-downloaded-file-in-folder": (downloadId: string) => void;
   "save-last-tab": (index: number) => void;
   "switch-server-tab": (index: number) => void;
   "toggle-app": () => void;
@@ -59,6 +60,11 @@ export type RendererMessage = {
   "reload-proxy": (showAlert: boolean) => void;
   "reload-viewer": () => void;
   "render-taskbar-icon": (messageCount: number) => void;
+  "show-download-success": (
+    title: string,
+    description: string,
+    downloadId: string,
+  ) => void;
   "set-active": () => void;
   "set-idle": () => void;
   "show-keyboard-shortcuts": () => void;

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -1,4 +1,4 @@
-import {clipboard} from "electron/common";
+import {clipboard, shell} from "electron/common";
 import {
   BrowserWindow,
   type IpcMainEvent,
@@ -25,7 +25,9 @@ import type {MenuProperties} from "../common/types.ts";
 
 import {appUpdater, shouldQuitForUpdate} from "./autoupdater.ts";
 import * as BadgeSettings from "./badge-settings.ts";
-import handleExternalLink from "./handle-external-link.ts";
+import handleExternalLink, {
+  getDownloadedFilePath,
+} from "./handle-external-link.ts";
 import * as AppMenu from "./menu.ts";
 import {_getServerSettings, _isOnline, _saveServerIcon} from "./request.ts";
 import {sentryInit} from "./sentry.ts";
@@ -451,6 +453,13 @@ function createMainWindow(): BrowserWindow {
       send(page, "update-realm-icon", serverURL, iconURL);
     },
   );
+
+  ipcMain.on("show-downloaded-file-in-folder", (_event, downloadId: string) => {
+    const filePath = getDownloadedFilePath(downloadId);
+    if (filePath !== undefined) {
+      shell.showItemInFolder(filePath);
+    }
+  });
 
   ipcMain.on("save-last-tab", (_event, index: number) => {
     ConfigUtil.setConfigItem("lastActiveTab", index);

--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -103,6 +103,13 @@ bridgeEvents.addEventListener("realm_icon_url", (event) => {
   );
 });
 
+bridgeEvents.addEventListener("show-downloaded-file-in-folder", (event) => {
+  const [downloadId] = z
+    .tuple([z.string()])
+    .parse(z.instanceof(BridgeEvent).parse(event).arguments_);
+  ipcRenderer.send("show-downloaded-file-in-folder", downloadId);
+});
+
 // Set user as active and update the time of last activity
 ipcRenderer.on("set-active", () => {
   idle = false;

--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -18,6 +18,19 @@ ipcRenderer.on("show-notification-settings", () => {
   bridgeEvents.dispatchEvent(new BridgeEvent("show-notification-settings"));
 });
 
+ipcRenderer.on(
+  "show-download-success",
+  (_event, title: string, description: string, downloadId: string) => {
+    bridgeEvents.dispatchEvent(
+      new BridgeEvent("show-download-success", [
+        title,
+        description,
+        downloadId,
+      ]),
+    );
+  },
+);
+
 window.addEventListener("load", () => {
   if (!location.href.includes("app/renderer/network.html")) {
     return;


### PR DESCRIPTION
Fixes #1371.
We do not accept a filePath from the web app when recieving the event to show the file in a folder, since that could introduce securithy vulnerabilies. We store the latest downloaded file path instead in a variable. Only one in-app notification is active at a time, so storing the latest file path is enough for out use case.

To test this PR, run a zulip server that runs the branch on https://github.com/zulip/zulip/pull/36408 and add it to the zulip desktop app running on this PR. Upload a file and download it to test.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="354" height="77" alt="Screenshot 2025-11-06 at 3 14 14 PM" src="https://github.com/user-attachments/assets/71fbe61a-d4f4-4aa2-bfab-de282eb9993e" />
<img width="292" height="63" alt="Screenshot 2025-11-06 at 3 04 50 PM" src="https://github.com/user-attachments/assets/8a75aeef-51de-468e-890c-1e62918159c4" />



**Platforms this PR was tested on:**

- [ ] Windows
- [x] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
