### PR TITLE
Handle mouse back/forward buttons for navigation

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -271,6 +271,28 @@ function createMainWindow(): BrowserWindow {
 
   const page = mainWindow.webContents;
 
+  page.on("before-input-event", (event, input) => {
+    if (input.type !== "mouseUp") {
+      return;
+    }
+
+    if (!("button" in input)) {
+      return;
+    }
+
+    // Mouse back button
+    if (input.button === 3) {
+      void page.executeJavaScript("history.back()");
+      event.preventDefault();
+    }
+
+    // Mouse forward button
+    if (input.button === 4) {
+      void page.executeJavaScript("history.forward()");
+      event.preventDefault();
+    }
+  });
+
   page.on("dom-ready", () => {
     if (ConfigUtil.getConfigItem("startMinimized", false)) {
       mainWindow.hide();


### PR DESCRIPTION
<!-- Describe your pull request here. -->

This PR adds support for mouse side back/forward buttons in Zulip Desktop by mapping Electron before-input-event mouse input to existing webContents navigation, matching standard browser behavior.

Fixes: #1486 

**Screenshots and screen captures:**

Not applicable — this change does not modify the UI.

**Platforms this PR was tested on:**

- [x] Windows
- [ ] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.

**Communicate decisions, questions, and potential concerns.**

- [x] Explains differences from previous plans (e.g., issue description).
  - Mouse side buttons are handled at the Electron main-process level using `before-input-event`, rather than in the renderer, to match native browser behavior.
- [x] Highlights technical choices and bugs encountered.
  - Uses `mouseUp` events to avoid repeated navigation triggers.
  - Relies on standard Electron mouse button codes for back/forward.
- [x] Calls out remaining decisions and concerns.
  - Unable to physically test mouse side buttons locally due to unavailable hardware.
- [ ] Automated tests verify logic where appropriate.

**Individual commits are ready for review.**

- [x] Each commit is a coherent idea.
- [x] Commit message explains reasoning and motivation for the change.

**Completed manual review and testing of the following:**

- [x] End-to-end functionality of navigation logic (`goBack` / `goForward`).
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
