### PR TITLE
Style: Adjust tooltip positioning in `main.css`.

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -374,7 +374,8 @@ webview.focus {
 #setting-tooltip {
   font-family: sans-serif;
   background: rgb(34 44 49 / 100%);
-  margin-left: 48px;
+  margin-left: 0;
+  left: 58px;
   padding: 6px 8px;
   position: absolute;
   margin-top: 0;
@@ -397,14 +398,14 @@ webview.focus {
   border-right: 8px solid rgb(34 44 49 / 100%);
   position: absolute;
   top: 7px;
-  right: 68px;
+  left: -8px;
 }
 
 #add-server-tooltip,
 .server-tooltip {
   font-family: arial, sans-serif;
   background: rgb(34 44 49 / 100%);
-  left: 56px;
+  left: 58px;
   padding: 10px 20px;
   position: fixed;
   margin-top: 11px;
@@ -424,7 +425,7 @@ webview.focus {
   border-right: 8px solid rgb(34 44 49 / 100%);
   position: absolute;
   top: 10px;
-  left: -5px;
+  left: -8px;
 }
 
 #collapse-button {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR aligns the `.server-tooltip` spacing with the other buttons in the sidebar to ensure visual consistency and maintain the application's security boundary.

**Why this fix is important:**
Previously, an older PR (#1465) attempted to fix the tooltip spacing by moving the tooltip entirely to `left: 60px`. As noted by @timabbott, doing so broke the **"Line of Death"** security boundary by pushing the tooltip wholly into the untrusted webview area, opening the possibility for malicious chat content to spoof native tooltips.

This PR implements the correct architectural approach by standardizing the `left` offset of all tooltips to `58px` and the arrow offsets to `-8px`. As a result, the tip of the server tooltip arrow now explicitly overlaps the 54px trusted avatar box boundary by exactly 4 pixels. 

This completely resolves the original author's reported visual inconsistency (#1087) while strictly enforcing the native UI security bounds.

Fixes: #1087

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="1061" height="680" alt="Screenshot from 2026-03-04 21-37-41" src="https://github.com/user-attachments/assets/3e4dd4dc-46f1-46c4-b05b-c6d439db8ffc" />
<img width="1061" height="680" alt="Screenshot from 2026-03-04 21-37-38" src="https://github.com/user-attachments/assets/05c180f1-bfe5-458b-88a0-15dff3a32b2f" />
<img width="1061" height="680" alt="Screenshot from 2026-03-04 21-37-32" src="https://github.com/user-attachments/assets/f9b7c5d7-6419-44f0-9fad-fdd81d125291" />


**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [x] Linux (Ubuntu) <!-- Update this if you're on a different distro! -->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
