### PR TITLE
feat(desktop-sidebar): update sidebar buttons to match web app design

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -153,6 +153,10 @@ body {
   color: rgb(108 133 146 / 100%);
 }
 
+#back-action i {
+  transform: scaleY(-1);
+}
+
 .tab {
   position: relative;
   margin: 2px 0;
@@ -398,6 +402,19 @@ webview.focus {
   position: absolute;
   top: 7px;
   right: 68px;
+}
+#dnd-tooltip {
+  min-width: 220px;
+  max-width: calc(100vw - 80px);
+  width: auto;
+  white-space: nowrap;
+  padding: 6px 12px;
+  box-sizing: border-box;
+  text-align: left;
+}
+#dnd-tooltip::after {
+  left: -8px;
+  right: auto;
 }
 
 #add-server-tooltip,

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -153,10 +153,6 @@ body {
   color: rgb(108 133 146 / 100%);
 }
 
-#back-action i {
-  transform: scaleY(-1);
-}
-
 .tab {
   position: relative;
   margin: 2px 0;
@@ -271,6 +267,10 @@ body {
   text-align: center;
   font-family: sans-serif;
   margin-bottom: 5px;
+}
+
+#back-action i {
+  transform: scaleY(-1);
 }
 
 .refresh {
@@ -403,6 +403,7 @@ webview.focus {
   top: 7px;
   right: 68px;
 }
+
 #dnd-tooltip {
   min-width: 220px;
   max-width: calc(100vw - 80px);
@@ -412,6 +413,7 @@ webview.focus {
   box-sizing: border-box;
   text-align: left;
 }
+
 #dnd-tooltip::after {
   left: -8px;
   right: auto;

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1207,15 +1207,15 @@ window.addEventListener("load", async () => {
               <i class="material-icons">add</i>
             </div>
             <span id="add-server-tooltip" style="display: none"
-              >${t.__("Add Organization")}</span
+              >${t.__("Add organization")}</span
             >
           </div>
         </div>
         <div id="actions-container">
-          <div class="action-button" id="dnd-action">
-            <i class="material-icons md-48">notifications</i>
-            <span id="dnd-tooltip" style="display: none"
-              >${t.__("Do Not Disturb")}</span
+          <div class="action-button disable" id="back-action">
+            <i class="material-icons md-48">subdirectory_arrow_left</i>
+            <span id="back-tooltip" style="display: none"
+              >${t.__("Go back")}</span
             >
           </div>
           <div class="action-button hidden" id="reload-action">
@@ -1230,10 +1230,10 @@ window.addEventListener("load", async () => {
               >${t.__("Loading")}</span
             >
           </div>
-          <div class="action-button disable" id="back-action">
-            <i class="material-icons md-48">arrow_back</i>
-            <span id="back-tooltip" style="display: none"
-              >${t.__("Go Back")}</span
+          <div class="action-button" id="dnd-action">
+            <i class="material-icons md-48">notifications</i>
+            <span id="dnd-tooltip" style="display: none"
+              >${t.__("Do Not Disturb")}</span
             >
           </div>
           <div class="action-button" id="settings-action">


### PR DESCRIPTION
Fixes #1436.

This PR updates the Zulip Desktop sidebar to match the web app design by reordering action buttons (Back → Reload → Loading → Do Not Disturb → Settings) and fixing the Do Not Disturb tooltip truncation to display full text and back button icone.

Screenshots posted in:  #https://chat.zulip.org/#narrow/channel/101-design/topic/desktop.20app.20buttons.20.23D1436/near/2205662



**Platforms this PR was tested on:
- [x] Windows
- [x] macOS (N/A - not available to test)
- [x] Linux (specify distro) (N/A - not available to test) 