### PR TITLE
Enhance app config handling 

### DIFF
--- a/app/common/enterprise-util.ts
+++ b/app/common/enterprise-util.ts
@@ -18,12 +18,20 @@ const logger = new Logger({
   file: "enterprise-util.log",
 });
 
-let enterpriseSettings: Partial<EnterpriseConfig>;
-let configFile: boolean;
+let isReloaded = false;
+let configFile = false;
+let isErrorShown = false;
+let enterpriseSettings: Partial<EnterpriseConfig> = {};
 
 reloadDatabase();
 
 function reloadDatabase(): void {
+  if (isReloaded) {
+    return;
+  }
+
+  isReloaded = true;
+
   let enterpriseFile = "/etc/zulip-desktop-config/global_config.json";
   if (process.platform === "win32") {
     enterpriseFile = String.raw`C:\Program Files\Zulip-Desktop-Config\global_config.json`;
@@ -40,10 +48,14 @@ function reloadDatabase(): void {
         .partial()
         .parse(data);
     } catch (error: unknown) {
-      dialog.showErrorBox(
-        "Error loading global_config",
-        "We encountered an error while reading global_config.json, please make sure the file contains valid JSON.",
-      );
+      if (!isErrorShown) {
+        dialog.showErrorBox(
+          "Error loading global_config",
+          "We encountered an error while reading global_config.json, please make sure the file contains valid JSON.",
+        );
+        isErrorShown = true;
+      }
+
       logger.log("Error while JSON parsing global_config.json: ");
       logger.log(error);
     }
@@ -60,7 +72,6 @@ export function getConfigItem<Key extends keyof EnterpriseConfig>(
   key: Key,
   defaultValue: EnterpriseConfig[Key],
 ): EnterpriseConfig[Key] {
-  reloadDatabase();
   if (!configFile) {
     return defaultValue;
   }
@@ -70,7 +81,6 @@ export function getConfigItem<Key extends keyof EnterpriseConfig>(
 }
 
 export function configItemExists(key: keyof EnterpriseConfig): boolean {
-  reloadDatabase();
   if (!configFile) {
     return false;
   }


### PR DESCRIPTION
Fixes: #1404

This PR improves the error handling and reliability of the enterprise configuration loader in `app/common/enterprise-util.ts`. Previously, a malformed or missing `global_config.json` file would cause a TypeError in the renderer process, leading to a **permanent blank screen** upon application launch.

**Technical Changes:**

1. **Crash Prevention:** Initialized `enterpriseSettings` to an empty object `{}`. This ensures that even if JSON parsing fails, subsequent calls to `getConfigItem` return the provided default value instead of attempting to read from `undefined`.

2. **Performance Optimization**: Added an `isReloaded `flag to the configuration loader. This ensures the filesystem is only checked and parsed once during the application's lifecycle, rather than re-reading and re parsing on every configuration check.

3. **UI Polish**: Implemented an `isErrorShown` guard to ensure the "Error loading global_config" native dialog box is only presented once to the user, even if multiple configuration items triggered a reload.

**Screenshots and screen captures:**
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/52205c26-0199-4db7-931a-8478634898d6" />

**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [x] Linux (Ubuntu 24.04)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
