### PR TITLE
Open cross-org link in desktop

### DIFF
--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -23,6 +23,7 @@ export type MainMessage = {
   "update-badge": (messageCount: number) => void;
   "update-menu": (properties: MenuProperties) => void;
   "update-taskbar-icon": (data: string, text: string) => void;
+  "update-org-urls": (urls: string[]) => void;
 };
 
 export type MainCall = {
@@ -78,6 +79,7 @@ export type RendererMessage = {
   "update-realm-icon": (serverURL: string, iconURL: string) => void;
   "update-realm-name": (serverURL: string, realmName: string) => void;
   "webview-reload": () => void;
+  "navigate-to-org-url": (url: string) => void;
   zoomActualSize: () => void;
   zoomIn: () => void;
   zoomOut: () => void;

--- a/app/main/handle-external-link.ts
+++ b/app/main/handle-external-link.ts
@@ -13,6 +13,7 @@ import * as ConfigUtil from "../common/config-util.ts";
 import * as LinkUtil from "../common/link-util.ts";
 import * as t from "../common/translation-util.ts";
 
+import {isConfiguredOrgUrl} from "./org-url-cache.ts";
 import {send} from "./typed-ipc-main.ts";
 
 function isUploadsUrl(server: string, url: URL): boolean {
@@ -159,6 +160,9 @@ export default function handleExternalLink(
         }
       },
     });
+  } else if (isConfiguredOrgUrl(url)) {
+    // URL belongs to a configured organization - navigate there in-app
+    send(mainContents, "navigate-to-org-url", url.href);
   } else {
     (async () => LinkUtil.openBrowser(url))();
   }

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -27,6 +27,7 @@ import {appUpdater, shouldQuitForUpdate} from "./autoupdater.ts";
 import * as BadgeSettings from "./badge-settings.ts";
 import handleExternalLink from "./handle-external-link.ts";
 import * as AppMenu from "./menu.ts";
+import {updateOrgUrls} from "./org-url-cache.ts";
 import {_getServerSettings, _isOnline, _saveServerIcon} from "./request.ts";
 import {sentryInit} from "./sentry.ts";
 import {setAutoLaunch} from "./startup.ts";
@@ -454,6 +455,10 @@ function createMainWindow(): BrowserWindow {
 
   ipcMain.on("save-last-tab", (_event, index: number) => {
     ConfigUtil.setConfigItem("lastActiveTab", index);
+  });
+
+  ipcMain.on("update-org-urls", (_event, urls: string[]) => {
+    updateOrgUrls(urls);
   });
 
   ipcMain.on("focus-this-webview", (event) => {

--- a/app/main/org-url-cache.ts
+++ b/app/main/org-url-cache.ts
@@ -1,0 +1,12 @@
+// Cache of configured organization origins for cross-org link handling
+// This is updated by the renderer process when orgs change
+
+let cachedOrgOrigins: string[] = [];
+
+export function updateOrgUrls(urls: string[]): void {
+  cachedOrgOrigins = urls.map((url) => new URL(url).origin);
+}
+
+export function isConfiguredOrgUrl(url: URL): boolean {
+  return cachedOrgOrigins.includes(url.origin);
+}

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -328,6 +328,8 @@ export class ServerManagerView {
 
   async initTabs(): Promise<void> {
     const servers = DomainUtil.getDomains();
+    // Sync org URLs to main process for cross-org link handling
+    this.syncOrgUrlsToMain();
     if (servers.length > 0) {
       for (const [i, server] of servers.entries()) {
         const tab = this.initServer(server, i);
@@ -487,6 +489,12 @@ export class ServerManagerView {
     const currentIndex = this.tabIndex;
     this.tabIndex++;
     return currentIndex;
+  }
+
+  // Sync configured org URLs to main process for cross-org link handling
+  syncOrgUrlsToMain(): void {
+    const urls = DomainUtil.getDomains().map((server) => server.url);
+    ipcRenderer.send("update-org-urls", urls);
   }
 
   async getCurrentActiveServer(): Promise<string> {
@@ -1007,6 +1015,25 @@ export class ServerManagerView {
 
     ipcRenderer.on("switch-server-tab", async (event, index: number) => {
       await this.activateLastTab(index);
+    });
+
+    ipcRenderer.on("navigate-to-org-url", async (event, urlString: string) => {
+      // Handle cross-organization link navigation, no-op if the url doesn't
+      // point to a connected organization.
+      const url = new URL(urlString);
+      const servers = DomainUtil.getDomains();
+      const orgIndex = servers.findIndex(
+        (s) => new URL(s.url).origin === url.origin,
+      );
+
+      if (orgIndex !== -1) {
+        await this.activateTab(orgIndex);
+        const tab = this.tabs[orgIndex];
+        if (tab instanceof ServerTab) {
+          const webview = await tab.webview;
+          await webview.getWebContents().loadURL(urlString);
+        }
+      }
     });
 
     ipcRenderer.on("open-org-tab", async () => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #1219

Two new IPC messages are introduced to implement this feature:
1. `"update-org-urls": (urls: string[]) => void` in `MainMessage` stores the list of urls for connected organizations. 
2. `"navigate-to-org-url": (url: string) => void` in `RenderMessage` that opens the corresponding tab if the url points to a connected organization. If not, this is a no-op. Uses the list of urls from above to determine whether a url belongs to a connected organization.

These should also help implement #1403.

I'm open to better ways of storing the urls in `update-org-urls`. The current logic of storing the list of urls in a global variable works but I don't program enough in JavaScript to know if this is idiomatic.

Surprising to me the current implementation works in an (imagined) corner case where the link points to an organization that was added after Zulip desktop was started. It seems like `reloadView()` (which calls `updateOrgUrls` through `initTabs`) is called every time a new organization is added? I couldn't find this in the code.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Apologies for the half blank screen and missing cursor, still trying to figure out the situation on Wayland :sweat_smile: 

https://github.com/user-attachments/assets/3355634f-98e5-4f2e-8501-6601eacdce63


**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [x] Linux (specify distro: Solus)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
