### PR TITLE
notifications: Fix sound not working when DND is on.

### DIFF
--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -10,6 +10,7 @@ export type MainMessage = {
   "get-silent-setting": () => boolean;
   "new-clipboard-key": () => {key: Uint8Array; sig: Uint8Array};
   "permission-callback": (permissionCallbackId: number, grant: boolean) => void;
+  "play-notification-sound": (url: string) => void;
   "quit-app": () => void;
   "realm-icon-changed": (serverURL: string, iconURL: string) => void;
   "realm-name-changed": (serverURL: string, realmName: string) => void;
@@ -56,6 +57,7 @@ export type RendererMessage = {
     rendererCallbackId: number,
   ) => void;
   "play-ding-sound": () => void;
+  "play-notification-sound": (url: string) => void;
   "reload-current-viewer": () => void;
   "reload-proxy": (showAlert: boolean) => void;
   "reload-viewer": () => void;

--- a/app/common/typed-ipc.ts
+++ b/app/common/typed-ipc.ts
@@ -7,6 +7,7 @@ export type MainMessage = {
   "fetch-user-agent": () => string;
   "focus-app": () => void;
   "focus-this-webview": () => void;
+  "get-silent-setting": () => boolean;
   "new-clipboard-key": () => {key: Uint8Array; sig: Uint8Array};
   "permission-callback": (permissionCallbackId: number, grant: boolean) => void;
   "quit-app": () => void;

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -275,6 +275,14 @@ function createMainWindow(): BrowserWindow {
     event.returnValue = ConfigUtil.getConfigItem("silent", false);
   });
 
+  ipcMain.on("play-notification-sound", (event, url: string) => {
+    if (ConfigUtil.getConfigItem("silent", false)) {
+      return;
+    }
+
+    send(mainWindow.webContents, "play-notification-sound", url);
+  });
+
   ipcMain.handle("get-server-settings", async (event, domain: string) =>
     _getServerSettings(domain, ses),
   );

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -271,6 +271,10 @@ function createMainWindow(): BrowserWindow {
       .getUserAgent();
   });
 
+  ipcMain.on("get-silent-setting", (event) => {
+    event.returnValue = ConfigUtil.getConfigItem("silent", false);
+  });
+
   ipcMain.handle("get-server-settings", async (event, domain: string) =>
     _getServerSettings(domain, ses),
   );

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -17,8 +17,6 @@ import * as SystemUtil from "../utils/system-util.ts";
 import {generateNodeFromHtml} from "./base.ts";
 import {contextMenu} from "./context-menu.ts";
 
-const shouldSilentWebview = ConfigUtil.getConfigItem("silent", false);
-
 type WebViewProperties = {
   $root: Element;
   rootWebContents: WebContents;
@@ -133,10 +131,6 @@ export default class WebView {
 
   private registerListeners(): void {
     const webContents = this.getWebContents();
-
-    if (shouldSilentWebview) {
-      webContents.setAudioMuted(true);
-    }
 
     webContents.on("page-title-updated", (_event, title) => {
       this.badgeCount = this.getBadgeCount(title);

--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -19,6 +19,7 @@ export type ElectronBridge = {
     dispatch: (type: string, eventInit: EventInit) => boolean,
   ) => NotificationData;
   play_notification_sound: (sound_path: string) => void;
+  set_play_notification_sound_supported: (supported: boolean) => void;
   get_idle_on_system: () => boolean;
   get_last_active_on_system: () => number;
   get_send_notification_reply_message_supported: () => boolean;
@@ -43,6 +44,11 @@ export class BridgeEvent extends Event {
     super(type);
   }
 }
+
+// Tells the main-world gate to stop muting in-page notification sounds
+// once the web app plays them through the bridge instead.
+export const disableNotificationSoundGateEvent =
+  "zulip-desktop-disable-notification-sound-gate";
 
 /* eslint-disable @typescript-eslint/naming-convention -- public API */
 const electron_bridge: ElectronBridge = {
@@ -80,6 +86,13 @@ const electron_bridge: ElectronBridge = {
     }
 
     ipcRenderer.send("play-notification-sound", resolved.href);
+  },
+
+  set_play_notification_sound_supported(supported: boolean): void {
+    if (supported) {
+      // The web app owns sound playback now; disarm the in-page mute.
+      globalThis.dispatchEvent(new Event(disableNotificationSoundGateEvent));
+    }
   },
 
   get_idle_on_system: (): boolean => idle,

--- a/app/renderer/js/electron-bridge.ts
+++ b/app/renderer/js/electron-bridge.ts
@@ -18,6 +18,7 @@ export type ElectronBridge = {
     options: NotificationOptions,
     dispatch: (type: string, eventInit: EventInit) => boolean,
   ) => NotificationData;
+  play_notification_sound: (sound_path: string) => void;
   get_idle_on_system: () => boolean;
   get_last_active_on_system: () => number;
   get_send_notification_reply_message_supported: () => boolean;
@@ -59,6 +60,27 @@ const electron_bridge: ElectronBridge = {
     options: NotificationOptions,
     dispatch: (type: string, eventInit: EventInit) => boolean,
   ): NotificationData => newNotification(title, options, dispatch),
+
+  play_notification_sound(sound_path: string): void {
+    // Only accept the page's own notification-sound files, so a
+    // compromised page can't make us play arbitrary audio. The main
+    // process gates on silent mode and plays it outside the webview.
+    let resolved: URL;
+    try {
+      resolved = new URL(sound_path, globalThis.location.origin);
+    } catch {
+      return;
+    }
+
+    if (
+      resolved.origin !== globalThis.location.origin ||
+      !resolved.pathname.startsWith("/static/audio/notification_sounds/")
+    ) {
+      return;
+    }
+
+    ipcRenderer.send("play-notification-sound", resolved.href);
+  },
 
   get_idle_on_system: (): boolean => idle,
 

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -65,6 +65,9 @@ const dingSound = new Audio(
   new URL("resources/sounds/ding.ogg", bundleUrl).href,
 );
 
+// Web-app notification sounds, cached by URL for latency-free replay.
+const notificationSounds = new Map<string, HTMLAudioElement>();
+
 export class ServerManagerView {
   $addServerButton: HTMLButtonElement;
   $tabsContainer: Element;
@@ -1244,6 +1247,20 @@ export class ServerManagerView {
 
     ipcRenderer.on("play-ding-sound", () => {
       void dingSound.play();
+    });
+
+    ipcRenderer.on("play-notification-sound", (event, url: string) => {
+      let audio = notificationSounds.get(url);
+      if (audio === undefined) {
+        audio = new Audio(url);
+        notificationSounds.set(url, audio);
+      }
+
+      void audio.play().catch(() => {
+        // Retry the fetch next time; fall back to the bundled ding.
+        notificationSounds.delete(url);
+        void dingSound.play();
+      });
     });
   }
 }

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -1076,7 +1076,7 @@ export class ServerManagerView {
       for (const tab of this.tabs) {
         if (tab instanceof ServerTab) {
           (async () => {
-            (await tab.webview).getWebContents().setAudioMuted(state);
+            (await tab.webview).send("toggle-silent", state);
           })();
         }
       }

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -91,7 +91,7 @@ export function initGeneralSection({$root}: GeneralSectionProperties): void {
         </div>
         <div class="setting-row" id="silent-option">
           <div class="setting-description">
-            ${t.__("Mute all sounds from Zulip")}
+            ${t.__("Mute notification sounds from Zulip")}
           </div>
           <div class="setting-control"></div>
         </div>

--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -6,6 +6,55 @@ import {ipcRenderer} from "./typed-ipc-renderer.ts";
 
 contextBridge.exposeInMainWorld("electron_bridge", electron_bridge);
 
+// In silent mode, skip the web app's notification sounds (matched by
+// their /static/audio/notification_sounds/ URL) while leaving other
+// media audible. Runs in the main world; state arrives via DOM events
+// since executeInMainWorld can't close over module scope.
+const muteEventName = "zulip-desktop-mute-notification-sounds";
+const unmuteEventName = "zulip-desktop-unmute-notification-sounds";
+
+function installNotificationSoundGate(
+  initiallySilent: boolean,
+  muteEvent: string,
+  unmuteEvent: string,
+): void {
+  let silent = initiallySilent;
+  globalThis.addEventListener(muteEvent, () => {
+    silent = true;
+  });
+  globalThis.addEventListener(unmuteEvent, () => {
+    silent = false;
+  });
+
+  const nativePlay = HTMLMediaElement.prototype.play;
+  HTMLMediaElement.prototype.play = async function (this: HTMLMediaElement) {
+    if (
+      silent &&
+      (this.currentSrc.includes("/static/audio/notification_sounds/") ||
+        this.querySelector(
+          'source[src*="/static/audio/notification_sounds/"]',
+        ) !== null)
+    ) {
+      return;
+    }
+
+    await nativePlay.apply(this);
+  };
+}
+
+contextBridge.executeInMainWorld({
+  func: installNotificationSoundGate,
+  args: [
+    ipcRenderer.sendSync("get-silent-setting"),
+    muteEventName,
+    unmuteEventName,
+  ],
+});
+
+ipcRenderer.on("toggle-silent", (_event, state) => {
+  globalThis.dispatchEvent(new Event(state ? muteEventName : unmuteEventName));
+});
+
 ipcRenderer.on("logout", () => {
   bridgeEvents.dispatchEvent(new BridgeEvent("logout"));
 });

--- a/app/renderer/js/preload.ts
+++ b/app/renderer/js/preload.ts
@@ -1,6 +1,10 @@
 import {contextBridge} from "electron/renderer";
 
-import electron_bridge, {BridgeEvent, bridgeEvents} from "./electron-bridge.ts";
+import electron_bridge, {
+  BridgeEvent,
+  bridgeEvents,
+  disableNotificationSoundGateEvent,
+} from "./electron-bridge.ts";
 import * as NetworkError from "./pages/network.ts";
 import {ipcRenderer} from "./typed-ipc-renderer.ts";
 
@@ -17,18 +21,25 @@ function installNotificationSoundGate(
   initiallySilent: boolean,
   muteEvent: string,
   unmuteEvent: string,
+  disableGate: string,
 ): void {
   let silent = initiallySilent;
+  // Disarmed once the web app declares it plays sounds via the bridge.
+  let armed = true;
   globalThis.addEventListener(muteEvent, () => {
     silent = true;
   });
   globalThis.addEventListener(unmuteEvent, () => {
     silent = false;
   });
+  globalThis.addEventListener(disableGate, () => {
+    armed = false;
+  });
 
   const nativePlay = HTMLMediaElement.prototype.play;
   HTMLMediaElement.prototype.play = async function (this: HTMLMediaElement) {
     if (
+      armed &&
       silent &&
       (this.currentSrc.includes("/static/audio/notification_sounds/") ||
         this.querySelector(
@@ -48,6 +59,7 @@ contextBridge.executeInMainWorld({
     ipcRenderer.sendSync("get-silent-setting"),
     muteEventName,
     unmuteEventName,
+    disableNotificationSoundGateEvent,
   ],
 });
 

--- a/app/renderer/main.html
+++ b/app/renderer/main.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta
-      content="default-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      content="default-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' data:; media-src 'self' http: https:; script-src 'self'; style-src 'self' 'unsafe-inline'"
       http-equiv="Content-Security-Policy"
     />
     <meta content="width=device-width" name="viewport" />

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -101,7 +101,7 @@
 	"Manual Download": "Manual Download",
 	"Manual proxy configuration": "Manual proxy configuration",
 	"Minimize": "Minimize",
-	"Mute all sounds from Zulip": "Mute all sounds from Zulip",
+	"Mute notification sounds from Zulip": "Mute notification sounds from Zulip",
 	"Network": "Network",
 	"Network and Proxy Settings": "Network and Proxy Settings",
 	"New servers added. Reload app now?": "New servers added. Reload app now?",


### PR DESCRIPTION
Earlier all the notification sounds were played via an audio tag. But electron only supports muting all sounds in the application all at once. This caused the muting of YouTube videos whenever Do Not Disturb was on. For older server versions, we filter by the audio file path in preload.ts. But that is not a reliable mechanism because that path can change anytime. To overcome that, we explicitly pass the notification to be played to the desktop app through the electron bridge.

set_play_notification_sound_supported notifies us that we can stop using the preload script that takes care of backward compatibility for older server versions. play_notification_sound delivers the actual notification. We recieve the relative path to the audio file from the webapp.

Fixes [#desktop > Audio in videos doesn't work in Zulip Desktop for Mac](https://chat.zulip.org/#narrow/channel/16-desktop/topic/Audio.20in.20videos.20doesn.27t.20work.20in.20Zulip.20Desktop.20for.20Mac/with/2491961)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Platforms this PR was tested on:**

- [ ] Windows
- [x] macOS
- [ ] Linux (specify distro)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
