### PR TITLE
app Handle missing log files gracefully on first launch

### DIFF
--- a/app/common/logger-util.ts
+++ b/app/common/logger-util.ts
@@ -74,7 +74,12 @@ export default class Logger {
   }
 
   async trimLog(file: string): Promise<void> {
-    const data = await fs.promises.readFile(file, "utf8");
+    let data: string;
+    try {
+      data = await fs.promises.readFile(file, "utf8");
+    } catch {
+      return;
+    }
 
     const maxLogFileLines = 500;
     const logs = data.split(os.EOL);


### PR DESCRIPTION
Fixes: #1281

### Description
This PR resolves an issue where the application floods the terminal with `UnhandledPromiseRejectionWarning: ENOENT` errors during its first launch (fresh install).

**Root Cause:** The `Logger` constructor in `app/common/logger-util.ts` schedules a log-trimming operation (`trimLog`) to run via `process.nextTick`. On a fresh install, this operation frequently attempts to read log files before the application's write stream has physically created them on disk, leading to multiple "File not found" errors in the terminal.

### Technical Changes
1.  **Resilient Log Trimming:** Added a `try/catch` block around the `fs.promises.readFile` operation in `app/common/logger-util.ts`.
2.  **Graceful Fallback:** If a log file does not exist yet (expected on a fresh install), the trimmer now returns early and silently. This ensures a clean and professional first-launch experience without extraneous unhandled rejection warnings.

**Screenshots and screen captures:**
<img width="948" height="594" alt="Screenshot from 2026-03-28 12-59-59" src="https://github.com/user-attachments/assets/f51a67e7-b6f7-4f0c-afe0-bfc15a86c164" />


**Platforms this PR was tested on:**

- [ ] Windows
- [ ] macOS
- [x] Linux (Ubuntu 24.04)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Each commit is a coherent idea and follows Zulip's commit discipline.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Terminal output verified for a clean startup on a fresh install (simulated via `rm -rf ~/.config/Zulip`).
- [x] Logic handles corner cases (missing files, unreadable files) gracefully.
</details>
