### PR TITLE
fix: Enable Wayland support on Linux to resolve fullscreen rendering …

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -37,6 +37,13 @@ import "gatemaker/electron-setup.js"; // eslint-disable-line import-x/no-unassig
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const {GDK_BACKEND} = process.env;
 
+// Enable Wayland support with automatic platform detection on Linux
+// This fixes fullscreen rendering issues on Ubuntu 24.04+ with fractional scaling
+// See: https://github.com/electron/electron/issues/28436
+if (process.platform === "linux") {
+  app.commandLine.appendSwitch("ozone-platform-hint", "auto");
+}
+
 // Initialize sentry for main process
 sentryInit();
 


### PR DESCRIPTION
## Fix fullscreen rendering issues on Ubuntu 24.04+ with Wayland

Add `--ozone-platform-hint=auto` Electron command-line switch for Linux to enable automatic Wayland/X11 platform detection. This fixes fullscreen rendering issues on Ubuntu 24.04+ where:
- The window doesn't fill the screen properly in fullscreen mode
- Window buttons (minimize, maximize, close) appear smaller than expected
- Transparency/rendering artifacts appear at screen edges

<!-- Describe your pull request here.-->

Fixes: Fullscreen rendering issues on Ubuntu 24.04 with fractional scaling and Wayland display server. Related to: https://github.com/electron/electron/issues/28436

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Before: Window doesn't fill screen in fullscreen, buttons appear smaller
- After: Window fills screen correctly, buttons at proper size

**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [x] Linux (Ubuntu 24.04)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

## Technical Details

The `ozone-platform-hint=auto` flag tells Electron/Chromium to automatically detect the display server:
- On **Wayland** sessions: Uses native Wayland rendering
- On **X11** sessions: Uses X11 rendering

This is only applied on Linux (`process.platform === "linux"`) and doesn't affect Windows or macOS builds.