### PR TITLE
permissions: Allow fullscreen video requests on macOS

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -395,8 +395,9 @@ export class ServerManagerView {
         role: "server",
         hasPermission: (origin: string, permission: string) =>
           origin === server.url &&
-          permission === "notifications" &&
-          ConfigUtil.getConfigItem("showNotification", true),
+          (permission === "fullscreen" ||
+            (permission === "notifications" &&
+              ConfigUtil.getConfigItem("showNotification", true))),
         isActive: () => index === this.activeTabIndex,
         switchLoading: async (loading: boolean, url: string) => {
           if (loading) {


### PR DESCRIPTION
On macOS, videos embedded in Zulip Desktop could not enter fullscreen mode because the app's permission handler did not explicitly grant fullscreen permissions.

This commit updates the `ipcRenderer.on("permission-request")` handler to include fullscreen, in addition to existing permissions such as notifications. With this change, video players (e.g., YouTube and Zulip-embedded media) can properly request fullscreen.

Tested on macOS to confirm fullscreen now works, and on Windows/Linux to ensure no regressions.

Fixes #1409.

Supersedes #1456 

<!-- Describe your pull request here.-->
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
