### PR TITLE
back button: Enable returning to server tab from Settings

### DIFF
--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -84,6 +84,7 @@ export class ServerManagerView {
   $fullscreenPopup: Element;
   loading: Set<string>;
   activeTabIndex: number;
+  previousActiveTabIndex: number;
   tabs: ServerOrFunctionalTab[];
   functionalTabs: Map<TabPage, number>;
   tabIndex: number;
@@ -129,6 +130,7 @@ export class ServerManagerView {
 
     this.loading = new Set();
     this.activeTabIndex = -1;
+    this.previousActiveTabIndex = -1;
     this.tabs = [];
     this.presetOrgs = [];
     this.functionalTabs = new Map();
@@ -467,7 +469,12 @@ export class ServerManagerView {
     });
     this.$backButton.addEventListener("click", async () => {
       const tab = this.tabs[this.activeTabIndex];
-      if (tab instanceof ServerTab) (await tab.webview).back();
+      if (tab instanceof ServerTab) {
+        (await tab.webview).back();
+      } else if (this.previousActiveTabIndex >= 0) {
+        await this.activateTab(this.previousActiveTabIndex);
+        this.previousActiveTabIndex = -1;
+      }
     });
 
     this.sidebarHoverEvent(this.$addServerButton, this.$addServerTooltip, true);
@@ -700,10 +707,22 @@ export class ServerManagerView {
       try {
         (await tab.webview).canGoBackButton();
       } catch {}
+    } else if (
+      (this.previousActiveTabIndex >= 0 &&
+        this.tabs[this.previousActiveTabIndex]) ||
+      this.activeTabIndex >= 0
+    ) {
+      document
+        .querySelector("#actions-container #back-action")!
+        .classList.remove("disable");
     } else {
       document
         .querySelector("#actions-container #back-action")!
         .classList.add("disable");
+    }
+
+    if (tab.properties.role === "function" && this.activeTabIndex >= 0) {
+      this.previousActiveTabIndex = this.activeTabIndex;
     }
 
     this.activeTabIndex = index;


### PR DESCRIPTION
Fixes #650 

Problem
When a user opens Settings (or any functional tab), the back button in the sidebar is always disabled, even when they navigated there from an active server tab. There was no way to return without clicking the server icon directly.

Changes
All changes are in app/renderer/main.ts:
Track previousActiveTabIndex: saved when entering a functional tab from a server tab
Re-enable the back button when a valid previous tab exists
Handle the back button click for functional tabs by activating the previous tab and resetting the index

The back button remains disabled only when there is genuinely no previous tab to return to (e.g. first launch with no servers).
Testing

Add a Zulip server and open it
Click Settings: back button should now be enabled
Click back: should return to the server tab
Open the app fresh with no servers: back button should remain disabled in the Add Server view

Screen Capture

https://github.com/user-attachments/assets/14dd56a1-d138-4c8b-b818-f4db87795da2

