### PR TITLE
Name spell checker languages with languageDisplay: "standard"

### DIFF
--- a/app/renderer/js/pages/preference/general-section.ts
+++ b/app/renderer/js/pages/preference/general-section.ts
@@ -635,10 +635,11 @@ export function initGeneralSection({$root}: GeneralSectionProperties): void {
       ).availableSpellCheckerLanguages;
       let languagePairs = new Map<string, string>();
       for (const l of availableLanguages) {
-        const locale = new Intl.Locale(l.replaceAll("_", "-"));
+        const locale = new Intl.Locale(l);
         let displayName = new Intl.DisplayNames([locale], {
           type: "language",
-        }).of(locale.language);
+          languageDisplay: "standard",
+        }).of(l);
         if (displayName === undefined) {
           continue;
         }
@@ -646,13 +647,6 @@ export function initGeneralSection({$root}: GeneralSectionProperties): void {
         displayName = displayName.replace(/^./v, (firstChar) =>
           firstChar.toLocaleUpperCase(locale),
         );
-        if (locale.script !== undefined) {
-          displayName += ` (${new Intl.DisplayNames([locale], {type: "script"}).of(locale.script)})`;
-        }
-
-        if (locale.region !== undefined) {
-          displayName += ` (${new Intl.DisplayNames([locale], {type: "region"}).of(locale.region)})`;
-        }
 
         languagePairs.set(displayName, l);
       }


### PR DESCRIPTION
This handles cases such as en-GB-oxendict → “English (United Kingdom, Oxford English Dictionary spelling)”.

- Closes #1528.