### PR TITLE
Autocomplete for new organisation

### DIFF
--- a/app/renderer/css/preference.css
+++ b/app/renderer/css/preference.css
@@ -768,3 +768,38 @@ i.open-network-button {
   z-index: 9999;
   height: 0;
 }
+
+#new-server-url-input {
+  outline: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  float: left;
+  width: 100%;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: rgb(34 44 49 / 100%);
+  background: inherit;
+}
+
+#new-server-url-domain {
+  float: left;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: rgb(125 135 138 / 100%);
+}
+
+#new-server-url-input:focus + #new-server-url-domain {
+  color: rgb(34 44 49 / 100%);
+}
+
+#new-server-url-size-calc {
+  visibility: hidden;
+  height: 0;
+  position: absolute;
+  white-space: pre;
+  font-family: inherit;
+  font-size: inherit;
+}

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -12,6 +12,10 @@ type NewServerFormProperties = {
   onChange: () => void;
 };
 
+// Subdomain names may only contain lowercase letters, digits, and hyphens.
+// See issue #1012: https://github.com/zulip/zulip-desktop/issues/1012
+const subdomainPattern = /^[a-z\d-]+$/;
+
 export function initNewServerForm({
   $root,
   onChange,
@@ -20,13 +24,17 @@ export function initNewServerForm({
     <div class="server-input-container">
       <div class="title">${t.__("Organization URL")}</div>
       <div class="add-server-info-row">
-        <input
-          class="setting-input-value"
-          autofocus
-          placeholder="${t.__(
-            "your-organization.zulipchat.com or zulip.your-organization.com",
-          )}"
-        />
+        <label class="setting-input-value" id="new-server-url-label">
+          <input
+            id="new-server-url-input"
+            autofocus
+            placeholder="${t.__(
+              "your-organization.zulipchat.com or zulip.your-organization.com",
+            )}"
+          />
+          <span id="new-server-url-domain"></span>
+          <span id="new-server-url-size-calc"></span>
+        </label>
       </div>
       <div class="server-center">
         <button id="connect">${t.__("Connect")}</button>
@@ -53,19 +61,38 @@ export function initNewServerForm({
       </div>
     </div>
   `);
+
   const $saveServerButton: HTMLButtonElement =
     $newServerForm.querySelector("#connect")!;
   $root.textContent = "";
   $root.append($newServerForm);
+
   const $newServerUrl: HTMLInputElement = $newServerForm.querySelector(
-    "input.setting-input-value",
+    "#new-server-url-input",
   )!;
+  const $serverDomain: HTMLSpanElement = $newServerForm.querySelector(
+    "#new-server-url-domain",
+  )!;
+  const $urlSizeCalc: HTMLSpanElement = $newServerForm.querySelector(
+    "#new-server-url-size-calc",
+  )!;
+
+  function autoComplete(url: string): string {
+    const trimmed = url.trim();
+    if (subdomainPattern.test(trimmed)) {
+      return `https://${trimmed}.zulipchat.com`;
+    }
+
+    return trimmed;
+  }
 
   async function submitFormHandler(): Promise<void> {
     $saveServerButton.textContent = t.__("Connecting…");
     let serverConfig;
     try {
-      serverConfig = await DomainUtil.checkDomain($newServerUrl.value.trim());
+      serverConfig = await DomainUtil.checkDomain(
+        autoComplete($newServerUrl.value),
+      );
     } catch (error: unknown) {
       $saveServerButton.textContent = t.__("Connect");
       await dialog.showMessageBox({
@@ -86,9 +113,24 @@ export function initNewServerForm({
   $saveServerButton.addEventListener("click", async () => {
     await submitFormHandler();
   });
+
   $newServerUrl.addEventListener("keypress", async (event) => {
     if (event.key === "Enter") {
       await submitFormHandler();
+    }
+  });
+
+  $newServerUrl.addEventListener("input", () => {
+    const url = $newServerUrl.value;
+    const isSubdomain = url.length > 0 && subdomainPattern.test(url);
+
+    if (isSubdomain) {
+      $urlSizeCalc.textContent = url;
+      $newServerUrl.style.width = `${$urlSizeCalc.offsetWidth}px`;
+      $serverDomain.textContent = ".zulipchat.com";
+    } else {
+      $newServerUrl.style.width = "";
+      $serverDomain.textContent = "";
     }
   });
 


### PR DESCRIPTION
Fixes #1012

Autocomplete to the Organisation URL input and adds inline ghost-text to show the behaviour visually while typing.

Problem
Typing myteam and hitting Connect now resolves to https://myteam instead of https://myteam.zulipchat.com.  it should be shown to the user within the input field before they submit.

Changes Made
HTML (new-server-form.ts)

Restored the autoComplete function — bare subdomains are expanded to https://<subdomain>.zulipchat.com on submit, anything containing a dot, slash, or protocol is passed through untouched
Wrapped the <input> inside a <label> styled to look like the input box to allow the ghost suffix to sit inline with the typed text
Added a ghost suffix <span> that displays .zulipchat.com directly after the cursor when a bare subdomain is detected, giving the user a preview before hitting Connect
Added an invisible measuring <span> that mirrors the typed text so its pixel width can be read and applied to the input, keeping the suffix flush against the last character

CSS (preferences.css)

Added label#new-server-url-label:focus-within alongside the existing .setting-input-value:focus rule so the teal focus border fires correctly through the label wrapper
Added width: 100% as the default on #new-server-url-input so the placeholder renders in full, with JS overriding this to a pixel value only while the suffix is visible
All new rules are scoped to four unique IDs (#new-server-url-label, #new-server-url-input, #new-server-url-domain, #new-server-url-size-calc) so there is zero risk of affecting any other input or form in the preferences component

Testing

Verified myteam now correctly resolves to https://myteam.zulipchat.com on submit
Tested with full URLs, self-hosted domains, and explicit http:// to confirm they are passed through untouched

Screen Capture


https://github.com/user-attachments/assets/b4ae83d6-4738-480a-9d97-9842b154d5c4

