### PR TITLE
tray: Fix unread badge rendering on Linux at fractional display scaling.

### DIFF
--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -53,7 +53,12 @@ const trayIconSize = (): number => {
 
 //  Default config for Icon we might make it OS specific if needed like the size
 const config = {
-  pixelRatio: window.devicePixelRatio,
+  // On Linux, Plasma's StatusNotifierItem host mis-renders tray pixmaps that
+  // carry a fractional scale factor (the badge comes out oversized and tiled
+  // under 125%/150% display scaling). Render at a fixed integer scale instead
+  // of the desktop's fractional devicePixelRatio so the output is deterministic
+  // and crisp regardless of the compositor's scaling.
+  pixelRatio: process.platform === "linux" ? 2 : window.devicePixelRatio,
   unreadCount: 0,
   showUnreadCount: true,
   unreadColor: "#000000",
@@ -127,8 +132,11 @@ const renderNativeImage = function (argument: number): NativeImage {
   const pngData = nativeImage
     .createFromDataURL(canvas.toDataURL("image/png"))
     .toPNG();
+  // Hand Linux a plain 1x pixmap and let the panel scale it. Declaring a
+  // fractional scaleFactor here is what makes Plasma's tray draw the badge
+  // oversized and repeated; an integer scale renders correctly.
   return nativeImage.createFromBuffer(pngData, {
-    scaleFactor: config.pixelRatio,
+    scaleFactor: process.platform === "linux" ? 1 : config.pixelRatio,
   });
 };
 


### PR DESCRIPTION
On Linux the tray unread badge renders oversized and tiled under
fractional display scaling (125%/150%) on KDE Plasma, because the icon
is created with a fractional `scaleFactor` that Plasma's
StatusNotifierItem host mishandles. This renders the Linux tray icon at
a fixed integer scale and passes a 1x pixmap, letting the panel scale it.

Fixes: #1364

**Screenshots and screen captures:**
Before: 
<img width="52" height="60" alt="Screenshot_20260608_221852" src="https://github.com/user-attachments/assets/73bf4155-066c-4958-ad7f-4ca004229c4c" />

After: 
<img width="49" height="48" alt="Screenshot_20260608_221916" src="https://github.com/user-attachments/assets/ec0eba9e-be61-4aba-9490-e8970cd099bf" />


**Platforms this PR was tested on:**
- [ ] Windows
- [ ] macOS
- [x] Linux (Arch, KDE Plasma 6, Wayland, 150% scaling)