### PR TITLE
translation-util: Fix reexport of i18n.

### DIFF
--- a/app/common/link-util.ts
+++ b/app/common/link-util.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {Html, html} from "./html.ts";
-import * as t from "./translation-util.ts";
+import {t} from "./translation-util.ts";
 
 export async function openBrowser(url: URL): Promise<void> {
   if (["http:", "https:", "mailto:"].includes(url.protocol)) {

--- a/app/common/messages.ts
+++ b/app/common/messages.ts
@@ -1,4 +1,4 @@
-import * as t from "./translation-util.ts";
+import {t} from "./translation-util.ts";
 
 type DialogBoxError = {
   title: string;

--- a/app/common/translation-util.ts
+++ b/app/common/translation-util.ts
@@ -13,4 +13,4 @@ i18n.configure({
 /* Fetches the current appLocale from settings.json */
 i18n.setLocale(ConfigUtil.getConfigItem("appLanguage", "en") ?? "en");
 
-export {__, __mf} from "i18n";
+export {default as t} from "i18n";

--- a/app/main/autoupdater.ts
+++ b/app/main/autoupdater.ts
@@ -10,7 +10,7 @@ import {
 } from "electron-updater";
 
 import * as ConfigUtil from "../common/config-util.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 
 import {linuxUpdateNotification} from "./linuxupdater.ts"; // Required only in case of linux
 

--- a/app/main/handle-external-link.ts
+++ b/app/main/handle-external-link.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 
 import * as ConfigUtil from "../common/config-util.ts";
 import * as LinkUtil from "../common/link-util.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 
 import {send} from "./typed-ipc-main.ts";
 

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -19,7 +19,7 @@ import windowStateKeeper from "electron-window-state";
 
 import * as ConfigUtil from "../common/config-util.ts";
 import {bundlePath, bundleUrl, publicPath} from "../common/paths.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 import type {RendererMessage} from "../common/typed-ipc.ts";
 import type {MenuProperties} from "../common/types.ts";
 

--- a/app/main/linux-update-util.ts
+++ b/app/main/linux-update-util.ts
@@ -6,7 +6,7 @@ import {JsonDB} from "node-json-db";
 import {DataError} from "node-json-db/dist/lib/Errors.js";
 
 import Logger from "../common/logger-util.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 
 const logger = new Logger({
   file: "linux-update-util.log",

--- a/app/main/linuxupdater.ts
+++ b/app/main/linuxupdater.ts
@@ -5,7 +5,7 @@ import {z} from "zod";
 
 import * as ConfigUtil from "../common/config-util.ts";
 import Logger from "../common/logger-util.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 
 import * as LinuxUpdateUtil from "./linux-update-util.ts";
 

--- a/app/main/menu.ts
+++ b/app/main/menu.ts
@@ -11,7 +11,7 @@ import AdmZip from "adm-zip";
 
 import * as ConfigUtil from "../common/config-util.ts";
 import * as DNDUtil from "../common/dnd-util.ts";
-import * as t from "../common/translation-util.ts";
+import {t} from "../common/translation-util.ts";
 import type {RendererMessage} from "../common/typed-ipc.ts";
 import type {MenuProperties, TabData} from "../common/types.ts";
 

--- a/app/renderer/js/components/context-menu.ts
+++ b/app/renderer/js/components/context-menu.ts
@@ -8,7 +8,7 @@ import process from "node:process";
 
 import {BrowserWindow, Menu} from "@electron/remote";
 
-import * as t from "../../../common/translation-util.ts";
+import {t} from "../../../common/translation-util.ts";
 
 export const contextMenu = (
   webContents: WebContents,

--- a/app/renderer/js/components/webview.ts
+++ b/app/renderer/js/components/webview.ts
@@ -7,7 +7,7 @@ import assert from "minimalistic-assert";
 
 import * as ConfigUtil from "../../../common/config-util.ts";
 import {type Html, html} from "../../../common/html.ts";
-import * as t from "../../../common/translation-util.ts";
+import {t} from "../../../common/translation-util.ts";
 import type {RendererMessage} from "../../../common/typed-ipc.ts";
 import type {TabRole} from "../../../common/types.ts";
 import preloadCss from "../../css/preload.css?raw";

--- a/app/renderer/js/main.ts
+++ b/app/renderer/js/main.ts
@@ -20,7 +20,7 @@ import * as LinkUtil from "../../common/link-util.ts";
 import Logger from "../../common/logger-util.ts";
 import * as Messages from "../../common/messages.ts";
 import {bundlePath, bundleUrl} from "../../common/paths.ts";
-import * as t from "../../common/translation-util.ts";
+import {t} from "../../common/translation-util.ts";
 import type {
   NavigationItem,
   ServerConfig,

--- a/app/renderer/js/pages/about.ts
+++ b/app/renderer/js/pages/about.ts
@@ -2,7 +2,7 @@ import {app} from "@electron/remote";
 
 import {Html, html} from "../../../common/html.ts";
 import {bundleUrl} from "../../../common/paths.ts";
-import * as t from "../../../common/translation-util.ts";
+import {t} from "../../../common/translation-util.ts";
 import {generateNodeFromHtml} from "../components/base.ts";
 
 export class AboutView {

--- a/app/renderer/js/pages/preference/base-section.ts
+++ b/app/renderer/js/pages/preference/base-section.ts
@@ -1,5 +1,5 @@
 import {type Html, html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {generateNodeFromHtml} from "../../components/base.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";
 

--- a/app/renderer/js/pages/preference/connected-org-section.ts
+++ b/app/renderer/js/pages/preference/connected-org-section.ts
@@ -1,5 +1,5 @@
 import {html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";
 import * as DomainUtil from "../../utils/domain-util.ts";
 

--- a/app/renderer/js/pages/preference/find-accounts.ts
+++ b/app/renderer/js/pages/preference/find-accounts.ts
@@ -1,6 +1,6 @@
 import {html} from "../../../../common/html.ts";
 import * as LinkUtil from "../../../../common/link-util.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {generateNodeFromHtml} from "../../components/base.ts";
 
 type FindAccountsProperties = {

--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -12,7 +12,7 @@ import supportedLocales from "../../../../../public/translations/supported-local
 import * as ConfigUtil from "../../../../common/config-util.ts";
 import * as EnterpriseUtil from "../../../../common/enterprise-util.ts";
 import {html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";
 
 import {generateSelectHtml, generateSettingOption} from "./base-section.ts";

--- a/app/renderer/js/pages/preference/nav.ts
+++ b/app/renderer/js/pages/preference/nav.ts
@@ -1,5 +1,5 @@
 import {type Html, html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import type {NavigationItem} from "../../../../common/types.ts";
 import {generateNodeFromHtml} from "../../components/base.ts";
 

--- a/app/renderer/js/pages/preference/network-section.ts
+++ b/app/renderer/js/pages/preference/network-section.ts
@@ -1,6 +1,6 @@
 import * as ConfigUtil from "../../../../common/config-util.ts";
 import {html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";
 
 import {generateSettingOption} from "./base-section.ts";

--- a/app/renderer/js/pages/preference/new-server-form.ts
+++ b/app/renderer/js/pages/preference/new-server-form.ts
@@ -2,7 +2,7 @@ import {dialog} from "@electron/remote";
 
 import {html} from "../../../../common/html.ts";
 import * as LinkUtil from "../../../../common/link-util.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import {generateNodeFromHtml} from "../../components/base.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";
 import * as DomainUtil from "../../utils/domain-util.ts";

--- a/app/renderer/js/pages/preference/server-info-form.ts
+++ b/app/renderer/js/pages/preference/server-info-form.ts
@@ -2,7 +2,7 @@ import {dialog} from "@electron/remote";
 
 import {html} from "../../../../common/html.ts";
 import * as Messages from "../../../../common/messages.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 import type {ServerConfig} from "../../../../common/types.ts";
 import {generateNodeFromHtml} from "../../components/base.ts";
 import {ipcRenderer} from "../../typed-ipc-renderer.ts";

--- a/app/renderer/js/pages/preference/servers-section.ts
+++ b/app/renderer/js/pages/preference/servers-section.ts
@@ -1,5 +1,5 @@
 import {html} from "../../../../common/html.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 
 import {reloadApp} from "./base-section.ts";
 import {initNewServerForm} from "./new-server-form.ts";

--- a/app/renderer/js/pages/preference/shortcuts-section.ts
+++ b/app/renderer/js/pages/preference/shortcuts-section.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 
 import {html} from "../../../../common/html.ts";
 import * as LinkUtil from "../../../../common/link-util.ts";
-import * as t from "../../../../common/translation-util.ts";
+import {t} from "../../../../common/translation-util.ts";
 
 type ShortcutsSectionProperties = {
   $root: Element;

--- a/app/renderer/js/tray.ts
+++ b/app/renderer/js/tray.ts
@@ -7,7 +7,7 @@ import {BrowserWindow, Menu, Tray} from "@electron/remote";
 
 import * as ConfigUtil from "../../common/config-util.ts";
 import {publicPath} from "../../common/paths.ts";
-import * as t from "../../common/translation-util.ts";
+import {t} from "../../common/translation-util.ts";
 import type {RendererMessage} from "../../common/typed-ipc.ts";
 
 import type {ServerManagerView} from "./main.ts";

--- a/app/renderer/js/utils/domain-util.ts
+++ b/app/renderer/js/utils/domain-util.ts
@@ -10,7 +10,7 @@ import {z} from "zod";
 import * as EnterpriseUtil from "../../../common/enterprise-util.ts";
 import Logger from "../../../common/logger-util.ts";
 import * as Messages from "../../../common/messages.ts";
-import * as t from "../../../common/translation-util.ts";
+import {t} from "../../../common/translation-util.ts";
 import type {ServerConfig} from "../../../common/types.ts";
 import defaultIcon from "../../img/icon.png";
 import {ipcRenderer} from "../typed-ipc-renderer.ts";

--- a/app/renderer/js/utils/reconnect-util.ts
+++ b/app/renderer/js/utils/reconnect-util.ts
@@ -2,7 +2,7 @@ import * as backoff from "backoff";
 
 import {html} from "../../../common/html.ts";
 import Logger from "../../../common/logger-util.ts";
-import * as t from "../../../common/translation-util.ts";
+import {t} from "../../../common/translation-util.ts";
 import type WebView from "../components/webview.ts";
 import {ipcRenderer} from "../typed-ipc-renderer.ts";
 


### PR DESCRIPTION
The vite@8 upgrade (#1495) caused translation to break because translation-util.ts was incorrectly re-exporting `__` and `__mf` as unbound methods.

- Closes #1521.