### PR TITLE
Added time durations for DND tooltip. Fixes #561

### DIFF
--- a/app/common/config-schemata.ts
+++ b/app/common/config-schemata.ts
@@ -17,6 +17,7 @@ export const configSchemata = {
   customCSS: z.string().or(z.literal(false)).nullable(),
   dnd: z.boolean(),
   dndPreviousSettings: z.object(dndSettingsSchemata).partial(),
+  dndExpiration: z.number().nullable().default(null),
   dockBouncing: z.boolean(),
   downloadsPath: z.string(),
   enableSpellchecker: z.boolean(),

--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -69,7 +69,12 @@ export type RendererMessage = {
     autoHideMenubar: boolean,
     updateMenu: boolean,
   ) => void;
-  "toggle-dnd": (state: boolean, newSettings: Partial<DndSettings>) => void;
+  "toggle-dnd-request": (duration?: number) => void;
+  "toggle-dnd": (
+    state: boolean,
+    newSettings: Partial<DndSettings>,
+    duration?: number,
+  ) => void;
   "toggle-sidebar": (show: boolean) => void;
   "toggle-silent": (state: boolean) => void;
   "toggle-tray": (state: boolean) => void;

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -18,6 +18,7 @@ import * as remoteMain from "@electron/remote/main";
 import windowStateKeeper from "electron-window-state";
 
 import * as ConfigUtil from "../common/config-util.ts";
+import * as DNDUtil from "../common/dnd-util.ts";
 import {bundlePath, bundleUrl, publicPath} from "../common/paths.ts";
 import * as t from "../common/translation-util.ts";
 import type {RendererMessage} from "../common/typed-ipc.ts";
@@ -47,6 +48,7 @@ let mainWindow: BrowserWindow;
 let badgeCount: number;
 
 let isQuitting = false;
+let dndRevertTimeout: NodeJS.Timeout | null = null;
 
 // Load this file in main window
 const mainUrl = new URL("app/renderer/main.html", bundleUrl).href;
@@ -67,6 +69,23 @@ const toggleApp = (): void => {
     mainWindow.hide();
   }
 };
+
+function checkDndExpirationOnStartup(page: WebContents): void {
+  const expiration = ConfigUtil.getConfigItem("dndExpiration", null);
+  if (expiration !== null && Date.now() > expiration) {
+    const revert = DNDUtil.toggle();
+    send(page, "toggle-dnd", revert.dnd, revert.newSettings);
+    ConfigUtil.removeConfigItem("dndExpiration");
+  } else if (expiration !== null) {
+    const timeLeft = expiration - Date.now();
+    dndRevertTimeout = setTimeout(() => {
+      const revert = DNDUtil.toggle();
+      send(page, "toggle-dnd", revert.dnd, revert.newSettings);
+      ConfigUtil.removeConfigItem("dndExpiration");
+      dndRevertTimeout = null;
+    }, timeLeft);
+  }
+}
 
 function createMainWindow(): BrowserWindow {
   // Load the previous state with fallback to defaults
@@ -272,6 +291,7 @@ function createMainWindow(): BrowserWindow {
   const page = mainWindow.webContents;
 
   page.on("dom-ready", () => {
+    checkDndExpirationOnStartup(page);
     if (ConfigUtil.getConfigItem("startMinimized", false)) {
       mainWindow.hide();
     } else {
@@ -407,6 +427,36 @@ function createMainWindow(): BrowserWindow {
       listener: Channel,
       ...parameters: Parameters<RendererMessage[Channel]>
     ) => {
+      if (listener === "toggle-dnd-request") {
+        const [duration] = parameters as [number | undefined];
+        const result = DNDUtil.toggle();
+        send(page, "toggle-dnd", result.dnd, result.newSettings);
+
+        if (result.dnd && duration !== undefined && !Number.isNaN(duration)) {
+          if (dndRevertTimeout) clearTimeout(dndRevertTimeout);
+          const expirationTime = Date.now() + duration * 60 * 1000;
+          ConfigUtil.setConfigItem("dndExpiration", expirationTime);
+          dndRevertTimeout = setTimeout(
+            () => {
+              const revert = DNDUtil.toggle();
+              send(page, "toggle-dnd", revert.dnd, revert.newSettings);
+              ConfigUtil.removeConfigItem("dndExpiration");
+              dndRevertTimeout = null;
+            },
+            duration * 60 * 1000,
+          );
+        } else {
+          if (dndRevertTimeout) {
+            clearTimeout(dndRevertTimeout);
+            dndRevertTimeout = null;
+          }
+
+          ConfigUtil.removeConfigItem("dndExpiration");
+        }
+
+        return;
+      }
+
       send(page, listener, ...parameters);
     },
   );

--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -386,6 +386,31 @@ webview.focus {
   font-size: 14px;
 }
 
+.dnd-dropdown {
+  position: absolute;
+  left: 60px;
+  background-color: rgb(32 33 36 / 100%);
+  border: 1px solid rgb(60 60 60 / 100%);
+  border-radius: 8px;
+  color: rgb(240 240 240 / 100%);
+  z-index: 1000;
+  padding: 4px 0;
+  font-size: 13px;
+  font-family: arial, sans-serif;
+  min-width: 150px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
+}
+
+.dnd-dropdown-item {
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.dnd-dropdown-item:hover {
+  background-color: rgb(60 60 60 / 100%);
+}
+
 #loading-tooltip::after,
 #dnd-tooltip::after,
 #back-tooltip::after,

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -11,7 +11,6 @@ import * as Sentry from "@sentry/electron/renderer";
 
 import type {Config} from "../../common/config-util.ts";
 import * as ConfigUtil from "../../common/config-util.ts";
-import * as DNDUtil from "../../common/dnd-util.ts";
 import type {DndSettings} from "../../common/dnd-util.ts";
 import * as EnterpriseUtil from "../../common/enterprise-util.ts";
 import {html} from "../../common/html.ts";
@@ -446,15 +445,37 @@ export class ServerManagerView {
   }
 
   initLeftSidebarEvents(): void {
-    this.$dndButton.addEventListener("click", () => {
-      const dndUtil = DNDUtil.toggle();
-      ipcRenderer.send(
-        "forward-message",
-        "toggle-dnd",
-        dndUtil.dnd,
-        dndUtil.newSettings,
-      );
+    const $dndDropdown = document.querySelector<HTMLElement>("#dnd-dropdown")!;
+
+    $dndDropdown.addEventListener("mouseleave", () => {
+      $dndDropdown.classList.add("hidden");
+      this.$dndTooltip.classList.remove("hidden");
     });
+
+    this.$dndButton.addEventListener("click", () => {
+      const isDndOn = ConfigUtil.getConfigItem("dnd", false);
+      if (isDndOn) {
+        ipcRenderer.send("forward-message", "toggle-dnd-request", undefined);
+        return;
+      }
+
+      $dndDropdown.classList.toggle("hidden");
+      this.$dndTooltip.classList.add("hidden");
+    });
+
+    for (const item of document.querySelectorAll<HTMLElement>(
+      ".dnd-dropdown-item",
+    )) {
+      item.addEventListener("click", (event) => {
+        event.stopPropagation();
+        const value = item.dataset.minutes;
+        const duration = value === "forever" ? undefined : Number(value);
+        ipcRenderer.send("forward-message", "toggle-dnd-request", duration);
+        $dndDropdown.classList.add("hidden");
+        this.$dndTooltip.classList.remove("hidden");
+      });
+    }
+
     this.$reloadButton.addEventListener("click", async () => {
       const tab = this.tabs[this.activeTabIndex];
       if (tab instanceof ServerTab) (await tab.webview).reload();
@@ -1217,6 +1238,23 @@ window.addEventListener("load", async () => {
             <span id="dnd-tooltip" style="display: none"
               >${t.__("Do Not Disturb")}</span
             >
+            <div id="dnd-dropdown" class="dnd-dropdown hidden">
+              <div class="dnd-dropdown-item" data-minutes="30">
+                ${t.__("30 minutes")}
+              </div>
+              <div class="dnd-dropdown-item" data-minutes="60">
+                ${t.__("1 hour")}
+              </div>
+              <div class="dnd-dropdown-item" data-minutes="180">
+                ${t.__("3 hours")}
+              </div>
+              <div class="dnd-dropdown-item" data-minutes="720">
+                ${t.__("12 hours")}
+              </div>
+              <div class="dnd-dropdown-item" data-minutes="forever">
+                ${t.__("Until I resume")}
+              </div>
+            </div>
           </div>
           <div class="action-button hidden" id="reload-action">
             <i class="material-icons md-48">refresh</i>


### PR DESCRIPTION
Fixes #561
This PR picks up the work from #1419 and addresses the outstanding issues to bring it to a mergeable state.
Changes from #1419:

Moved checkDndExpirationOnStartup inside the dom-ready handler, the previous implementation called it before the renderer was ready, causing the IPC message to silently fail on startup
Moved the mouseleave listener outside the $dndButton click handler, previously a new listener was registered on every click, requiring multiple clicks to close the dropdown after repeated use
Fixed a config leak where cancelling "Until I resume" DND would leave dndExpiration persisted in the config indefinitely — removeConfigItem now always runs when DND is turned off regardless of whether a timeout exists
Added event.stopPropagation() to dropdown item click handlers to prevent clicks bubbling up to the $dndButton handler and re-toggling the dropdown immediately
Updated CSS to .dnd-dropdown and .dnd-dropdown-item classes rather than bare div selectors

Tested on: Windows

Screen Capture


https://github.com/user-attachments/assets/91e1db02-08fc-4108-9934-a4f3b3545a20

